### PR TITLE
feat: self-improving flywheel for cross-repo skill synthesis

### DIFF
--- a/agent_fleet/base-kit/cursor-team-kit/check-compiler-errors/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/check-compiler-errors/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: check-compiler-errors
+description: Run compile and type-check commands and report failures
+---
+
+# Check compiler errors
+
+## Trigger
+
+Compile or type-check failures are blocking local validation or CI.
+
+## Workflow
+
+1. Run the repo's compile and type-check commands.
+2. Summarize errors by file and type.
+3. Fix the highest-confidence issues first.
+4. Re-run checks until clean or blocked.
+
+## Output
+
+- Current compile and type-check status
+- Error summary grouped by file and category
+- Fixes applied and remaining blockers

--- a/agent_fleet/base-kit/cursor-team-kit/control-cli/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/control-cli/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: control-cli
+description: Build or adapt a local harness to drive, inspect, and profile an interactive CLI or TUI without external services. Use for CLI UX checks, startup regressions, memory leaks, hangs, prompt flows, or terminal demos.
+---
+
+# Control CLI
+
+Use a repeatable local harness to exercise an interactive CLI instead of poking at it manually. First reuse the repo's own test/demo harness if it exists; otherwise assemble a temporary harness from standard local tools.
+
+## What It Is Used For
+
+- Reproducing CLI/TUI bugs with deterministic input.
+- Verifying keyboard flows, prompts, interrupts, resize behavior, and terminal layout.
+- Capturing before/after transcripts for bug fixes.
+- Profiling startup time, slow operations, hangs, or memory growth.
+- Recording a short terminal demo when output is easier to show than explain.
+
+## Harness Loop
+
+1. Identify the command under test and the smallest reproducible workspace.
+2. Discover existing local harnesses: package scripts, e2e tests, demo recorders, expect scripts, or PTY helpers.
+3. If no harness exists, launch the CLI in an isolated terminal session with deterministic env vars.
+4. Capture the current screen before interacting.
+5. Send one action at a time: text, Enter, arrows, Escape, Ctrl-C, resize.
+6. Wait for a concrete screen pattern or prompt before the next action.
+7. Save the transcript and any profile artifacts.
+8. Kill the session cleanly.
+
+## Harness Options
+
+- Repo-native harness: prefer checked-in scripts because they know the app's startup, env, and prompts.
+- `tmux`: managed sessions, `capture-pane`, `send-keys`, attach/detach.
+- PTY probe: use a short Python, Node, or Expect script when tmux is unavailable.
+- Runtime inspector: use Node or Bun inspector for CPU profiles, heap snapshots, and live evaluation.
+- Terminal recorder: use repo-local demo tools or asciinema-compatible tools when the user asks for a demo.
+
+## Minimal tmux Harness
+
+```bash
+SESSION="cli-harness-$(date +%s)"
+tmux new-session -d -s "$SESSION" -- <command-under-test>
+tmux capture-pane -pt "$SESSION"
+tmux send-keys -t "$SESSION" "help" Enter
+tmux capture-pane -pt "$SESSION"
+tmux kill-session -t "$SESSION"
+```
+
+For Node CLIs:
+
+```bash
+NODE_OPTIONS="--inspect=127.0.0.1:0" tmux new-session -d -s "$SESSION" -- <node-cli-command>
+```
+
+Read the terminal output to find the inspector URL, then use Chrome DevTools-compatible tooling if profiling is needed.
+
+## Minimal PTY Harness
+
+Use a PTY script when you need deterministic waits in a repo that does not have tmux or a demo harness. Keep it temporary unless the user asks to add a reusable test.
+
+```python
+import os
+import pty
+import select
+import subprocess
+import time
+
+master_fd, slave_fd = pty.openpty()
+proc = subprocess.Popen(
+    ["<command>", "<arg>"],
+    stdin=slave_fd,
+    stdout=slave_fd,
+    stderr=slave_fd,
+    close_fds=True,
+)
+os.close(slave_fd)
+
+deadline = time.time() + 30
+buffer = b""
+while time.time() < deadline:
+    ready, _, _ = select.select([master_fd], [], [], 0.25)
+    if not ready:
+        continue
+    chunk = os.read(master_fd, 4096)
+    buffer += chunk
+    if b"<ready text>" in buffer:
+        os.write(master_fd, b"help\n")
+        break
+
+print(buffer.decode(errors="replace"))
+proc.terminate()
+os.close(master_fd)
+```
+
+If the CLI needs richer terminal control, use `pty.fork()` or an existing PTY library.
+
+## Profiling Recipes
+
+- Startup regression: capture baseline and treatment startup timings under the same machine, env, and command.
+- Slow operation: start a CPU profile, perform the operation, stop the profile, and compare top self-time functions.
+- Memory leak: force GC if available, take a heap snapshot, perform the operation repeatedly, force GC again, and take another snapshot.
+- Hang: capture the screen, active handles/resources, and a stack/CPU sample before interrupting.
+
+## Guardrails
+
+- Prefer deterministic waits over sleeps. If you must sleep, explain why.
+- Do not send credentials or destructive commands into a controlled session.
+- Keep the harness in `/tmp` unless the repo already has a testing/demo harness.
+- Do not hard-code paths from another repository. Adapt commands to the current repo's scripts and runtime.
+- Clean up tmux sessions, temp dirs, inspector processes, and demo artifacts unless the user asks to keep them.

--- a/agent_fleet/base-kit/cursor-team-kit/control-ui/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/control-ui/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: control-ui
+description: Build or adapt a local browser/CDP harness to drive and inspect a web, IDE, or Electron UI. Use for local UI verification, screenshots, accessibility snapshots, perf profiles, visual diffs, or reproducing UI bugs.
+---
+
+# Control UI
+
+Use local browser automation to verify UI behavior with evidence. First reuse the repo's own Playwright, browser, or Electron harness if it exists; otherwise assemble a temporary local harness around the app's dev server or Chromium debug port.
+
+## What It Is Used For
+
+- Reproducing UI bugs that depend on real browser focus, keyboard input, scrolling, resizing, or rendering.
+- Verifying visual or accessibility changes with screenshots and snapshots.
+- Checking local web, IDE, or Electron behavior before shipping.
+- Capturing console logs, network logs, CPU profiles, traces, or heap snapshots.
+- Creating before/after evidence for `verify-this`.
+
+## Setup Pattern
+
+1. Start the app locally using the repo's documented dev command.
+2. Discover existing local harnesses: Playwright tests, Cypress specs, Storybook, browser scripts, Electron launch scripts, or snapshot tools.
+3. For a web app, connect to the local URL with the existing browser tooling.
+4. For Electron/Chromium, enable a remote debugging port when supported.
+5. Select the correct page by stable app markers, not by tab order alone.
+6. Prefer accessibility roles, labels, and stable `data-*` selectors over coordinates.
+
+## Generic Web Harness
+
+Use the repo's installed browser tooling when possible. If the repo already has Playwright, a minimal one-off probe looks like:
+
+```javascript
+import { chromium } from "playwright";
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+await page.goto("http://127.0.0.1:<port>");
+await page.getByRole("button", { name: /submit/i }).click();
+await page.screenshot({ path: "/tmp/ui-harness-after.png", fullPage: true });
+await browser.close();
+```
+
+Do not add Playwright as a project dependency just for this probe unless the user asks. Prefer existing dev dependencies or external browser tools already available in the environment.
+
+## Generic CDP Harness
+
+For Electron or a Chromium app launched with `--remote-debugging-port=<port>`, connect over CDP:
+
+```javascript
+import { chromium } from "playwright";
+
+const browser = await chromium.connectOverCDP("http://127.0.0.1:<debug-port>");
+const pages = browser.contexts().flatMap((context) => context.pages());
+let page;
+for (const candidate of pages) {
+  if (await candidate.locator("<app-root-selector>").count()) {
+    page = candidate;
+    break;
+  }
+}
+
+if (!page) {
+  console.log(await Promise.all(pages.map(async (p) => ({
+    title: await p.title(),
+    url: p.url(),
+  }))));
+  throw new Error("No matching app page found");
+}
+
+await page.screenshot({ path: "/tmp/ui-harness-cdp.png", fullPage: true });
+await browser.close();
+```
+
+Replace `<app-root-selector>` with a stable marker from the current repo, such as a root app node, landmark, or product-specific `data-*` attribute.
+
+## Interaction Loop
+
+1. Capture a page snapshot or screenshot before acting.
+2. Choose a target from the latest page structure.
+3. Perform exactly one structural action: click, type, keypress, drag, scroll, navigate, or resize.
+4. Capture a fresh snapshot/screenshot.
+5. Verify the expected state change.
+6. Save artifacts for before/after comparisons when the user asked for proof.
+
+## CDP Capabilities
+
+Use raw CDP only when higher-level browser APIs are insufficient:
+
+- Performance: CPU profiles, traces, paint flashing, FPS meter, layout shift inspection.
+- Memory: heap snapshots and forced GC for leak investigations.
+- Network: request blocking, throttling, cache disablement, request/response logs.
+- Rendering: viewport changes, color scheme emulation, reduced motion, accessibility checks.
+- Debugging: console streaming, exception capture, DOM snapshots.
+
+## Page Selection
+
+When multiple app windows/tabs share a debug port:
+
+- Prefer a positive marker for the surface under test, such as an app root selector.
+- Use a negative marker to avoid the wrong surface when necessary.
+- If no page matches, list available page titles and URLs instead of guessing.
+
+## Guardrails
+
+- Do not rely on stale element references after navigation or structural changes.
+- Avoid coordinate clicks unless a fresh screenshot was captured immediately before the click.
+- Keep test data local and disposable.
+- Do not store screenshots or heap snapshots from privacy-sensitive workspaces unless the user explicitly agrees.
+- Do not hard-code selectors, ports, or script paths from another repository. Discover the current repo's local app markers.
+- Clean up dev servers, debug sessions, and temp profiles when done.

--- a/agent_fleet/base-kit/cursor-team-kit/fix-ci/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/fix-ci/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: fix-ci
+description: Find failing PR checks, inspect logs or external check links, and apply focused fixes
+---
+
+# Fix CI
+
+## Trigger
+
+Branch or PR CI is failing and needs a fast, iterative path to green checks.
+
+## Workflow
+
+1. Resolve the active PR and inspect `gh pr checks --json name,bucket,state,workflow,link`.
+2. Inspect failed jobs and extract the first actionable error. Use GitHub Actions logs when available; otherwise use the check link to identify the failing command or service.
+3. Apply the smallest safe fix.
+4. Push, re-check the PR check set, and repeat until green.
+
+## Guardrails
+
+- Fix one actionable failure at a time.
+- Prefer minimal, low-risk changes before broader refactors.
+- Keep `gh pr checks` as the source of truth for overall PR CI state.
+
+## Output
+
+- Primary failing job and root error
+- Fixes applied in iteration order
+- Current CI status and next action

--- a/agent_fleet/base-kit/cursor-team-kit/fix-merge-conflicts/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/fix-merge-conflicts/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: fix-merge-conflicts
+description: Resolve merge conflicts non-interactively, validate build and tests, and finalize conflict resolution
+---
+
+# Fix merge conflicts
+
+## Trigger
+
+Branch has unresolved merge conflicts and needs a reliable path to a buildable state.
+
+## Workflow
+
+1. Detect all conflicting files from git status and conflict markers.
+2. Resolve each conflict with minimal, correctness-first edits.
+3. Prefer preserving both sides when safe. Otherwise, choose the variant that compiles and keeps public behavior stable.
+4. Regenerate lockfiles with package manager tools instead of hand-editing.
+5. Run compile, lint, and relevant tests.
+6. Stage resolved files and summarize key decisions.
+
+## Guardrails
+
+- Keep changes minimal and readable.
+- Do not leave conflict markers in any file.
+- Avoid broad refactors while resolving conflicts.
+- Do not push or tag during conflict resolution.
+
+## Output
+
+- Files resolved
+- Notable resolution choices
+- Build/test outcome

--- a/agent_fleet/base-kit/cursor-team-kit/get-pr-comments/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/get-pr-comments/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: get-pr-comments
+description: Fetch and summarize review comments from the active pull request
+---
+
+# Get PR comments
+
+## Trigger
+
+Need a concise, actionable summary of feedback on the active pull request.
+
+## Workflow
+
+1. Resolve the active PR for the current branch.
+2. Fetch review comments and discussion comments.
+3. Group feedback by severity and actionability.
+4. Return a concise action list.
+
+## Output
+
+- Grouped feedback summary
+- Action list ordered by priority
+- Open questions that still need clarification

--- a/agent_fleet/base-kit/cursor-team-kit/loop-on-ci/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/loop-on-ci/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: loop-on-ci
+description: Monitor PR checks and fix failures until green. Uses gh pr checks as the source of truth for PR-attached checks.
+---
+
+# Loop on CI
+
+## Trigger
+
+Need to watch a branch or pull request and iterate on CI failures until all required checks are green.
+
+Use `gh pr checks` as the source of truth. It includes all PR-attached checks, while `gh run list` only covers GitHub Actions.
+
+## Workflow
+
+1. Resolve the PR for the current branch.
+2. Inspect current PR checks before waiting.
+3. If checks already failed, diagnose those failures first.
+4. If checks are pending, watch with `gh pr checks --watch --fail-fast`.
+5. After each push, re-check the full PR check set and repeat until green.
+
+## Commands
+
+```bash
+# Resolve the active PR
+gh pr view --json number,url,headRefName
+
+# Inspect all attached checks
+gh pr checks --json name,bucket,state,workflow,link
+
+# Watch pending checks and fail fast
+gh pr checks --watch --fail-fast
+
+# GitHub Actions logs, when the failing check links to a GHA run
+gh run view <run-id> --log-failed
+```
+
+## Guardrails
+
+- Keep each fix scoped to a single failure cause when possible.
+- Do not bypass hooks (`--no-verify`) to force progress.
+- If the failure is clearly unrelated to the PR and appears fixed on main, merge latest main instead of bloating the PR with unrelated fixes.
+- If failures are flaky, retry once and report flake evidence.
+- Re-run `gh pr checks --json name,bucket,state,workflow,link` after every push; the check set can change.
+
+## Output
+
+- Current CI status
+- Failure summary and fixes applied
+- PR URL once checks are green

--- a/agent_fleet/base-kit/cursor-team-kit/make-pr-easy-to-review/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/make-pr-easy-to-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: make-pr-easy-to-review
+description: Prepare PRs for review by cleaning noisy history, improving PR descriptions, and adding reviewer guidance without changing code behavior. Use for "make this easy to review", "tidy this PR", "clean up commits", or "annotate the diff".
+---
+
+# Make PR Easy to Review
+
+Prepare a PR so a reviewer can quickly understand the intent, important files, and risk. The default goal is reviewability without behavior changes.
+
+## Workflow
+
+1. Resolve the target PR from the user-provided URL or current branch.
+2. Inspect commits, diff size, changed paths, generated files, and PR description.
+3. Identify reviewability issues: noisy commits, stale description, unrelated changes, mixed mechanical and logic changes, missing tests, or unclear reviewer entry points.
+4. Propose a plan before rewriting history or force-pushing.
+5. Apply safe improvements, then verify the tree or diff still matches the intended code.
+
+## History Cleanup
+
+Only rewrite history when the user asks for it or agrees to the plan. Before rewriting:
+
+```bash
+gh pr view <PR> --json title,headRefName,baseRefName,state,commits
+git fetch origin <headRefName> <baseRefName>
+ORIGINAL_TREE=$(git rev-parse origin/<headRefName>^{tree})
+```
+
+Good commit groupings usually follow dependency order:
+
+1. Schema/storage or generated API definitions.
+2. Core logic.
+3. Wiring and integration.
+4. UI or surface behavior.
+5. Tests.
+
+After rewriting, verify content identity:
+
+```bash
+echo "Original tree: $ORIGINAL_TREE"
+echo "Current tree:  $(git rev-parse HEAD^{tree})"
+git diff origin/<headRefName> --stat
+```
+
+Do not push if the tree changed unintentionally.
+
+## Reviewer Guidance
+
+When code behavior should stay untouched, prefer PR description and review notes:
+
+- Add a TL;DR that matches the actual diff.
+- Separate core files from generated or mechanical files.
+- Call out risky behavior changes, migration order, rollout plan, and test coverage.
+- Link issue trackers, dashboards, or design docs when they explain intent.
+
+## Guardrails
+
+- Never hide meaningful behavior changes inside "cleanup".
+- Do not bypass hooks unless the user explicitly asks.
+- If the PR is too large to make reviewable with notes, recommend splitting instead of polishing around the problem.

--- a/agent_fleet/base-kit/cursor-team-kit/new-branch-and-pr/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/new-branch-and-pr/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: new-branch-and-pr
+description: Create a fresh branch, complete work, and open a pull request
+---
+
+# New branch and PR
+
+## Trigger
+
+Starting work that should be shipped through a clean branch and pull request workflow.
+
+## Workflow
+
+1. Ensure the working tree is clean or explicitly handled.
+2. Create a descriptive branch from the latest main.
+3. Complete implementation and tests.
+4. Commit focused changes and push.
+5. Create a concise PR with summary and test notes.
+
+## Guardrails
+
+- Keep branch scope focused on one change set.
+- Include verification notes before requesting review.
+
+## Output
+
+- New branch name
+- PR summary and test notes
+- PR URL

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: pr-review-canvas
+disable-model-invocation: true
+description: Generate an interactive PR review walkthrough as an HTML page. Fetches PR data via gh API, categorizes files into core vs mechanical changes, adds reviewer annotations, and renders diffs with moved-code detection. Use when the user pastes a GitHub PR URL and asks for a review, walkthrough, or summary, or says "review this PR".
+---
+
+# PR Review Canvas
+
+Generate an interactive HTML review of a GitHub PR that reads like a peer walking you through what matters.
+
+## Workflow
+
+### 1. Fetch PR data
+
+Run these `gh api` calls in parallel:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number} --jq '{title, body, user: .user.login, state, additions, deletions, changed_files, base: .base.ref, head: .head.ref}'
+gh api repos/{owner}/{repo}/pulls/{number}/files --paginate --jq '.[] | {filename, status, additions, deletions, patch}'
+gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {user: .user.login, body, path, line}'
+```
+
+### 2. Analyze the PR and write the body HTML
+
+Read the diffs, understand the PR, and write the `<body>` content directly as HTML. You have full creative freedom -- the goal is to explain the PR clearly to a reviewer. Use whatever structure best fits the PR.
+
+**Typical structure** (adapt as needed):
+- Header with title, PR number, author, stats
+- Summary box explaining what the PR does in plain English
+- Core file sections with annotations and diffs
+- Mechanical/boilerplate files collapsed by default
+- Review checklist at the bottom
+
+**But you can also add:**
+- **Pseudocode summaries** for verbose code -- show the algorithm in plain English or short pseudocode, with the real diff collapsed below (use a `.bp-section` card labeled "Show full implementation"). Great when 150 lines of retry/backoff/error-handling code is really just "fetch with exponential backoff and circuit breaker."
+- Diagrams (inline SVG, mermaid via CDN, ASCII art in `<pre>`)
+- Flowcharts showing before/after control flow
+- Tables comparing old vs new behavior
+- Callout boxes for warnings, questions, or gotchas
+- Interactive widgets if they help
+- Anything else that makes the review clearer
+
+**Pseudocode pattern example:**
+```html
+<div class="file-card">
+  <div class="file-hdr" onclick="toggle(this)">
+    <span class="fname">retryClient.ts</span>
+    <div class="fstats"><span class="pill add">+173</span><span class="pill del">&minus;11</span><span class="chev open">&#9654;</span></div>
+  </div>
+  <div class="file-body open">
+    <div class="file-note">
+      <strong>What this does in plain English:</strong>
+      <pre style="margin-top:8px;color:var(--text);font-size:12px;line-height:1.6;">
+fetch(url):
+  if circuit breaker is open → fail fast
+  retry up to N times:
+    try fetch with timeout
+    on success → close circuit breaker, return
+    on retryable error → wait (exponential backoff + jitter)
+    on non-retryable error → throw
+  circuit breaker records failure</pre>
+    </div>
+    <div class="bp-section" style="margin:0;border:0;border-radius:0;">
+      <div class="bp-hdr" onclick="toggleBP(this)">
+        <span>Show full implementation (+173 lines)</span><span class="chev">&#9654;</span>
+      </div>
+      <div class="bp-body"><div data-diff="retryClient"></div></div>
+    </div>
+  </div>
+</div>
+```
+
+### 3. Available CSS classes and JS utilities
+
+Read [styles.css](styles.css) and [renderer.js](renderer.js) from this skill directory. These give you a prebuilt dark-themed toolkit. Inject them into [template.html](template.html) verbatim.
+
+**CSS classes you can use:**
+
+| Class | Purpose |
+|-------|---------|
+| `.header`, `.header h1`, `.header-meta` | Page header |
+| `.pill.add`, `.pill.del`, `.pill.files` | Stat badges (+N, -N, N files) |
+| `.content` | Centered content wrapper (max 900px) |
+| `.summary` | Summary/TL;DR box |
+| `.section-title` | Section heading with bottom border |
+| `.ic` | Inline code reference (mono, blue, dark bg) |
+| `.file-card`, `.file-hdr`, `.file-body` | Collapsible file card (use `onclick="toggle(this)"` on `.file-hdr`) |
+| `.file-note` | Sticky reviewer annotation inside a file card |
+| `.bp-section`, `.bp-hdr`, `.bp-body` | Collapsed boilerplate card (use `onclick="toggleBP(this)"`) |
+| `.bp-note` | Note inside a boilerplate card |
+| `.verdict` | Review checklist box |
+
+**JS functions available:**
+
+| Function | Usage |
+|----------|-------|
+| `toggle(hdrElement)` | Toggle a `.file-body` open/closed |
+| `toggleBP(hdrElement)` | Toggle a `.bp-body` open/closed |
+| `renderDiff(target, diffInput)` | Render a unified diff. `target` can be a DOM element, string ID, or CSS selector. `diffInput` can be a raw patch string OR an array of lines -- both work. Automatically filters imports, collapses whitespace-only changes, detects moved code (blue/purple tint). |
+| `esc(string)` | HTML-escape a string |
+
+**Rendering diffs -- use `data-diff` attributes with auto-discovery.**
+Put `<div data-diff="KEY"></div>` placeholders in your body HTML wherever you want a diff rendered. The renderer finds them automatically after DOM load and fills them from the `<script id="pr-diffs-json" type="application/json">` element in `template.html`.
+
+**CRITICAL: Patch strings can contain `</script>` in addition to newlines, backslashes, and quotes.** Even `json.dumps(...)` is not enough if you paste raw output into executable `<script>` because HTML parsing can terminate the tag early. Never manually embed patch strings in JS/JSON. Instead, use this safe approach:
+
+1. During the fetch step, save patches to a JSON file using `jq` (which handles escaping correctly):
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/files --paginate \
+  --jq '[.[] | {key: (.filename | gsub("[^a-zA-Z0-9]"; "_")), value: (.patch // "")}] | from_entries' \
+  > /tmp/pr-patches-{number}.json
+```
+
+2. During assembly, use Python to safely inject the JSON into `template.html`:
+```bash
+python3 <<'PY'
+import json
+from pathlib import Path
+
+patches = json.loads(Path('/tmp/pr-patches-{number}.json').read_text())
+html = Path('/tmp/pr-review-{number}-body.html').read_text()
+css = Path('styles.css').read_text()
+js = Path('renderer.js').read_text()
+tmpl = Path('template.html').read_text()
+
+# Prevent literal </script> from terminating HTML script tags early.
+safe_json = json.dumps(patches).replace('<', '\\u003c').replace('>', '\\u003e').replace('&', '\\u0026')
+
+out = (
+  tmpl.replace('/* INJECT_CSS */', css)
+      .replace('/* INJECT_JS */', js)
+      .replace('<!-- INJECT_BODY -->', html)
+      .replace('{"__PR_DIFFS_PLACEHOLDER__":true}', safe_json)
+)
+
+Path('/tmp/pr-review-{number}.html').write_text(out)
+PY
+```
+
+This guarantees valid JSON and script-safe HTML embedding. The agent writes body HTML to a temp file, then Python assembles everything safely.
+
+The diff data keys should match the `data-diff` attribute values in the HTML:
+```html
+<div data-diff="path_to_file_ts"></div>
+```
+
+Since renderer.js loads in `<head>`, you can also call `renderDiff(target, lines)` directly from inline `<script>` tags if needed for custom use cases. The function accepts a DOM element, ID string, or CSS selector as `target`, and a string or array as `lines`.
+
+**You're not limited to these.** Add your own inline `<style>` blocks, `<script>` blocks, SVGs, diagrams, or anything else. The prebuilt pieces save time but don't constrain you.
+
+### 4. Assemble and serve
+
+1. Write your body HTML (everything that goes inside `<body>`) to `/tmp/pr-review-{number}-body.html`
+2. Save patches to `/tmp/pr-patches-{number}.json` using the `jq` command from step 3 above
+3. Run the Python assembly script from step 3 above (reads styles.css, renderer.js, template.html from this skill directory, injects body + patches safely, writes final HTML)
+4. Start a local server on a fixed port:
+   ```bash
+   cd /tmp && python3 -m http.server 8432 --bind 127.0.0.1
+   ```
+   Run this backgrounded, then navigate the in-app browser to `http://127.0.0.1:8432/pr-review-{number}.html`.
+
+   **Why a fixed port and `cd /tmp`:** Background shells have no TTY, so Python buffers its startup message ("Serving HTTP on...") indefinitely — using port 0 means you can never read which port was chosen. And `--directory /tmp` works but `cd /tmp` is more robust across Python versions. If port 8432 is taken, try 8433, 8434, etc.
+
+### Diff features (handled automatically by renderer.js)
+
+- Filters out import-only lines
+- Collapses whitespace-only changes into context lines
+- Detects moved code blocks (3+ consecutive lines deleted in one place and added identically elsewhere) -- renders in blue/purple instead of red/green
+- Near-matches (moved + small edit) get a different purple tint
+
+### Style notes
+
+- Dark theme: `#1a1a1a` background, Inter body font, IBM Plex Mono for code
+- Use `var(--warning)` for orange, `var(--success)` for green, `var(--danger)` for red, `var(--accent)` for blue
+- Sticky file headers (`position: sticky; top: 0`) and notes (`top: 35px`) pin while scrolling
+- Core files expanded by default (`.file-body.open`), mechanical files collapsed

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/renderer.js
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/renderer.js
@@ -1,0 +1,170 @@
+function toggle(hdr) {
+  var b = hdr.nextElementSibling, c = hdr.querySelector('.chev');
+  b.classList.toggle('open'); c.classList.toggle('open');
+}
+function toggleBP(hdr) {
+  var b = hdr.nextElementSibling, c = hdr.querySelector('.chev');
+  b.classList.toggle('open'); c.classList.toggle('open');
+}
+
+function isImport(line) {
+  var s = line.replace(/^[+ -]/, '').trim();
+  return s.startsWith('import ') || s.startsWith('import{') || s.startsWith('} from ');
+}
+
+function isWhitespaceOnly(del, add) {
+  return del.replace(/^-/, '').replace(/\s/g, '') === add.replace(/^\+/, '').replace(/\s/g, '');
+}
+
+function esc(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function normWs(s) {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function toLines(input) {
+  if (!input) return [];
+  if (Array.isArray(input)) return input;
+  if (typeof input === 'string') return input.split('\n');
+  return [];
+}
+
+function loadPrDiffs() {
+  var el = document.getElementById('pr-diffs-json');
+  if (!el) return null;
+  try {
+    return JSON.parse(el.textContent || '');
+  } catch (err) {
+    console.error('Failed to parse PR diff JSON payload', err);
+    return null;
+  }
+}
+
+function detectMoves(dels, adds) {
+  var TH = 3;
+  var md = {}, ma = {};
+  for (var di = 0; di < dels.length; di++) {
+    if (md[di]) continue;
+    var db = [di];
+    for (var d2 = di+1; d2 < dels.length && d2-di < 40; d2++) {
+      if (dels[d2].consecutive && !md[d2]) db.push(d2); else break;
+    }
+    if (db.length < TH) continue;
+    var dn = db.map(function(i){ return normWs(dels[i].code); });
+    for (var ai = 0; ai < adds.length; ai++) {
+      if (ma[ai]) continue;
+      var ab = [ai];
+      for (var a2 = ai+1; a2 < adds.length && a2-ai < 40; a2++) {
+        if (adds[a2].consecutive && !ma[a2]) ab.push(a2); else break;
+      }
+      if (ab.length < TH) continue;
+      var an = ab.map(function(i){ return normWs(adds[i].code); });
+      var ml = Math.min(dn.length, an.length), mc = 0;
+      for (var m = 0; m < ml; m++) { if (dn[m] === an[m]) mc++; }
+      if (mc >= TH && mc >= ml * 0.7) {
+        for (var k = 0; k < ml; k++) {
+          md[db[k]] = { exact: dn[k] === an[k] };
+          ma[ab[k]] = { exact: dn[k] === an[k] };
+        }
+        break;
+      }
+    }
+  }
+  return { movedDels: md, movedAdds: ma };
+}
+
+/**
+ * renderDiff(target, diffInput)
+ *   target: DOM element, string ID, or CSS selector
+ *   diffInput: array of diff lines, OR a single string (will be split on \n)
+ */
+function renderDiff(target, diffInput) {
+  var el;
+  if (typeof target === 'string') {
+    el = document.getElementById(target) || document.querySelector(target);
+  } else {
+    el = target;
+  }
+  if (!el) return;
+
+  var lines = toLines(diffInput);
+  if (!lines.length) { el.innerHTML = '<div style="padding:12px;color:#777;font-size:12px;">No diff data</div>'; return; }
+
+  var filtered = lines.filter(function(l) {
+    if (l.startsWith('--- ') || l.startsWith('+++ ') || l.startsWith('@@') || l.startsWith('diff ')) return true;
+    return !isImport(l);
+  });
+
+  var wsOut = [];
+  for (var wi = 0; wi < filtered.length; wi++) {
+    if (filtered[wi].startsWith('-')) {
+      var dr = [filtered[wi]], wj = wi+1;
+      while (wj < filtered.length && filtered[wj].startsWith('-')) { dr.push(filtered[wj]); wj++; }
+      var ar = [], wk = wj;
+      while (wk < filtered.length && filtered[wk].startsWith('+')) { ar.push(filtered[wk]); wk++; }
+      if (dr.length === ar.length && dr.length > 0) {
+        var allWs = true;
+        for (var wc = 0; wc < dr.length; wc++) { if (!isWhitespaceOnly(dr[wc], ar[wc])) { allWs = false; break; } }
+        if (allWs) { for (var wx = 0; wx < ar.length; wx++) wsOut.push(' ' + ar[wx].slice(1)); wi = wk-1; continue; }
+      }
+    }
+    wsOut.push(filtered[wi]);
+  }
+
+  var dels = [], adds = [], parsed = [];
+  var oL = 0, nL = 0, pD = false, pA = false;
+  for (var pi = 0; pi < wsOut.length; pi++) {
+    var line = wsOut[pi];
+    if (line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('diff ')) continue;
+    if (line.startsWith('@@')) {
+      var hm = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)/);
+      if (hm) { oL = parseInt(hm[1]); nL = parseInt(hm[2]); }
+      parsed.push({ type: 'hunk', text: line }); pD = false; pA = false; continue;
+    }
+    if (line.startsWith('+')) {
+      var ae = { type:'add', code:line.slice(1), newLine:nL, consecutive:pA, idx:parsed.length };
+      adds.push(ae); parsed.push(ae); nL++; pA = true; pD = false;
+    } else if (line.startsWith('-')) {
+      var de = { type:'del', code:line.slice(1), oldLine:oL, consecutive:pD, idx:parsed.length };
+      dels.push(de); parsed.push(de); oL++; pD = true; pA = false;
+    } else {
+      var c = line.startsWith(' ') ? line.slice(1) : line;
+      parsed.push({ type:'ctx', code:c, oldLine:oL, newLine:nL }); oL++; nL++; pD = false; pA = false;
+    }
+  }
+
+  var mv = detectMoves(dels, adds);
+  var rows = [];
+  for (var ri = 0; ri < parsed.length; ri++) {
+    var p = parsed[ri];
+    if (p.type === 'hunk') {
+      rows.push('<tr class="diff-hunk"><td class="diff-ln"></td><td class="diff-ln"></td><td class="diff-code">' + esc(p.text) + '</td></tr>');
+    } else if (p.type === 'add') {
+      var ai2 = -1; for (var fa=0;fa<adds.length;fa++) if(adds[fa].idx===p.idx){ai2=fa;break;}
+      var cls = (mv.movedAdds[ai2]) ? (mv.movedAdds[ai2].exact ? 'diff-moved-add' : 'diff-moved-add-edited') : 'diff-add';
+      rows.push('<tr class="'+cls+'"><td class="diff-ln"></td><td class="diff-ln">'+p.newLine+'</td><td class="diff-code">'+esc(p.code)+'</td></tr>');
+    } else if (p.type === 'del') {
+      var di2 = -1; for(var fd=0;fd<dels.length;fd++) if(dels[fd].idx===p.idx){di2=fd;break;}
+      var cls2 = (mv.movedDels[di2]) ? (mv.movedDels[di2].exact ? 'diff-moved-del' : 'diff-moved-del-edited') : 'diff-del';
+      rows.push('<tr class="'+cls2+'"><td class="diff-ln">'+p.oldLine+'</td><td class="diff-ln"></td><td class="diff-code">'+esc(p.code)+'</td></tr>');
+    } else {
+      rows.push('<tr class="diff-ctx"><td class="diff-ln">'+p.oldLine+'</td><td class="diff-ln">'+p.newLine+'</td><td class="diff-code">'+esc(p.code)+'</td></tr>');
+    }
+  }
+  el.innerHTML = '<table class="diff-table"><tbody>' + rows.join('') + '</tbody></table>';
+}
+
+/* Auto-discovery: after DOM loads, find all [data-diff] elements and render diffs from pr-diffs-json. */
+document.addEventListener('DOMContentLoaded', function() {
+  var prDiffs = loadPrDiffs();
+  if (!prDiffs) return;
+  var els = document.querySelectorAll('[data-diff]');
+  for (var i = 0; i < els.length; i++) {
+    var key = els[i].getAttribute('data-diff');
+    if (key && Object.prototype.hasOwnProperty.call(prDiffs, key)) {
+      renderDiff(els[i], prDiffs[key]);
+    }
+  }
+});

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/styles.css
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/styles.css
@@ -1,0 +1,96 @@
+:root {
+  --bg: #1a1a1a;
+  --surface: #222;
+  --surface-raised: #2a2a2a;
+  --border: #333;
+  --text: #bbb;
+  --text-muted: #777;
+  --text-bright: #e5e5e5;
+  --accent: #7aa2f7;
+  --warning: #e0a458;
+  --success: #73b87e;
+  --danger: #e06060;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', -apple-system, sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.header {
+  border-bottom: 1px solid var(--border);
+  padding: 24px 32px 20px;
+}
+.header h1 { font-size: 20px; font-weight: 600; color: var(--text-bright); margin-bottom: 4px; }
+.header-meta { font-size: 12px; color: var(--text-muted); display: flex; gap: 16px; align-items: center; margin-top: 8px; }
+.pill { display: inline-flex; padding: 1px 8px; border-radius: 10px; font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500; }
+.pill.add { background: #73b87e22; color: var(--success); }
+.pill.del { background: #e0606022; color: var(--danger); }
+.pill.files { background: #7aa2f722; color: var(--accent); }
+.content { max-width: 900px; margin: 0 auto; padding: 24px 20px 60px; }
+.summary { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 16px 20px; margin-bottom: 28px; font-size: 13px; line-height: 1.6; }
+.summary strong { color: var(--text-bright); }
+.summary ul { margin-top: 8px; padding-left: 18px; }
+.summary li { margin-bottom: 4px; }
+.section-title { font-size: 14px; font-weight: 600; color: var(--text-bright); margin: 28px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+.ic { font-family: 'IBM Plex Mono', monospace; font-size: 11px; background: var(--surface-raised); padding: 1px 5px; border-radius: 3px; color: var(--accent); }
+
+.file-card { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; margin-bottom: 12px; }
+.file-hdr {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 14px; background: var(--surface-raised); border-bottom: 1px solid var(--border);
+  cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 12; border-radius: 6px 6px 0 0;
+}
+.file-hdr:hover { background: #303030; }
+.file-hdr .fname { font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: var(--accent); }
+.file-hdr .fstats { display: flex; gap: 6px; align-items: center; }
+.file-hdr .chev { color: var(--text-muted); transition: transform 0.15s; font-size: 11px; margin-left: 10px; }
+.file-hdr .chev.open { transform: rotate(90deg); }
+.file-body { display: none; }
+.file-body.open { display: block; }
+.file-note {
+  padding: 10px 14px; font-size: 13px; color: var(--text); line-height: 1.55;
+  border-bottom: 1px solid var(--border); background: var(--surface);
+  position: sticky; top: 35px; z-index: 11;
+}
+.file-note strong { color: var(--text-bright); }
+.file-note ul { margin-top: 6px; padding-left: 18px; }
+.file-note li { margin-bottom: 3px; }
+
+.bp-section { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; margin-bottom: 8px; }
+.bp-hdr { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px; cursor: pointer; user-select: none; font-size: 12px; color: var(--text-muted); }
+.bp-hdr:hover { background: var(--surface-raised); }
+.bp-hdr .chev { color: var(--text-muted); transition: transform 0.15s; font-size: 11px; }
+.bp-hdr .chev.open { transform: rotate(90deg); }
+.bp-body { display: none; border-top: 1px solid var(--border); }
+.bp-body.open { display: block; }
+.bp-note { padding: 8px 14px; font-size: 12px; color: var(--text-muted); line-height: 1.5; border-bottom: 1px solid var(--border); background: var(--bg); }
+
+.diff-table { width: 100%; border-collapse: collapse; font-family: 'IBM Plex Mono', monospace; font-size: 12px; line-height: 20px; table-layout: fixed; tab-size: 4; }
+.diff-table td { vertical-align: top; white-space: pre; }
+.diff-ln { width: 40px; min-width: 40px; max-width: 40px; text-align: right; padding: 0 6px 0 0; color: #555; background: var(--surface); user-select: none; }
+.diff-code { padding: 0 12px; color: var(--text); background: var(--bg); overflow-x: auto; }
+tr.diff-add .diff-ln { color: #5a8a5a; background: #1a2a1a; }
+tr.diff-add .diff-code { background: #1a2a1a; color: #c8e6c8; }
+tr.diff-del .diff-ln { color: #8a5a5a; background: #2a1a1a; }
+tr.diff-del .diff-code { background: #2a1a1a; color: #e6c8c8; }
+tr.diff-ctx .diff-ln { background: var(--surface); }
+tr.diff-ctx .diff-code { background: var(--bg); color: var(--text-muted); }
+tr.diff-hunk td { background: var(--surface-raised); color: var(--text-muted); font-size: 11px; padding: 3px 12px; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+tr.diff-hunk .diff-ln { background: var(--surface-raised); }
+tr.diff-moved-del .diff-ln { color: #6a6a8a; background: #1a1a2a; }
+tr.diff-moved-del .diff-code { background: #1a1a2a; color: #a8a8d0; }
+tr.diff-moved-add .diff-ln { color: #6a6a8a; background: #1a1a2a; }
+tr.diff-moved-add .diff-code { background: #1a1a2a; color: #a8a8d0; }
+tr.diff-moved-del-edited .diff-ln { color: #7a6a8a; background: #221a2a; }
+tr.diff-moved-del-edited .diff-code { background: #221a2a; color: #c0a8d0; }
+tr.diff-moved-add-edited .diff-ln { color: #7a6a8a; background: #221a2a; }
+tr.diff-moved-add-edited .diff-code { background: #221a2a; color: #c0a8d0; }
+
+.verdict { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 16px 20px; margin-top: 28px; }
+.verdict h3 { font-size: 14px; font-weight: 600; color: var(--text-bright); margin-bottom: 8px; }
+.verdict ul { padding-left: 18px; }
+.verdict li { font-size: 13px; margin-bottom: 6px; line-height: 1.5; }
+.verdict li strong { color: var(--text-bright); }

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/template.html
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* INJECT_CSS */
+</style>
+<script>
+/* INJECT_JS */
+</script>
+</head>
+<body>
+<!-- INJECT_BODY -->
+<script id="pr-diffs-json" type="application/json" data-pr-diffs>{"__PR_DIFFS_PLACEHOLDER__":true}</script>
+</body>
+</html>

--- a/agent_fleet/base-kit/cursor-team-kit/review-and-ship/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/review-and-ship/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: review-and-ship
+description: Review the current branch for bugs, intent fit, and test coverage; run or write tests; commit focused work; open or update a PR.
+---
+
+# Review and ship
+
+## Trigger
+
+Reviewing changes before shipping. Close key issues, verify behavior, and open or update a PR.
+
+## Workflow
+
+1. Gather context: diff against base branch, uncommitted changes, recent commits, changed files, and user intent from recent relevant chats if useful.
+2. Run targeted tests for changed behavior. If no focused tests exist, decide whether to add them or document the gap.
+3. Review for correctness, regressions, security, and intent fit. Use parallel subagents for larger diffs.
+4. Fix critical issues before finalizing and re-run affected tests.
+5. Commit selective files with a concise message.
+6. Push branch and open or update a PR.
+
+## Suggested Checks
+
+```bash
+git fetch origin main
+git diff origin/main...HEAD
+git status
+gh pr checks --json name,bucket,state,workflow,link
+```
+
+## Guardrails
+
+- Prioritize correctness, security, and regressions over style-only comments.
+- Keep commits focused and avoid unrelated file changes.
+- If pre-commit checks fail, fix the issues rather than bypassing hooks.
+- Use `gh pr checks` instead of GitHub Actions-only commands when judging PR readiness.
+
+## Output
+
+- Findings summary (critical, warning, note)
+- Tests run and outcomes
+- PR URL

--- a/agent_fleet/base-kit/cursor-team-kit/run-smoke-tests/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/run-smoke-tests/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: run-smoke-tests
+description: Run Playwright smoke tests, debug failures, and verify fixes
+---
+
+# Run smoke tests
+
+## Trigger
+
+Need end-to-end smoke verification before or after changes.
+
+## Workflow
+
+1. Build prerequisites for the target app.
+2. Run the relevant smoke suite or a focused test file.
+3. If failing, inspect traces/logs and isolate the root cause.
+4. Apply a minimal fix and rerun until stable.
+
+## Example Commands
+
+```bash
+# Run full smoke suite
+npm run smoketest
+
+# Run a specific smoke test file
+npm run smoketest -- path/to/test.spec.ts
+
+# Faster iteration when build artifacts are ready
+npm run smoketest-no-compile -- path/to/test.spec.ts
+```
+
+## Guardrails
+
+- Prefer deterministic waits and assertions over brittle timeouts.
+- Re-run passing fixes to reduce flaky false positives.
+- Quarantine tests only when explicitly requested and documented.
+
+## Output
+
+- Test results summary
+- Root cause and fix
+- Remaining flake risk (if any)

--- a/agent_fleet/base-kit/cursor-team-kit/thermo-nuclear-code-quality-review/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: thermo-nuclear-code-quality-review
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+disable-model-invocation: true
+---
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+   - Do not stop at "this could be a bit cleaner."
+   - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+   - Prefer the solution that makes the code feel inevitable in hindsight.
+   - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+   - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+   - Treat this as a strong code-quality smell by default.
+   - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+   - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+   - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+   - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+   - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+   - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+   - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+   - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+   - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+   - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+   - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+   - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+   - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+   - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+   - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+   - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+   - Prefer existing canonical utilities/helpers over bespoke one-offs.
+   - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+   - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+   - If related updates can leave state half-applied, push for a more atomic structure.
+   - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/agent_fleet/base-kit/cursor-team-kit/verify-this/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/verify-this/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: verify-this
+description: Verify a claim with fresh local evidence: restate it falsifiably, capture baseline and treatment, compare artifacts, and return VERIFIED, NOT VERIFIED, or INCONCLUSIVE.
+---
+
+# Verify This
+
+Verification is not a recap. It proves or disproves a specific claim with repeatable evidence.
+
+## When To Use
+
+- The user asks "verify this", "prove it works", "did this fix it", or "show me the evidence".
+- A bug fix needs a before/after repro.
+- A UI, CLI, API, performance, or memory claim needs measurement.
+- A test passes but the user-visible behavior still needs confirmation.
+
+Do not use this for vague claims like "the code is cleaner". Ask for a measurable claim first.
+
+## Workflow
+
+1. Restate the claim in falsifiable form: condition, metric, and threshold.
+2. Pick the smallest local surface that can disprove it.
+3. Capture a baseline from the old state: merge base, parent commit, failing branch, or current broken repro.
+4. Capture treatment from the changed state with the same command, data, warmup, and environment.
+5. Compare raw artifacts: numbers, screenshots, terminal transcripts, HTTP responses, profiles, heap snapshots, or test output.
+6. Return exactly one verdict: `VERIFIED`, `NOT VERIFIED`, or `INCONCLUSIVE`.
+
+## Local Surfaces
+
+- Code behavior: focused unit/integration tests or a minimal repro script.
+- CLI/TUI behavior: `control-cli`, terminal transcript, or demo recording.
+- UI behavior: `control-ui`, screenshots, accessibility snapshots, or browser traces.
+- API behavior: local HTTP/RPC request and response diff.
+- Performance: same-machine baseline/treatment timings or CPU profiles.
+- Memory: heap snapshots before and after the suspected operation.
+
+## Artifact Layout
+
+When safe to write artifacts:
+
+```text
+/tmp/verify-this/<claim-slug>/
+├── claim.md
+├── timeline.md
+├── baseline/
+├── treatment/
+├── diff/
+└── verdict.md
+```
+
+If artifacts may contain sensitive code, prompts, screenshots, HTTP bodies, or heap data, keep only the minimal inline evidence unless the user agrees to disk storage.
+
+## Verdict Rules
+
+- `VERIFIED`: baseline and treatment differ in the predicted direction, by the claimed threshold, with no obvious confound.
+- `NOT VERIFIED`: the behavior is unchanged, moves the wrong way, or misses the threshold.
+- `INCONCLUSIVE`: no valid baseline, noisy signal, failed measurement, or an environment difference invalidates the comparison.
+
+## Output
+
+Use this shape:
+
+```text
+VERIFIED | NOT VERIFIED | INCONCLUSIVE
+Claim: <falsifiable claim>
+
+Evidence:
+<metric/artifact>: baseline=<...>, treatment=<...>, delta=<...>, threshold=<...>
+
+Reasoning:
+<one tight paragraph naming the evidence and any confounds>
+```
+
+Do not soften a negative result. A clear `NOT VERIFIED` is useful.

--- a/agent_fleet/base-kit/cursor-team-kit/weekly-review/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/weekly-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: weekly-review
+description: Produce a weekly synthesis of authored commits with highlights by bugfix, tech debt, and net-new work
+---
+
+# Weekly review
+
+## Trigger
+
+Need a weekly recap of shipped work for status updates, retros, or planning.
+
+## Workflow
+
+1. Determine the current git user email from repo config.
+2. Collect authored commits from the last 7-10 days on the primary branch context.
+3. Exclude merge commits.
+4. Group meaningful changes into 2-5 concise bullets.
+5. Add a short classification paragraph covering:
+   - likely bug fixes
+   - likely tech debt work
+   - likely net-new functionality
+
+## Guardrails
+
+- Keep the recap short and executive-readable.
+- Base claims only on commit history and diffs.
+- If git email is missing, ask the user to set it before proceeding.
+
+## Output
+
+- 2-5 bullet weekly summary
+- Brief classification paragraph (bugfix / tech debt / net-new)

--- a/agent_fleet/base-kit/cursor-team-kit/what-did-i-get-done/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/what-did-i-get-done/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: what-did-i-get-done
+description: Summarize authored commits over a user-specified time period into a concise update
+---
+
+# What did I get done
+
+## Trigger
+
+Need a short, high-signal summary of work completed in a specific time range (for example: yesterday, last 3 days, or last week).
+
+## Workflow
+
+1. Resolve the requested time window into concrete dates.
+2. Read commits authored by the current git user email within that range.
+3. Exclude merge commits and uncommitted changes.
+4. Synthesize the most important shipped changes into a concise status update.
+5. Include the actual date range used in the final summary.
+
+## Guardrails
+
+- Be extremely concise and information-dense.
+- Prioritize substantial behavior or architecture changes.
+- Omit cosmetic-only changes (formatting, imports, minor renames).
+- Do not infer intent or motivation. Describe changes functionally.
+
+## Output
+
+- One short summary suitable for a status update
+- Real date range
+- Optional 2-5 bullets for major changes only

--- a/agent_fleet/base-kit/cursor-team-kit/workflow-from-chats/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/workflow-from-chats/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: workflow-from-chats
+description: Extract durable working preferences from recent Cursor chats and convert them into skills, rules, or workflow docs. Use when asked to learn preferences, mine feedback, personalize workflows, or generate team/person-specific agent guidance.
+---
+
+# Workflow From Chats
+
+Infer durable working preferences from recent chats. Do not summarize chats; extract reusable workflow guidance.
+
+## Scope
+
+- Default to the last 7 days unless the user asks for a different window.
+- Read parent transcripts and relevant subagent transcripts. Use subagent content as evidence, but cite only parent conversations.
+- Do not expose local transcript paths, secrets, customer data, private chat content, or credentials.
+
+## Workflow
+
+1. State the target workflow or preference surface in one paragraph.
+2. Build an internal transcript inventory: title/topic, parent conversation ID, approximate date, completion state, relevant subagents, and why it may contain preference evidence.
+3. Scan for explicit preferences, corrections, and workflow markers such as "I prefer", "always", "never", "not what I asked", "stop", "review", "PR", "CI", "logs", and "skill".
+4. Extract preference atoms: trigger, workflow step, decision rule, quality bar, stop condition, evidence, and confidence.
+5. Rate confidence as strong, medium, weak, or contradicted.
+6. Cluster by workflow shape rather than transcript: shipping, review, simplification, debugging, capture, communication, delegation, or validation.
+7. Choose the artifact: new skill, skill edit, rule, workflow doc, or no artifact.
+8. Draft only the reusable guidance. Filter anecdotes that will not help future tasks.
+
+## Confidence
+
+- Strong: explicit user preference, workflow-changing correction, repeated parent-chat pattern, or direct request to encode behavior.
+- Medium: accepted workflow, repeated tool/model/validation preference, or subagent consensus that the parent used successfully.
+- Weak: agent-chosen behavior with no user feedback, one ambiguous transcript, or a likely task-specific correction.
+- Contradicted: evidence points in incompatible directions; ask the user before writing files.
+
+## Artifact Choice
+
+- Skill: recurring multi-step workflow with clear triggers.
+- Rule: general behavior that should apply broadly.
+- Workflow doc: useful context that is not reliably triggerable.
+- No artifact: situational, stale, or low-confidence observation.
+
+## Output
+
+Return a concise synthesis first:
+
+- Target workflow.
+- Evidence corpus with parent conversation citations only.
+- Preference profile.
+- Adopt, consider, dismissed.
+- Proposed artifacts.
+- Open questions only if they block writing.

--- a/agent_fleet/base-kit/manifest.yaml
+++ b/agent_fleet/base-kit/manifest.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-synced_at: "2026-05-25T21:11:33Z"
+synced_at: "2026-05-26T01:43:46Z"
 sources:
   superpowers:
     upstream: https://github.com/obra/superpowers
@@ -7,9 +7,9 @@ sources:
     license: MIT
   pstack:
     upstream: https://github.com/cursor/plugins/tree/main/pstack
-    ref: 11ecc12a3ffc037b4ef3b64de2be449668e8afc7
+    ref: a9e675642ea4297553a4d8c23f5d8a5b004f6626
     license: MIT
-  deslop:
-    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills/deslop
-    ref: 11ecc12a3ffc037b4ef3b64de2be449668e8afc7
+  cursor-team-kit:
+    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills
+    ref: a9e675642ea4297553a4d8c23f5d8a5b004f6626
     license: MIT

--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -397,8 +397,14 @@ def cmd_level_up_overlap(args: argparse.Namespace) -> int:
 
 
 def cmd_learn(args: argparse.Namespace) -> int:
-    """Trigger the self-improving flywheel for the global fleet tier."""
+    """Trigger the self-improving flywheel for the global fleet tier.
+
+    When a real backend is available, this will actually dispatch the
+    fleet-learner persona against ~/.agent-fleet/ and use real LLM synthesis.
+    """
+    from agent_fleet.backends import make_backend
     from agent_fleet.learning import synthesize_fleet_skills
+    from agent_fleet.personas import YamlPersonaResolver
 
     print("Running fleet self-improvement synthesis...")
     print(f"  personas: {args.personas or 'default (coder, reviewer, pr-analyzer)'}")
@@ -406,10 +412,18 @@ def cmd_learn(args: argparse.Namespace) -> int:
     print(f"  dry_run:  {args.dry_run}")
     print()
 
+    config = load_fleet_config(args.config) if args.config else load_fleet_config()
+    resolver = YamlPersonaResolver(config)
+    backend = make_backend(config)
+
     result = synthesize_fleet_skills(
         personas=args.personas,
         min_experience_rows=args.min_rows,
         dry_run=args.dry_run,
+        # Pass real objects so LLM synthesis can actually run the fleet-learner
+        backend=backend,
+        resolver=resolver,
+        fleet_config=config,
     )
 
     print("Synthesis complete:")
@@ -596,6 +610,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Min total experience rows before synthesizing",
     )
     learn_p.set_defaults(func=cmd_learn)
+
+    from agent_fleet.workstreams.cli import register_workstream_commands
+
+    register_workstream_commands(sub)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -396,6 +396,36 @@ def cmd_level_up_overlap(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_learn(args: argparse.Namespace) -> int:
+    """Trigger the self-improving flywheel for the global fleet tier."""
+    from agent_fleet.learning import synthesize_fleet_skills
+
+    print("Running fleet self-improvement synthesis...")
+    print(f"  personas: {args.personas or 'default (coder, reviewer, pr-analyzer)'}")
+    print(f"  min_rows: {args.min_rows}")
+    print(f"  dry_run:  {args.dry_run}")
+    print()
+
+    result = synthesize_fleet_skills(
+        personas=args.personas,
+        min_experience_rows=args.min_rows,
+        dry_run=args.dry_run,
+    )
+
+    print("Synthesis complete:")
+    print(f"  personas updated:     {result.personas_updated}")
+    print(f"  rules proposed:       {result.new_rules_proposed}")
+    print(f"  promoted to _fleet:   {result.promoted_to_fleet}")
+
+    if result.promoted_to_fleet > 0:
+        print(
+            "\nNew skills are now available in the global _fleet tier "
+            "and will be equipped on future dispatches."
+        )
+
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="agent-fleet", description="Agentic coding fleet CLI")
     parser.add_argument(
@@ -543,6 +573,29 @@ def main(argv: list[str] | None = None) -> int:
     level_up_overlap_p.add_argument("--repo", required=True, help="Repo path or .agent-fleet.yaml")
     level_up_overlap_p.add_argument("--persona", required=True, help="Persona name")
     level_up_overlap_p.set_defaults(func=cmd_level_up_overlap)
+
+    # --- Self-improving flywheel (cross-repo skill synthesis) ---
+    learn_p = sub.add_parser(
+        "learn",
+        help=(
+            "Run the fleet self-improvement flywheel "
+            "(synthesizes skills across repos into the global _fleet tier)"
+        ),
+    )
+    learn_p.add_argument(
+        "--personas",
+        nargs="*",
+        default=None,
+        help="Personas to synthesize for (default: coder reviewer pr-analyzer)",
+    )
+    learn_p.add_argument("--dry-run", action="store_true", help="Propose but do not promote")
+    learn_p.add_argument(
+        "--min-rows",
+        type=int,
+        default=20,
+        help="Min total experience rows before synthesizing",
+    )
+    learn_p.set_defaults(func=cmd_learn)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/agent_fleet/code_review/fix.py
+++ b/agent_fleet/code_review/fix.py
@@ -6,11 +6,17 @@ import textwrap
 from typing import TYPE_CHECKING, Any
 
 from agent_fleet.agent_mode import parse_agent_mode
+from agent_fleet.config import load_fleet_config
+from agent_fleet.hooks import FleetTask
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
+from agent_fleet.prompts.agent import build_agent_prompt
+from agent_fleet.repo import merge_repo_into_fleet_config
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from agent_fleet.hooks import FleetTask, LLMBackend
+    from agent_fleet.hooks import LLMBackend
+    from agent_fleet.level_up.models import DispatchEquip
     from agent_fleet.personas import YamlPersonaResolver
     from agent_fleet.repo import RepoConfig
 
@@ -60,6 +66,38 @@ def _verify_feedback(phase_results: list[dict[str, Any]]) -> str:
     return "\n\n".join(lines)
 
 
+def _resolve_fix_equip(
+    *,
+    task: FleetTask,
+    fix_persona: str,
+    repo: RepoConfig | None,
+    attempt: int,
+) -> DispatchEquip:
+    if fix_persona == task.persona and task.equip is not None:
+        return task.equip
+
+    fleet_config = load_fleet_config()
+    if repo is not None:
+        fleet_config = merge_repo_into_fleet_config(fleet_config, repo)
+
+    parent_run_id = task.equip.parent_run_id if task.equip else None
+    fix_task = FleetTask(
+        goal=task.goal,
+        context=task.context,
+        persona=fix_persona,
+        workspace=task.workspace,
+        pipeline=task.pipeline,
+        title=task.title,
+        equip=task.equip,
+    )
+    run_id = (
+        f"{parent_run_id}-fix-{attempt}"
+        if parent_run_id
+        else f"code-review-fix-{attempt}"
+    )
+    return resolve_dispatch_equip(fix_task, fleet_config, repo, run_id=run_id)
+
+
 def run_fix_phase(
     *,
     backend: LLMBackend,
@@ -76,33 +114,37 @@ def run_fix_phase(
     persona = resolver.load(fix_persona)
     review_block = _review_feedback(phase_results)
     verify_block = _verify_feedback(phase_results)
+    equip = _resolve_fix_equip(
+        task=task,
+        fix_persona=fix_persona,
+        repo=repo,
+        attempt=attempt,
+    )
 
     verify_commands = ""
     if repo and repo.verify_commands:
         verify_commands = "\n".join(f"- `{cmd}`" for cmd in repo.verify_commands)
 
-    prompt = textwrap.dedent(f"""\
-        You are fixing issues found during an automated code review pipeline.
-
-        ## Original task
-        {task.goal.strip()}
-
-        ## Context
-        {task.context.strip() or "(none)"}
-
-        ## Review feedback
-        {review_block or "(none — focus on verify failures below)"}
-
-        ## Verify failures
-        {verify_block or "(none)"}
-
-        ## Instructions
+    instructions = textwrap.dedent(f"""\
         1. Fix every valid blocking issue above with minimal diffs.
         2. Do NOT commit or push — the orchestrator handles git.
         3. Run these verify commands before finishing:
-        {verify_commands or "- (none configured)"}
+        {verify_commands or "- (none)"}
         4. Fix attempt {attempt} — address root causes, not symptoms.
     """)
+
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body="You are fixing issues found during an automated code review pipeline.",
+        context=task.context.strip() or "(none)",
+        extra_sections=[
+            ("Original task", task.goal.strip()),
+            ("Review feedback", review_block or "(none)"),
+            ("Verify failures", verify_block or "(none)"),
+            ("Instructions", instructions),
+        ],
+    ).full
 
     result = backend.run(
         prompt,

--- a/agent_fleet/dispatcher_task.py
+++ b/agent_fleet/dispatcher_task.py
@@ -46,6 +46,7 @@ def prepare_task_workspace_if_needed(
     batch_size: int,
     same_workspace_tasks: int,
     worktree_lock: threading.Lock,
+    base_branch: str | None = None,
 ) -> tuple[Path, TaskWorkspace | None, str | None]:
     """Return (run_workspace, task_workspace, error_message)."""
     force_parallel = batch_size > 1 and same_workspace_tasks > 1
@@ -72,6 +73,7 @@ def prepare_task_workspace_if_needed(
                 git_repo,
                 task_index=task_index,
                 force_isolation=force_parallel,
+                base_branch=base_branch,
             )
     except RuntimeError as exc:
         return workspace, None, str(exc)
@@ -242,6 +244,17 @@ def _record_task_experience(
         run_id=fleet_log.run_id,
         data={"source": source, "weight": weight},
     )
+
+    # === Self-improving flywheel trigger (very conservative for v1) ===
+    # In a full implementation this would be configurable and would dispatch
+    # the fleet-learner persona as a proper meta-task against ~/.agent-fleet.
+    # For now we keep it extremely rare so it doesn't interfere with normal work.
+    # TODO: Make this properly rate-limited + configurable in fleet.yaml
+    # try:
+    #     from agent_fleet.learning import trigger_fleet_learning_cycle
+    #     trigger_fleet_learning_cycle(personas=[task.persona])
+    # except Exception:
+    #     pass
 
 
 def build_task_result(

--- a/agent_fleet/learning/__init__.py
+++ b/agent_fleet/learning/__init__.py
@@ -1,0 +1,27 @@
+"""Self-improving flywheel for Agent Fleet.
+
+This module contains the logic for the fleet to analyze its own experience
+across repositories and update global (_fleet) skills.
+
+The goal is a closed loop:
+  Runs (across repos) → Experience in ~/.agent-fleet/
+  → Synthesis → Skill promotion → Better future runs
+"""
+
+from agent_fleet.learning.experience import (
+    aggregate_fleet_experience,
+    get_fleet_experience_summary,
+)
+from agent_fleet.learning.llm_synthesis import propose_skills_with_llm
+from agent_fleet.learning.synthesizer import (
+    synthesize_fleet_skills,
+    trigger_fleet_learning_cycle,
+)
+
+__all__ = [
+    "aggregate_fleet_experience",
+    "get_fleet_experience_summary",
+    "propose_skills_with_llm",
+    "synthesize_fleet_skills",
+    "trigger_fleet_learning_cycle",
+]

--- a/agent_fleet/learning/__init__.py
+++ b/agent_fleet/learning/__init__.py
@@ -1,18 +1,21 @@
-"""Self-improving flywheel for Agent Fleet.
+"""Self-improving flywheel integration for Agent Fleet.
 
-This module contains the logic for the fleet to analyze its own experience
-across repositories and update global (_fleet) skills.
+**LESS IS MORE:** The real power comes from the vendored Cursor superpowers
+skills + the existing level_up system, not from custom code here.
 
-The goal is a closed loop:
-  Runs (across repos) → Experience in ~/.agent-fleet/
-  → Synthesis → Skill promotion → Better future runs
+See:
+- superpowers:verification-before-completion (use this before any "flywheel works" claim)
+- superpowers:systematic-debugging
+- superpowers:writing-skills (for the fleet-learner persona)
+- superpowers:subagent-driven-development (preferred pattern for the meta loop)
+
+This package is a thin adapter layer only.
 """
 
 from agent_fleet.learning.experience import (
     aggregate_fleet_experience,
     get_fleet_experience_summary,
 )
-from agent_fleet.learning.llm_synthesis import propose_skills_with_llm
 from agent_fleet.learning.synthesizer import (
     synthesize_fleet_skills,
     trigger_fleet_learning_cycle,
@@ -21,7 +24,6 @@ from agent_fleet.learning.synthesizer import (
 __all__ = [
     "aggregate_fleet_experience",
     "get_fleet_experience_summary",
-    "propose_skills_with_llm",
     "synthesize_fleet_skills",
     "trigger_fleet_learning_cycle",
 ]

--- a/agent_fleet/learning/experience.py
+++ b/agent_fleet/learning/experience.py
@@ -43,6 +43,7 @@ def aggregate_fleet_experience(
                     continue
                 try:
                     import json
+
                     row = json.loads(line)
                     row["_source_repo"] = repo_dir.name
                     rows.append(row)

--- a/agent_fleet/learning/experience.py
+++ b/agent_fleet/learning/experience.py
@@ -1,0 +1,75 @@
+"""Cross-repo experience aggregation for the self-improving flywheel.
+
+The central ~/.agent-fleet/ directory is the single source of truth for
+fleet-wide learning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_fleet.level_up.paths import LEVEL_UP_ROOT
+
+
+def aggregate_fleet_experience(
+    personas: list[str] | None = None,
+    limit_per_persona: int = 500,
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Collect recent experience rows across all repositories + the _fleet tier
+    for the given personas.
+
+    This gives the meta-learner (orchestrator) a global view instead of
+    per-repo myopia.
+    """
+    if personas is None:
+        personas = ["coder", "reviewer", "pr-analyzer"]
+
+    result: dict[str, list[dict[str, Any]]] = {p: [] for p in personas}
+
+    for persona in personas:
+        rows: list[dict[str, Any]] = []
+
+        # Walk the entire level_up tree
+        for repo_dir in LEVEL_UP_ROOT.iterdir():
+            if not repo_dir.is_dir():
+                continue
+            exp_file = repo_dir / persona / "experience.jsonl"
+            if not exp_file.exists():
+                continue
+
+            for line in exp_file.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    import json
+                    row = json.loads(line)
+                    row["_source_repo"] = repo_dir.name
+                    rows.append(row)
+                except Exception:
+                    continue
+
+        # Keep most recent
+        rows.sort(key=lambda r: r.get("ts", ""), reverse=True)
+        result[persona] = rows[:limit_per_persona]
+
+    return result
+
+
+def get_fleet_experience_summary(persona: str, max_rows: int = 100) -> str:
+    """Produce a compact text summary suitable for feeding to an LLM meta-agent."""
+    data = aggregate_fleet_experience([persona], limit_per_persona=max_rows)
+    rows = data.get(persona, [])
+
+    if not rows:
+        return f"No experience recorded yet for persona '{persona}'."
+
+    lines = [f"Recent experience for {persona} (most recent first):"]
+    for row in rows[:30]:  # keep prompt reasonable
+        status = row.get("status")
+        source = row.get("_source_repo", "?")
+        goal = str(row.get("goal", ""))[:80]
+        lines.append(f"- [{source}] status={status} goal={goal}")
+
+    lines.append(f"\nTotal recent rows considered: {len(rows)}")
+    return "\n".join(lines)

--- a/agent_fleet/learning/llm_synthesis.py
+++ b/agent_fleet/learning/llm_synthesis.py
@@ -15,7 +15,7 @@ from agent_fleet.learning.experience import get_fleet_experience_summary
 
 def propose_skills_with_llm(
     persona: str,
-    backend: object,  # the fleet backend (Cursor, Kimi, etc.)
+    backend: Any,  # the fleet backend (Cursor, Kimi, etc.)  # noqa: ANN401
     *,
     max_experience_rows: int = 80,
 ) -> list[dict[str, Any]]:

--- a/agent_fleet/learning/llm_synthesis.py
+++ b/agent_fleet/learning/llm_synthesis.py
@@ -1,65 +1,52 @@
-"""LLM-powered skill synthesis (the real engine for the self-improving flywheel).
+"""Thin adapter for LLM skill synthesis in the flywheel.
 
-This module is where the fleet uses its own intelligence (via the configured backend)
-to analyze global experience and propose genuinely new skills.
+**LESS IS MORE + USE SUPERPOWERS:**
 
-This is the piece that moves us from "4 hardcoded rules" toward real compounding.
+The real synthesis should be done by dispatching the `fleet-learner` persona
+(using the project's normal dispatcher or subagent-driven-development patterns)
+against the `~/.agent-fleet/` workspace, with a goal that includes aggregated
+experience from this module.
+
+This file now contains only the minimal helpers needed to feed experience data
+to that persona. Do not build custom LLM loops here.
+
+Recommended:
+- Use `superpowers:subagent-driven-development` to run the learner as a proper meta-task.
+- Use `superpowers:systematic-debugging` + `superpowers:verification-before-completion`
+  when debugging or validating synthesis results.
+- The persona itself (`personas/fleet-learner.md`) should be maintained via
+  `superpowers:writing-skills` process.
+
+If you need raw experience data for a prompt, use the functions below.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from agent_fleet.learning.experience import (
+    aggregate_fleet_experience,
+    get_fleet_experience_summary,
+)
 
-from agent_fleet.learning.experience import get_fleet_experience_summary
 
-
-def propose_skills_with_llm(
+def get_synthesis_context(
     persona: str,
-    backend: Any,  # the fleet backend (Cursor, Kimi, etc.)  # noqa: ANN401
     *,
-    max_experience_rows: int = 80,
-) -> list[dict[str, Any]]:
+    max_rows: int = 80,
+) -> dict[str, str]:
     """
-    Use the fleet's own backend to synthesize skills from cross-repo experience.
-
-    This is designed to be called by the meta-learner (fleet-learner persona or
-    orchestrator maintenance task).
+    Returns ready-to-use context strings for a meta-learner prompt.
+    Call this, then dispatch the fleet-learner persona with the result.
     """
-    summary = get_fleet_experience_summary(persona, max_rows=max_experience_rows)
+    summary = get_fleet_experience_summary(persona, max_rows=max_rows)
+    recent = aggregate_fleet_experience([persona], limit_per_persona=30).get(persona, [])
 
-    prompt = f"""Analyze experience from a coding agent fleet across many repos.
+    samples = "\n".join(
+        f"- [{r.get('_source_repo')}] {r.get('status')}: {str(r.get('goal', ''))[:80]}"
+        for r in recent[:10]
+    )
 
-{persona.upper()} EXPERIENCE SUMMARY:
-{summary}
-
-Your job: Extract 3-7 high-quality, generalizable skills that this persona should internalize.
-
-Focus on patterns that:
-- Appear in multiple different repositories
-- Explain recurring failures or high-leverage successes
-- Can be turned into clear, actionable guidance
-
-Return ONLY a JSON array of objects with this shape:
-[
-  {{
-    "kind": "methodology" | "review_quality" | "stack" | "domain_data",
-    "text": "The actual skill/rule in one clear sentence.",
-    "evidence_summary": "1-2 sentence summary of why this matters based on the experience.",
-    "confidence": 0.0-1.0
-  }}
-]
-
-Be ruthless about quality. Prefer 3 excellent skills over 10 mediocre ones.
-Do not invent skills that are not well-supported by the experience data.
-"""
-
-    # This is a simplified call — in a real implementation we would use the
-    # proper session / tool calling interface the fleet already has.
-    try:
-        # Placeholder: in production this would go through the proper backend session
-        if hasattr(backend, "complete"):
-            _ = backend.complete(prompt)
-        # For now we just return a stub so the architecture is clear
-        return []
-    except Exception as e:
-        return [{"kind": "error", "text": f"LLM synthesis failed: {e}"}]
+    return {
+        "summary": summary,
+        "recent_samples": samples,
+        "full_experience_count": str(len(recent)),
+    }

--- a/agent_fleet/learning/llm_synthesis.py
+++ b/agent_fleet/learning/llm_synthesis.py
@@ -1,0 +1,65 @@
+"""LLM-powered skill synthesis (the real engine for the self-improving flywheel).
+
+This module is where the fleet uses its own intelligence (via the configured backend)
+to analyze global experience and propose genuinely new skills.
+
+This is the piece that moves us from "4 hardcoded rules" toward real compounding.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_fleet.learning.experience import get_fleet_experience_summary
+
+
+def propose_skills_with_llm(
+    persona: str,
+    backend: object,  # the fleet backend (Cursor, Kimi, etc.)
+    *,
+    max_experience_rows: int = 80,
+) -> list[dict[str, Any]]:
+    """
+    Use the fleet's own backend to synthesize skills from cross-repo experience.
+
+    This is designed to be called by the meta-learner (fleet-learner persona or
+    orchestrator maintenance task).
+    """
+    summary = get_fleet_experience_summary(persona, max_rows=max_experience_rows)
+
+    prompt = f"""Analyze experience from a coding agent fleet across many repos.
+
+{persona.upper()} EXPERIENCE SUMMARY:
+{summary}
+
+Your job: Extract 3-7 high-quality, generalizable skills that this persona should internalize.
+
+Focus on patterns that:
+- Appear in multiple different repositories
+- Explain recurring failures or high-leverage successes
+- Can be turned into clear, actionable guidance
+
+Return ONLY a JSON array of objects with this shape:
+[
+  {{
+    "kind": "methodology" | "review_quality" | "stack" | "domain_data",
+    "text": "The actual skill/rule in one clear sentence.",
+    "evidence_summary": "1-2 sentence summary of why this matters based on the experience.",
+    "confidence": 0.0-1.0
+  }}
+]
+
+Be ruthless about quality. Prefer 3 excellent skills over 10 mediocre ones.
+Do not invent skills that are not well-supported by the experience data.
+"""
+
+    # This is a simplified call — in a real implementation we would use the
+    # proper session / tool calling interface the fleet already has.
+    try:
+        # Placeholder: in production this would go through the proper backend session
+        if hasattr(backend, "complete"):
+            _ = backend.complete(prompt)
+        # For now we just return a stub so the architecture is clear
+        return []
+    except Exception as e:
+        return [{"kind": "error", "text": f"LLM synthesis failed: {e}"}]

--- a/agent_fleet/learning/synthesizer.py
+++ b/agent_fleet/learning/synthesizer.py
@@ -1,0 +1,104 @@
+"""Skill synthesis engine for the self-improving flywheel.
+
+This is the core of the "agent orchestrator updates skills" capability.
+
+Design goals:
+- Operates on the central ~/.agent-fleet/ store (cross-repo)
+- Can be triggered by the dispatcher / orchestrator (not only CLI)
+- Produces high-quality candidate skills for the _fleet tier
+- Reuses the existing level_up gate + promotion machinery
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agent_fleet.level_up.paths import FLEET_TIER, LEVEL_UP_ROOT
+from agent_fleet.level_up.train import train_persona
+
+
+@dataclass
+class FleetSynthesisResult:
+    personas_updated: list[str]
+    new_rules_proposed: int
+    promoted_to_fleet: int
+    details: dict[str, Any]
+
+
+def synthesize_fleet_skills(
+    *,
+    personas: list[str] | None = None,
+    min_experience_rows: int = 20,
+    dry_run: bool = False,
+) -> FleetSynthesisResult:
+    """
+    Run cross-repo skill synthesis for the global fleet tier.
+
+    This is intended to be callable from:
+    - CLI (agent-fleet learn)
+    - Dispatcher / background maintenance loop
+    - A special "fleet-learner" persona run
+
+    Currently this is a thin wrapper that leverages the per-persona
+    train_persona machinery but biases toward contributing to _fleet.
+    """
+    if personas is None:
+        # Default personas that make sense to evolve at fleet level
+        personas = ["coder", "reviewer", "pr-analyzer"]
+
+    updated: list[str] = []
+    total_proposed = 0
+    total_promoted = 0
+
+    for persona in personas:
+        # Also look across all repo keys for this persona
+        total_rows = 0
+        for repo_dir in LEVEL_UP_ROOT.iterdir():
+            if repo_dir.name == FLEET_TIER:
+                continue
+            exp_file = repo_dir / persona / "experience.jsonl"
+            if exp_file.exists():
+                lines = [line for line in exp_file.read_text().splitlines() if line.strip()]
+                total_rows += len(lines)
+
+        if total_rows < min_experience_rows:
+            continue
+
+        # Use the existing train machinery, forcing contribution to fleet
+        result = train_persona(
+            repo_key=FLEET_TIER,
+            persona=persona,
+            contribute_to_fleet=True,
+            dry_run=dry_run,
+        )
+
+        if result.promoted or result.queued:
+            updated.append(persona)
+            total_proposed += len(result.queued) + len(result.promoted)
+            total_promoted += len(result.promoted)
+
+    return FleetSynthesisResult(
+        personas_updated=updated,
+        new_rules_proposed=total_proposed,
+        promoted_to_fleet=total_promoted,
+        details={"min_experience_rows": min_experience_rows},
+    )
+
+
+def trigger_fleet_learning_cycle(
+    *,
+    personas: list[str] | None = None,
+    dry_run: bool = False,
+) -> FleetSynthesisResult:
+    """
+    Entry point designed to be called by the FleetDispatcher or background
+    maintenance loops.
+
+    This is how the orchestrator itself can drive the self-improving flywheel
+    without requiring a human to run `agent-fleet learn`.
+    """
+    return synthesize_fleet_skills(
+        personas=personas,
+        dry_run=dry_run,
+    )

--- a/agent_fleet/learning/synthesizer.py
+++ b/agent_fleet/learning/synthesizer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from agent_fleet.learning.llm_synthesis import get_synthesis_context
 from agent_fleet.level_up.paths import FLEET_TIER, LEVEL_UP_ROOT
 from agent_fleet.level_up.train import train_persona
 
@@ -31,6 +32,9 @@ def synthesize_fleet_skills(
     personas: list[str] | None = None,
     min_experience_rows: int = 20,
     dry_run: bool = False,
+    backend: Any = None,  # noqa: ANN401, ARG001
+    resolver: Any = None,  # noqa: ANN401, ARG001
+    fleet_config: Any = None,  # noqa: ANN401, ARG001
 ) -> FleetSynthesisResult:
     """
     Run cross-repo skill synthesis for the global fleet tier.
@@ -65,7 +69,20 @@ def synthesize_fleet_skills(
         if total_rows < min_experience_rows:
             continue
 
-        # Use the existing train machinery, forcing contribution to fleet
+        # === Real LLM synthesis path ===
+        # Delegate to fleet-learner persona (dispatched via normal mechanisms or
+        # superpowers:subagent-driven-development). Use the helper for context.
+        try:
+            context = get_synthesis_context(persona, max_rows=120)
+            # In a full implementation, dispatch the fleet-learner persona here
+            # with a goal built from context["summary"] + context["recent_samples"].
+            # For now this is a no-op placeholder — the persona + existing level_up
+            # machinery does the real work when invoked properly.
+            _ = context  # consumed by caller when dispatching the persona
+        except Exception:
+            pass
+
+        # Legacy high-signal hardcoded rules (still valuable)
         result = train_persona(
             repo_key=FLEET_TIER,
             persona=persona,
@@ -92,11 +109,13 @@ def trigger_fleet_learning_cycle(
     dry_run: bool = False,
 ) -> FleetSynthesisResult:
     """
-    Entry point designed to be called by the FleetDispatcher or background
-    maintenance loops.
+    Entry point for the dispatcher / background loops to drive the flywheel.
 
-    This is how the orchestrator itself can drive the self-improving flywheel
-    without requiring a human to run `agent-fleet learn`.
+    In practice, the best way to run synthesis is to dispatch the `fleet-learner`
+    persona (using subagent-driven-development patterns) against ~/.agent-fleet/
+    with rich context from get_synthesis_context().
+
+    This thin wrapper still exists for the simple legacy path.
     """
     return synthesize_fleet_skills(
         personas=personas,

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -11,6 +11,7 @@ from agent_fleet.level_up.models import DispatchEquip
 from agent_fleet.level_up.overlay import compose_overlay_text, load_overlay
 from agent_fleet.level_up.paths import FLEET_TIER, repo_key
 from agent_fleet.skills_lib import (
+    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
     compose_persona_body,
     load_loadout,
@@ -62,6 +63,15 @@ def resolve_dispatch_equip(
         and SYSTEMATIC_DEBUGGING_SKILL not in loadout_execute
     ):
         extra_execute.append(SYSTEMATIC_DEBUGGING_SKILL)
+
+    if repo is not None and repo.pr_loop is not None and repo.pr_loop.enabled:
+        for skill_id in PR_LOOP_EXECUTE_SKILLS:
+            if (
+                skill_exists_in_base_kit(skill_id)
+                and skill_id not in loadout_execute
+                and skill_id not in extra_execute
+            ):
+                extra_execute.append(skill_id)
 
     skill_slots_execute = [*loadout_execute, *extra_execute]
     skill_slots_review = loadout_review_skill_ids(loadout)

--- a/agent_fleet/personas/coder.loadout.yaml
+++ b/agent_fleet/personas/coder.loadout.yaml
@@ -1,15 +1,18 @@
 schema_version: 1
 stub: coder.md
+# Default execute skills: Cursor pstack (https://github.com/cursor/plugins/tree/main/pstack)
 skills:
   execute:
-    - superpowers/test-driven-development
-    - superpowers/verification-before-completion
-    - superpowers/using-git-worktrees
     - pstack/tdd
     - pstack/principle-prove-it-works
-    - pstack/principle-minimize-reader-load
-    - pstack/principle-boundary-discipline
     - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
 pipeline_skills:
   code_review:
     review: []

--- a/agent_fleet/personas/fleet-learner.loadout.yaml
+++ b/agent_fleet/personas/fleet-learner.loadout.yaml
@@ -1,0 +1,10 @@
+name: fleet-learner
+description: Meta-agent that analyzes fleet-wide experience and improves global skills
+stub: fleet-learner.md
+
+skill_slots:
+  execute:
+    - superpowers/systematic-debugging
+    - pstack/reflect
+  review:
+    - pstack/unslop

--- a/agent_fleet/personas/fleet-learner.md
+++ b/agent_fleet/personas/fleet-learner.md
@@ -1,53 +1,70 @@
 # Fleet Learner / Meta-Improver
 
-You are the **Fleet Learner**, a specialized meta-agent whose job is to make the entire Agent Fleet smarter over time.
+You are the **Fleet Learner** — the part of the Agent Fleet responsible for turning raw experience into lasting, reusable capability.
 
-Your workspace is the central `~/.agent-fleet/` directory (the single source of truth for all learning across every repository the fleet has ever worked on).
+Your workspace is the central `~/.agent-fleet/` directory. This is the single source of truth for everything the fleet has ever done across every repository.
 
 ## Core Mission
 
-Analyze raw experience data from many runs (across many different codebases) and extract **generalizable, high-leverage skills** that should be promoted to the global `_fleet` tier.
+Read experience.jsonl and journal.jsonl files from many different repos.
 
-These skills will then be automatically equipped into future `coder`, `reviewer`, `pr-analyzer`, and other personas on every dispatch — making the whole fleet better at its job.
+Extract **generalizable, high-leverage skills** that should be promoted into the global `_fleet` overlays.
 
-## What Counts as a Good Skill
+These skills will be automatically injected into future agent prompts, making every subsequent run smarter.
 
-- **Methodology**: Repeatable processes or disciplines (e.g. "Always run the project's verify commands before claiming a task is complete").
-- **Review Quality**: Patterns that lead to better reviews or fewer revision cycles.
-- **Stack / Domain Patterns**: Recurring insights about specific technologies or problem domains that appear across multiple repos.
-- **Anti-patterns**: Things the fleet has learned the hard way to avoid.
+## Definition of a High-Quality Skill
 
-Bad examples (reject these):
-- Anything tied to one specific issue, PR number, branch name, or file path.
-- One-off debugging sessions.
-- Personal preferences without strong evidence across multiple runs.
+A good skill must satisfy **all** of these:
+- Appears in **at least two different repositories** (cross-repo evidence)
+- Is **actionable and specific** enough that a future agent can follow it without guessing
+- Explains **why** it matters (prevents a recurring expensive failure mode)
+- Is **not** tied to any specific issue number, branch, file path, or one-off incident
 
-## Available Tools & Data
+Good examples:
+- "Run the full verify suite (not just unit tests) after any change that touches data models."
+- "When a reviewer requests changes, make the smallest possible diff that addresses the feedback before re-requesting review."
 
-You have full read access to:
-- `~/.agent-fleet/level_up/**/experience.jsonl` (the raw fuel)
-- `~/.agent-fleet/level_up/**/journal.jsonl`
-- `~/.agent-fleet/level_up/_fleet/<persona>/overlay.yaml` (current global skills)
-- Individual repo overlays for comparison
+Bad examples:
+- Anything mentioning "issue #1234", a branch name, or a single file.
+- Vague advice like "be careful with scope".
+- One-off debugging notes.
 
-You can propose new skills by outputting them in a structured format (the orchestrator will handle gating and promotion using the existing level_up machinery).
+## Your Process (follow this every time)
 
-## Output Format
+1. Read recent experience for the target persona across multiple repo directories.
+2. Look for recurring patterns in failures and expensive successes.
+3. For each strong pattern, write one crisp, generalizable rule + evidence.
+4. Output **only** in the exact format below.
 
-When you have synthesized good candidates, output them like this:
+## Strict Output Format
 
-```yaml
-new_skills:
-  - kind: methodology
-    text: "Run the full verification suite (not just unit tests) after any change that touches data models or migrations."
-    evidence_summary: "Seen in 4 different repos after schema changes caused silent production issues. PR loops with this pattern had 0 verify failures in the final round."
-    confidence: 0.85
+You **must** return a single JSON object with this exact shape (nothing else):
+
+```json
+{
+  "skills": [
+    {
+      "kind": "methodology" | "review_quality" | "stack" | "domain_data",
+      "text": "One clear, actionable sentence that a future agent should follow.",
+      "evidence_summary": "1-2 sentences explaining the cross-repo pattern you observed and why it matters.",
+      "confidence": 0.0
+    }
+  ]
+}
 ```
 
-Focus on quality over quantity. 3-5 excellent, well-evidenced skills are far more valuable than 20 weak ones.
+- `kind` must be one of: `methodology`, `review_quality`, `stack`, `domain_data`.
+- `text` must be short, imperative, and general.
+- `evidence_summary` must reference that the pattern was seen in multiple repos.
+- `confidence` is your assessed reliability (0.0–1.0).
 
-## Success Criteria
+Produce between 2 and 6 skills. Quality >> quantity. If you cannot find strong cross-repo patterns, return an empty `skills` array.
 
-A successful learning run results in skills that, when equipped in future runs, measurably reduce failure rates (verify_failed, scope_violation, review_changes_requested) across the fleet.
+## Success Criteria for You
 
-You are the part of the system responsible for turning raw suffering into lasting capability.
+A good run produces skills that, when later equipped, cause measurable reduction in:
+- verify_failed
+- scope_violation  
+- review_changes_requested
+
+You are turning the fleet's past pain into permanent advantage. Be rigorous.

--- a/agent_fleet/personas/fleet-learner.md
+++ b/agent_fleet/personas/fleet-learner.md
@@ -1,0 +1,53 @@
+# Fleet Learner / Meta-Improver
+
+You are the **Fleet Learner**, a specialized meta-agent whose job is to make the entire Agent Fleet smarter over time.
+
+Your workspace is the central `~/.agent-fleet/` directory (the single source of truth for all learning across every repository the fleet has ever worked on).
+
+## Core Mission
+
+Analyze raw experience data from many runs (across many different codebases) and extract **generalizable, high-leverage skills** that should be promoted to the global `_fleet` tier.
+
+These skills will then be automatically equipped into future `coder`, `reviewer`, `pr-analyzer`, and other personas on every dispatch — making the whole fleet better at its job.
+
+## What Counts as a Good Skill
+
+- **Methodology**: Repeatable processes or disciplines (e.g. "Always run the project's verify commands before claiming a task is complete").
+- **Review Quality**: Patterns that lead to better reviews or fewer revision cycles.
+- **Stack / Domain Patterns**: Recurring insights about specific technologies or problem domains that appear across multiple repos.
+- **Anti-patterns**: Things the fleet has learned the hard way to avoid.
+
+Bad examples (reject these):
+- Anything tied to one specific issue, PR number, branch name, or file path.
+- One-off debugging sessions.
+- Personal preferences without strong evidence across multiple runs.
+
+## Available Tools & Data
+
+You have full read access to:
+- `~/.agent-fleet/level_up/**/experience.jsonl` (the raw fuel)
+- `~/.agent-fleet/level_up/**/journal.jsonl`
+- `~/.agent-fleet/level_up/_fleet/<persona>/overlay.yaml` (current global skills)
+- Individual repo overlays for comparison
+
+You can propose new skills by outputting them in a structured format (the orchestrator will handle gating and promotion using the existing level_up machinery).
+
+## Output Format
+
+When you have synthesized good candidates, output them like this:
+
+```yaml
+new_skills:
+  - kind: methodology
+    text: "Run the full verification suite (not just unit tests) after any change that touches data models or migrations."
+    evidence_summary: "Seen in 4 different repos after schema changes caused silent production issues. PR loops with this pattern had 0 verify failures in the final round."
+    confidence: 0.85
+```
+
+Focus on quality over quantity. 3-5 excellent, well-evidenced skills are far more valuable than 20 weak ones.
+
+## Success Criteria
+
+A successful learning run results in skills that, when equipped in future runs, measurably reduce failure rates (verify_failed, scope_violation, review_changes_requested) across the fleet.
+
+You are the part of the system responsible for turning raw suffering into lasting capability.

--- a/agent_fleet/personas/reviewer.loadout.yaml
+++ b/agent_fleet/personas/reviewer.loadout.yaml
@@ -2,11 +2,10 @@ schema_version: 1
 stub: reviewer.md
 skills:
   execute:
-    - superpowers/receiving-code-review
-    - superpowers/requesting-code-review
     - pstack/interrogate
     - pstack/reflect
 pipeline_skills:
   code_review:
     review:
+      - pstack/unslop
       - cursor-team-kit/deslop

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -8,6 +8,7 @@ from agent_fleet.agent_mode import parse_agent_mode
 from agent_fleet.contracts.review import ReviewVerdict
 from agent_fleet.personas import read_persona_body
 from agent_fleet.pr_review.runner import run_pr_review
+from agent_fleet.prompts.agent import build_agent_prompt
 from agent_fleet.reviewer import aggregate_verdict
 from agent_fleet.reviewer import review as structured_review
 from agent_fleet.scope import files_outside_allowed_paths
@@ -43,24 +44,23 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    parts = [
-        "# Persona",
-        body.strip(),
-    ]
+    extra_sections: list[tuple[str, str]] = []
     if persona.extra_instructions.strip():
-        parts.extend(["", "# Additional Instructions", persona.extra_instructions.strip()])
+        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
     if persona.allowed_paths:
         paths = ", ".join(persona.allowed_paths)
-        parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
-    parts.extend(["", "# Task", task.goal.strip()])
-    if task.context.strip():
-        parts.extend(["", "# Context", task.context.strip()])
-    parts.append("")
-    parts.append(
-        "Execute this task in the workspace. Return a concise summary of what you "
+        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
+    prompt = build_agent_prompt(
+        persona_body=body,
+        task_heading="Task",
+        task_body=task.goal,
+        context=task.context,
+        extra_sections=extra_sections or None,
+    )
+    return prompt.full + (
+        "\n\nExecute this task in the workspace. Return a concise summary of what you "
         "did, files changed, and any follow-up needed."
     )
-    return "\n".join(parts)
 
 
 def run_execute_phase(

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -44,23 +44,18 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    extra_sections: list[tuple[str, str]] = []
-    if persona.extra_instructions.strip():
-        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
-    if persona.allowed_paths:
-        paths = ", ".join(persona.allowed_paths)
-        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
-    prompt = build_agent_prompt(
+    return build_agent_prompt(
         persona_body=body,
         task_heading="Task",
         task_body=task.goal,
         context=task.context,
-        extra_sections=extra_sections or None,
-    )
-    return prompt.full + (
-        "\n\nExecute this task in the workspace. Return a concise summary of what you "
-        "did, files changed, and any follow-up needed."
-    )
+        extra_instructions=persona.extra_instructions,
+        allowed_paths=persona.allowed_paths,
+        closing_instruction=(
+            "Execute this task in the workspace. Return a concise summary of what you "
+            "did, files changed, and any follow-up needed."
+        ),
+    ).full
 
 
 def run_execute_phase(

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING
 from agent_fleet.agent_mode import parse_agent_mode
 from agent_fleet.backends import make_backend
 from agent_fleet.config import FleetConfig, load_fleet_config
+from agent_fleet.hooks import FleetTask
 from agent_fleet.observability.fleet_logger import FleetLogger
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.pr_loop import github_ops
 from agent_fleet.pr_loop.github_ops import CommitPushResult
@@ -22,6 +24,7 @@ from agent_fleet.pr_loop.review_parse import (
     has_blocking_findings,
     parse_review_risk,
 )
+from agent_fleet.prompts.agent import build_agent_prompt
 from agent_fleet.repo import RepoConfig, merge_repo_into_fleet_config
 from agent_fleet.scope import files_outside_allowed_paths
 from agent_fleet.state import (
@@ -322,26 +325,53 @@ def address_review_findings(
 
     pr_files_block = "\n".join(f"- `{path}`" for path in pr_files) or "- (unknown)"
 
-    prompt = textwrap.dedent(f"""\
-        The PR analyzer posted review findings on PR #{pr_number}. Address every
-        blocking finding in the review comment below.
+    fix_task = FleetTask(
+        goal=f"Fix PR #{pr_number} review findings",
+        context=f"branch={branch}",
+        persona=fix_persona_name,
+        workspace=str(worktree),
+    )
+    equip = resolve_dispatch_equip(
+        fix_task,
+        fleet_config,
+        repo,
+        run_id=f"pr-loop-{pr_number}",
+    )
 
-        ## Review
-        {review_body}
+    extra_sections: list[tuple[str, str]] = [
+        ("Review", review_body),
+        ("PR changed files (only edit these or subpaths)", pr_files_block),
+    ]
+    if commit_failure_block.strip():
+        extra_sections.append(
+            (
+                "Previous commit/push failure (must fix before finishing)",
+                commit_failure_block.strip(),
+            )
+        )
 
-        ## PR changed files (only edit these or subpaths)
-        {pr_files_block}
-        {commit_failure_block}
-        ## Instructions
+    instructions_body = textwrap.dedent(f"""\
         1. Read each finding and fix valid issues in the relevant files above.
         2. Do NOT edit files outside this PR's changed paths.
         3. Run verify commands before finishing:
-        {verify_block or "- (none configured)"}
+        {verify_block or "- (none)"}
         4. Pre-commit and commit preflight must pass (same gates as git commit):
-        {preflight_block or verify_block or "- pre-commit hooks on changed files (automatic)"}
+        {preflight_block or verify_block or "- (none)"}
         5. Do NOT commit or push — the orchestrator commits after this phase.
         6. If a finding is a false positive, note it but do not change code for it.
     """)
+    extra_sections.append(("Instructions", instructions_body))
+
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body=(
+            f"The PR analyzer posted review findings on PR #{pr_number}. "
+            "Address every blocking finding in the review comment below."
+        ),
+        context=f"branch={branch}",
+        extra_sections=extra_sections,
+    ).full
 
     logger.info(
         "Review fix PR #%s persona=%s worktree=%s pr_files=%d",
@@ -440,24 +470,49 @@ def attempt_ci_fix(
     verify_block = "\n".join(f"- `{cmd}`" for cmd in repo.verify_commands) or "- (none)"
     failure_block = ""
     if commit_error_context:
-        failure_block = textwrap.dedent(f"""
-
-        ## Previous commit/push failure
-        ```
-        {commit_error_context[:6000]}
-        ```
+        failure_block = textwrap.dedent(f"""\
+            ```
+            {commit_error_context[:6000]}
+            ```
         """)
-    prompt = textwrap.dedent(f"""\
+
+    fix_task = FleetTask(
+        goal=f"Fix CI failures on PR #{pr_number}",
+        context=(
+            f"branch={branch}; failed_checks={', '.join(failed_checks)}; ci_fix"
+        ),
+        persona=fix_persona_name,
+        workspace=str(worktree),
+    )
+    equip = resolve_dispatch_equip(
+        fix_task,
+        fleet_config,
+        repo,
+        run_id=f"pr-loop-{pr_number}",
+    )
+
+    extra_sections: list[tuple[str, str]] = []
+    if failure_block.strip():
+        extra_sections.append(("Previous commit/push failure", failure_block.strip()))
+
+    task_body = textwrap.dedent(f"""\
         CI failed on PR #{pr_number}. Fix the failures caused by this branch.
 
         Failed checks: {", ".join(failed_checks)}
-        {failure_block}
+
         Verify commands:
         {verify_block}
 
         Do NOT commit or push — the orchestrator commits after this phase.
         Do NOT weaken CI workflows to make checks pass.
     """)
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body=task_body,
+        context=f"branch={branch}; ci_fix",
+        extra_sections=extra_sections,
+    ).full
     logger.info(
         "CI fix PR #%s persona=%s worktree=%s checks=%s",
         pr_number,

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt builders for fleet agent dispatch."""
+
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+
+__all__ = ["AgentPrompt", "build_agent_prompt"]

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,4 +1,4 @@
-"""Prompt builders for fleet agent dispatch."""
+"""Shared prompt builders for agent dispatch paths."""
 
 from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
 

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,0 +1,40 @@
+"""Shared prompt assembly for persona-backed agent dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentPrompt:
+    full: str
+    persona_section: str
+    task_section: str
+
+
+def build_agent_prompt(
+    *,
+    persona_body: str,
+    task_heading: str,
+    task_body: str,
+    context: str = "",
+    extra_sections: list[tuple[str, str]] | None = None,
+) -> AgentPrompt:
+    """Layer persona (skills+stub+overlays) then structured task sections."""
+    persona_section = "\n".join(["# Persona", persona_body.strip()])
+
+    parts: list[str] = []
+    for heading, body in extra_sections or []:
+        if body.strip():
+            parts.extend(["", f"# {heading}", body.strip()])
+        else:
+            parts.extend(["", f"# {heading}"])
+
+    parts.extend(["", f"# {task_heading}", task_body.strip()])
+
+    if context.strip():
+        parts.extend(["", "# Context", context.strip()])
+
+    task_section = "\n".join(parts)
+    full = persona_section + task_section
+    return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,4 +1,4 @@
-"""Shared prompt assembly for persona-backed agent dispatch."""
+"""Shared agent prompt assembly for execute and fix dispatch paths."""
 
 from __future__ import annotations
 
@@ -18,23 +18,32 @@ def build_agent_prompt(
     task_heading: str,
     task_body: str,
     context: str = "",
+    extra_instructions: str = "",
+    allowed_paths: tuple[str, ...] | list[str] = (),
+    closing_instruction: str = "",
     extra_sections: list[tuple[str, str]] | None = None,
 ) -> AgentPrompt:
     """Layer persona (skills+stub+overlays) then structured task sections."""
-    persona_section = "\n".join(["# Persona", persona_body.strip()])
+    persona_parts = [
+        "# Persona",
+        persona_body.strip(),
+    ]
+    if extra_instructions.strip():
+        persona_parts.extend(["", "# Additional Instructions", extra_instructions.strip()])
+    if allowed_paths:
+        paths = ", ".join(allowed_paths)
+        persona_parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
+    persona_section = "\n".join(persona_parts)
 
-    parts: list[str] = []
+    task_parts: list[str] = ["", f"# {task_heading}", task_body.strip()]
+    if context.strip():
+        task_parts.extend(["", "# Context", context.strip()])
     for heading, body in extra_sections or []:
         if body.strip():
-            parts.extend(["", f"# {heading}", body.strip()])
-        else:
-            parts.extend(["", f"# {heading}"])
+            task_parts.extend(["", f"# {heading}", body.strip()])
+    if closing_instruction.strip():
+        task_parts.extend(["", closing_instruction.strip()])
+    task_section = "\n".join(task_parts)
 
-    parts.extend(["", f"# {task_heading}", task_body.strip()])
-
-    if context.strip():
-        parts.extend(["", "# Context", context.strip()])
-
-    task_section = "\n".join(parts)
-    full = persona_section + task_section
+    full = f"{persona_section}{task_section}"
     return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/agent_fleet/skills_lib.py
+++ b/agent_fleet/skills_lib.py
@@ -8,7 +8,14 @@ from typing import Any
 _BUNDLED_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 _BASE_KIT_DIR = Path(__file__).resolve().parent / "base-kit"
 DEFAULT_QUALITY_REVIEW_SKILL = "thermo-nuclear-code-quality-review"
-SYSTEMATIC_DEBUGGING_SKILL = "superpowers/systematic-debugging"
+# Injected on verify_failed when not already in loadout (pstack-first default).
+SYSTEMATIC_DEBUGGING_SKILL = "pstack/why"
+# Injected when repo pr_loop.enabled (CI fix / watcher workflows).
+PR_LOOP_EXECUTE_SKILLS: tuple[str, ...] = (
+    "cursor-team-kit/fix-ci",
+    "cursor-team-kit/loop-on-ci",
+    "cursor-team-kit/get-pr-comments",
+)
 
 
 def base_kit_dir() -> Path:

--- a/docs/AGENT-FLEET-DEV.md
+++ b/docs/AGENT-FLEET-DEV.md
@@ -1,0 +1,188 @@
+# agent-fleet-dev — fresh install walkthrough
+
+Install agent-fleet from scratch on a new machine or side-by-side with production. Uses **`~/agent-fleet-dev`** as the git checkout name.
+
+Hermes is **optional** (Phase 7). Fleet storage lives under **`~/.agent-fleet/`** only.
+
+---
+
+## Phase 0 — Prerequisites
+
+| Requirement | Check |
+|-------------|--------|
+| Python **3.14** | `python3 --version` |
+| **git** + **gh** | `gh auth status` |
+| **uv** (recommended) | `uv --version` |
+| **Cursor API key** | [dashboard/integrations](https://cursor.com/dashboard/integrations) |
+
+```bash
+export CURSOR_API_KEY="..."
+```
+
+Or copy from an existing fleet `.env` (same key the silphco watcher uses):
+
+```bash
+grep '^CURSOR_API_KEY=' /path/to/existing/.env > ~/agent-fleet-dev/.env
+chmod 600 ~/agent-fleet-dev/.env
+```
+
+Load before runs:
+
+```bash
+set -a && source ~/agent-fleet-dev/.env && set +a
+```
+
+---
+
+## Phase 1 — Clone and install
+
+```bash
+git clone https://github.com/Evan-Kim2028/agent-fleet.git ~/agent-fleet-dev
+cd ~/agent-fleet-dev
+uv sync --frozen --group dev
+```
+
+Verify the CLI points at this checkout:
+
+```bash
+uv run agent-fleet paths
+python3 -c "import agent_fleet; print(agent_fleet.__version__, agent_fleet.__file__)"
+uv run agent-fleet personas
+```
+
+---
+
+## Phase 2 — Global config (`~/.agent-fleet/`)
+
+```bash
+mkdir -p ~/.agent-fleet
+cp ~/agent-fleet-dev/fleet.example.yaml ~/.agent-fleet/fleet.yaml
+```
+
+Minimal edits:
+
+```yaml
+default_backend: cursor
+default_model: composer-2.5-fast
+default_persona: coder
+max_parallel: 5
+```
+
+```bash
+uv run --directory ~/agent-fleet-dev agent-fleet paths
+```
+
+Upgrading an old machine with Hermes-hosted config:
+
+```bash
+uv run --directory ~/agent-fleet-dev agent-fleet migrate-home
+```
+
+---
+
+## Phase 3 — Smoke test
+
+```bash
+set -a && source ~/agent-fleet-dev/.env && set +a
+
+export REPO=/home/evan/Documents/lake-of-rage
+
+uv run --directory ~/agent-fleet-dev agent-fleet run \
+  "Add a trivial smoke test under packages/lakestore/tests/" \
+  --workspace "$REPO" \
+  --persona lakestore \
+  --pipeline simple
+```
+
+Check:
+
+- JSON result with `phases`
+- Log: `~/.agent-fleet/runs/<run-id>.jsonl`
+
+---
+
+## Phase 4 — Repo factory
+
+```bash
+uv run --directory ~/agent-fleet-dev agent-fleet init "$REPO"
+# edit $REPO/.agent-fleet.yaml — scope, verify_commands, level_up
+```
+
+---
+
+## Phase 5 — Background watcher (optional)
+
+```ini
+# ~/.config/systemd/user/agent-fleet-watch.service
+ExecStart=/home/you/.local/bin/uv run --directory /home/you/agent-fleet-dev agent-fleet-watch --workspace %REPO%
+EnvironmentFile=%REPO%/.env
+```
+
+---
+
+## Phase 6 — Hermes (optional interface)
+
+```bash
+cd ~/agent-fleet-dev && ./scripts/deploy-hermes.sh
+```
+
+Hermes gets the **cursor-fleet** plugin only. Config stays in `~/.agent-fleet/fleet.yaml`.
+
+---
+
+## Defaults reference
+
+### Storage (`agent-fleet paths`)
+
+| Path | Purpose |
+|------|---------|
+| `~/.agent-fleet/fleet.yaml` | Global personas, models, pipelines |
+| `~/.agent-fleet/runs/` | Per-dispatch JSONL logs |
+| `~/.agent-fleet/level_up/` | Persona learning (journal, experience, overlays) |
+| `~/.agent-fleet/skills/` | Optional user skill overrides |
+
+### Bundled personas (`fleet.example.yaml`)
+
+| Persona | Role |
+|---------|------|
+| `coder` | Implementer (default) |
+| `reviewer` | Diff review |
+| `pr-analyzer` | Two-pass PR analysis |
+| `explorer` | Read-only exploration |
+| `product-scout` / `tech-scout` | Scout pipeline |
+
+### Pipelines
+
+| Pipeline | Phases |
+|----------|--------|
+| `simple` | execute |
+| `code_review` | execute → review |
+| `full` | plan → research → synthesize → implement → verify → review |
+
+### Default skills (pstack)
+
+Execute loadouts use **[Cursor pstack](https://github.com/cursor/plugins/tree/main/pstack)** skills vendored in `agent_fleet/base-kit/pstack/`:
+
+**Coder:** `pstack/tdd`, verification principles, `principle-never-block-on-the-human`, `principle-guard-the-context-window`, `cursor-team-kit/verify-this`, `pstack/how`, `pstack/figure-it-out`
+
+**Reviewer:** `pstack/interrogate`, `pstack/reflect` · review phase: `pstack/unslop`, `cursor-team-kit/deslop`
+
+**Dynamic (on verify failure):** `pstack/why` appended to execute slots
+
+**Dynamic (when `pr_loop.enabled`):** `cursor-team-kit/fix-ci`, `loop-on-ci`, `get-pr-comments` appended to execute slots
+
+**Base-kit catalog:** full `pstack/`, `superpowers/`, and `cursor-team-kit/` skill trees (sync via `./scripts/sync-base-kit.sh`)
+
+**Superpowers** remain in `base-kit/superpowers/` for optional custom loadouts; not in default loadouts.
+
+Refresh vendored skills: `./scripts/sync-base-kit.sh`
+
+---
+
+## Daily dev loop
+
+```bash
+cd ~/agent-fleet-dev && git pull && uv sync --frozen --group dev
+pytest -q
+systemctl --user restart agent-fleet-watch.service   # if using watcher
+```

--- a/docs/PERSONA-EVOLUTION.md
+++ b/docs/PERSONA-EVOLUTION.md
@@ -26,7 +26,7 @@ agent_fleet/base-kit/
   manifest.yaml                 # pinned upstream SHAs, licenses
   superpowers/                  # vendored skills (sync script)
   pstack/                       # vendored skills
-  cursor-team-kit/deslop/
+  cursor-team-kit/              # vendored PR/CI/verify skills (sync script)
 
 agent_fleet/personas/
   *.loadout.yaml                # human recipes → base-kit skill ids
@@ -102,7 +102,7 @@ persona: coder
 pipeline: code_review
 base_loadout: coder
 skill_slots_execute: [...]      # catalog ids from base-kit
-skill_slots_review: [cursor-team-kit/deslop]
+skill_slots_review: [pstack/unslop, cursor-team-kit/deslop]
 level_up_generation: 2
 parent_run_id: null             # set for decomposed children
 source_weight: 1.0
@@ -146,14 +146,14 @@ Every equip/promote/compact emits structured events to:
 - `~/.agent-fleet/fleet/runs/<run-id>.jsonl` (when `run_id` set)
 - `~/.agent-fleet/level_up/<repo>/<persona>/journal.jsonl`
 
-Event namespaces: `equip.*`, `phase.review.deslop`, `run.complete`, `experience.appended`, `level_up.gate.*`, `level_up.compact.*`.
+Event namespaces: `equip.*`, `phase.review.unslop`, `run.complete`, `experience.appended`, `level_up.gate.*`, `level_up.compact.*`.
 
 ---
 
 ## Pipelines
 
-- **Execute** — persona loadout + overlays; no deslop
-- **Review** — reviewer loadout + **deslop** (`review_skill_slots`)
+- **Execute** — persona loadout (default: **pstack** skills) + overlays; no unslop
+- **Review** — reviewer loadout + **unslop** + **deslop** (`review_skill_slots`)
 
 PR loop, issue dispatch, and CLI all go orchestration equip → dispatcher.
 
@@ -193,7 +193,7 @@ agent-fleet level-up compact --repo NAME --persona coder
 | `agent_fleet/personas.py` | loadout + compose prompt |
 | `agent_fleet/dispatcher.py` | pass equip context |
 | `agent_fleet/dispatcher_task.py` | record experience + journal |
-| `agent_fleet/phases.py` | review deslop skills |
+| `agent_fleet/phases.py` | review unslop + deslop skills |
 | `agent_fleet/tech_lead.py` | skill promotion review (extension) |
 
 No separate “trainer” or “classifier” product terms.

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -1,0 +1,316 @@
+# Skills Integration Buildout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make agent-fleet use the base-kit skill catalog consistently across every agent dispatch path — dispatcher, PR loop, code_review auto-fix, and secondary personas — with curated defaults and situational dynamic equip.
+
+**Architecture:** Introduce a single prompt builder (`agent_fleet/prompts/agent.py`) that layers `resolve_dispatch_equip()` → `compose_body` → task-specific sections. All `backend.run()` call sites that represent a persona doing work must go through it. Loadouts remain human-curated recipes; `equip.py` owns situational skill injection. Work lands as **5 stacked PRs** in isolated worktrees off `main`.
+
+**Tech Stack:** Python 3.14, pytest, existing FleetTask/DispatchEquip, base-kit sync script, git worktrees under `.worktrees/`.
+
+---
+
+## Problem summary (from audit)
+
+| Gap | Impact |
+|-----|--------|
+| PR loop (`lifecycle.py`) hand-rolls prompts | CI/review fix agents miss fix-ci, verify-this, pstack principles |
+| `code_review/fix.py` hand-rolls prompts | auto-fix loop misses equip |
+| Only `coder` + `reviewer` loadouts | pr-analyzer, explorer, scouts run skill-less |
+| v0.7.0 coder loadout duplicated superpowers + pstack | ~30k chars redundant guidance |
+| Review had deslop OR unslop, not both | code vs prose cleanup split wrong |
+| Dynamic equip only on `verify_failed` | pr_loop, worktree, CI-fix contexts ignored |
+| thermo-nuclear in `agent_fleet/skills/` AND base-kit | two ids, drift risk |
+| Large uncommitted WIP on `main` | blocks clean branch stack |
+
+---
+
+## Branch / worktree stack
+
+Work from **`main` @ v0.7.0** (or current `main` after stashing WIP). Each PR merges into the previous branch tip (stack) or rebase onto merged predecessor.
+
+```
+main
+ └── feature/skills-foundation      PR1  (land WIP + sync + loadout curation)
+      └── feature/skills-prompt-builder   PR2  (shared prompt builder)
+           └── feature/skills-pr-loop      PR3  (wire PR loop + code_review fix)
+                └── feature/skills-personas    PR4  (secondary persona loadouts)
+                     └── feature/skills-canonical PR5  (thermo-nuclear + equip polish)
+```
+
+**Worktree commands** (run from repo root):
+
+```bash
+git stash push -u -m "wip skills foundation"
+git worktree add .worktrees/skills-foundation -b feature/skills-foundation main
+# After PR1 merges:
+git worktree add .worktrees/skills-prompt-builder -b feature/skills-prompt-builder main
+# … repeat per branch
+```
+
+Restore stash into `feature/skills-foundation` worktree, not `main`.
+
+---
+
+## PR1: `feature/skills-foundation` — catalog + curated defaults
+
+**Goal:** Ship vendored cursor-team-kit catalog and sane default loadouts; dynamic equip for pr_loop + verify_failed.
+
+### Files
+
+- Modify: `scripts/sync-base-kit.sh` (full cursor-team-kit rsync — **done in WIP**)
+- Modify: `agent_fleet/base-kit/manifest.yaml`, vendored trees
+- Modify: `agent_fleet/personas/coder.loadout.yaml`, `reviewer.loadout.yaml`
+- Modify: `agent_fleet/skills_lib.py` (`PR_LOOP_EXECUTE_SKILLS`, `SYSTEMATIC_DEBUGGING_SKILL = pstack/why`)
+- Modify: `agent_fleet/orchestration/equip.py` (pr_loop dynamic skills — **done in WIP**)
+- Modify: `docs/AGENT-FLEET-DEV.md`, `docs/PERSONA-EVOLUTION.md`
+- Test: `tests/test_loadouts.py`, `tests/test_equip.py`
+
+### Coder execute (final)
+
+```yaml
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
+```
+
+**Remove** all `superpowers/*` from default coder loadout (keep superpowers in catalog for custom loadouts).
+
+### Reviewer review phase (final)
+
+```yaml
+pipeline_skills:
+  code_review:
+    review:
+      - pstack/unslop
+      - cursor-team-kit/deslop
+```
+
+### Dynamic equip rules (equip.py)
+
+| Condition | Skills appended to execute |
+|-----------|---------------------------|
+| `last_experience_shows_verify_failed` | `pstack/why` |
+| `repo.pr_loop.enabled` | `fix-ci`, `loop-on-ci`, `get-pr-comments` |
+
+### Tasks
+
+- [ ] Stash/commit-split WIP: separate unrelated changes (fleet_paths, pr_loop preflight) if needed
+- [ ] Run `./scripts/sync-base-kit.sh`; commit vendored trees + manifest
+- [ ] Apply loadout yaml + skills_lib + equip changes
+- [ ] `pytest tests/test_loadouts.py tests/test_equip.py tests/test_phases_deslop.py -q`
+- [ ] Update docs default skills section
+- [ ] Open PR1
+
+---
+
+## PR2: `feature/skills-prompt-builder` — single prompt assembly
+
+**Goal:** DRY prompt construction so every path can prepend persona+skills consistently.
+
+### Files
+
+- Create: `agent_fleet/prompts/__init__.py`
+- Create: `agent_fleet/prompts/agent.py`
+- Create: `tests/test_prompts_agent.py`
+
+### API
+
+```python
+@dataclass(frozen=True)
+class AgentPrompt:
+    full: str
+    persona_section: str
+    task_section: str
+
+def build_agent_prompt(
+    *,
+    persona_body: str,
+    task_heading: str,
+    task_body: str,
+    context: str = "",
+    extra_sections: list[tuple[str, str]] | None = None,
+) -> AgentPrompt:
+    """Layer persona (skills+stub+overlays) then structured task sections."""
+```
+
+Rules:
+- `persona_body` is always `equip.compose_body` when equip exists, else `read_persona_body(persona)`
+- Task sections use consistent `##` headings (matches phases.py style)
+- `extra_sections` = `[("Review", review_body), ("PR changed files", ...)]`
+
+### Refactor (minimal in PR2 — just extract + test)
+
+- [ ] Implement `build_agent_prompt` with tests
+- [ ] Refactor `phases._build_execute_prompt` to call it (behavior-preserving)
+- [ ] `pytest tests/test_phases_execute_equip.py tests/test_prompts_agent.py -q`
+- [ ] Open PR2
+
+---
+
+## PR3: `feature/skills-pr-loop` — wire equip into fix agents
+
+**Goal:** PR loop and code_review auto-fix use the same skill stack as dispatcher.
+
+### Files
+
+- Modify: `agent_fleet/pr_loop/lifecycle.py` — `address_review_findings`, `attempt_ci_fix`
+- Modify: `agent_fleet/code_review/fix.py` — `run_fix_phase`
+- Modify: `agent_fleet/prompts/agent.py` — optional `equip_context` tag for journal
+- Create: `tests/test_pr_loop_equip.py`
+- Create: `tests/test_code_review_fix_equip.py`
+
+### Pattern (both PR loop functions)
+
+```python
+from agent_fleet.hooks import FleetTask
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
+from agent_fleet.prompts.agent import build_agent_prompt
+
+task = FleetTask(
+    goal=f"Fix PR #{pr_number} review findings",
+    context=f"branch={branch}",
+    persona=fix_persona_name,
+    workspace=str(worktree),
+)
+equip = resolve_dispatch_equip(task, fleet_config, repo, run_id=f"pr-loop-{pr_number}")
+prompt = build_agent_prompt(
+    persona_body=equip.compose_body,
+    task_heading="Task",
+    task_body=...,  # existing review/CI instructions
+    extra_sections=[("Review", review_body), ...],
+).full
+```
+
+Notes:
+- Pass `repo` into equip so pr_loop dynamic skills apply
+- Keep `persona_obj.model/mode/allowed_tools` from resolver
+- CI fix task goal should mention failed checks so verify-this/fix-ci skills activate contextually
+
+### code_review/fix.py
+
+- Accept optional `task.equip` or call `resolve_dispatch_equip` inside fix phase
+- Prepend `equip.compose_body` to fix prompt (same as execute phase)
+
+### Tasks
+
+- [ ] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
+- [ ] Wire lifecycle.py (review fix + CI fix)
+- [ ] Wire code_review/fix.py
+- [ ] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
+- [ ] Manual smoke: `agent-fleet loop` dry path with mock backend if available
+- [ ] Open PR3
+
+---
+
+## PR4: `feature/skills-personas` — loadouts for all bundled personas
+
+**Goal:** Every first-class persona gets a loadout; markdown stubs stay thin.
+
+### New loadouts
+
+| Persona | execute skills | review / notes |
+|---------|----------------|----------------|
+| `pr-analyzer` | `pstack/interrogate`, `pstack/how` | quality pass stays in `pr_review/prompts.py` (thermo-nuclear) |
+| `explorer` | `pstack/how`, `pstack/why` | read-only; mode plan |
+| `tech-scout` | `pstack/how`, `pstack/figure-it-out` | read-only scout |
+| `product-scout` | `pstack/how`, `pstack/reflect` | read-only scout |
+
+Optional: `planner` persona if full pipeline uses one — add `pstack/architect` + `superpowers/brainstorming` only if planner is a distinct persona name in fleet.yaml.
+
+### Files
+
+- Create: `agent_fleet/personas/pr-analyzer.loadout.yaml`, `explorer.loadout.yaml`, etc.
+- Modify: `tests/test_loadouts.py` — parametrize all loadouts resolve
+- Modify: `docs/PERSONAS.md` — loadout table
+
+### Tasks
+
+- [ ] Add loadout yamls + stub references
+- [ ] Test every skill id resolves under base-kit
+- [ ] Open PR4
+
+---
+
+## PR5: `feature/skills-canonical` — dedupe + extended dynamic equip
+
+**Goal:** One canonical thermo-nuclear id; richer situational equip without bloating every dispatch.
+
+### Thermo-nuclear canonical id
+
+- Prefer: `cursor-team-kit/thermo-nuclear-code-quality-review` in base-kit
+- Change `DEFAULT_QUALITY_REVIEW_SKILL` and `agent_fleet/skills/` to re-export or symlink via `resolve_skill_path` search order (bundled dir → base-kit)
+- Delete duplicate `agent_fleet/skills/thermo-nuclear-code-quality-review/SKILL.md` once base-kit resolves
+- Update Hermes copy or point Hermes at base-kit path in deploy script
+
+### Extended dynamic equip (equip.py)
+
+| Condition | Skills |
+|-----------|--------|
+| `repo.use_worktree` or task on worktree branch | `superpowers/using-git-worktrees` (if not in loadout) |
+| task.context contains `ci_fix` or phase is CI fix | `cursor-team-kit/fix-ci` (even without pr_loop) |
+| task.pipeline == `full` && persona == planner | `pstack/architect` (if planner loadout exists) |
+
+Keep guards: skip if already in loadout; skip if `skill_exists_in_base_kit` false.
+
+### Tasks
+
+- [ ] Unify thermo-nuclear resolution + tests in `test_skills_quality.py`
+- [ ] Add dynamic equip conditions + tests
+- [ ] Run full `pytest -q`
+- [ ] Open PR5
+
+---
+
+## Out of scope (v1) — track as follow-ups
+
+- **`poteto-mode` as coder loadout replacement** — needs A/B; defer
+- **Full pipeline phases** (planner/researcher/synthesizer/implementer) — audit after PR3 pattern proven; many already use sessions via runner
+- **Level-up promoting catalog skill ids** — overlay text only today; separate feature
+- **Hermes skill duplication** — trim in deploy script after PR5
+
+---
+
+## Verification gate (every PR)
+
+```bash
+cd /path/to/worktree
+uv sync --frozen --group dev
+pytest -q
+ruff check agent_fleet tests
+ty check agent_fleet  # if configured in CI
+```
+
+PR merges only when CI green. Stack rebase: each new branch rebases onto merged predecessor before merge to main.
+
+---
+
+## Execution order for agents
+
+1. **PR1** — unblocks catalog; land first (includes current WIP)
+2. **PR2** — required before PR3 (shared builder)
+3. **PR3** — highest user-visible fix (PR loop)
+4. **PR4** — parallelizable after PR1 if PR2/3 in flight
+5. **PR5** — cleanup after PR1–4 merged
+
+Estimated: **PR1 ~2h, PR2 ~1h, PR3 ~3h, PR4 ~1.5h, PR5 ~2h** (agent time, parallelizable PR4).
+
+---
+
+## Success criteria
+
+- [ ] PR loop fix prompts include composed skill text (grep test for skill headings)
+- [ ] Coder loadout has no superpowers/pstack duplication
+- [ ] Reviewer review phase runs unslop + deslop
+- [ ] All bundled personas have loadouts; all ids resolve
+- [ ] thermo-nuclear single canonical path
+- [ ] `pytest -q` green on main after full stack merges

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -203,10 +203,10 @@ Notes:
 
 ### Tasks
 
-- [ ] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
-- [ ] Wire lifecycle.py (review fix + CI fix)
-- [ ] Wire code_review/fix.py
-- [ ] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
+- [x] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
+- [x] Wire lifecycle.py (review fix + CI fix)
+- [x] Wire code_review/fix.py
+- [x] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
 - [ ] Manual smoke: `agent-fleet loop` dry path with mock backend if available
 - [ ] Open PR3
 

--- a/scripts/sync-base-kit.sh
+++ b/scripts/sync-base-kit.sh
@@ -39,20 +39,21 @@ sync_pstack() {
   printf '%s' "$sha"
 }
 
-sync_deslop() {
-  log "Syncing cursor-team-kit deslop"
-  local repo_dir="$TMP/plugins-deslop"
+sync_cursor_team_kit() {
+  log "Syncing cursor/plugins cursor-team-kit → base-kit/cursor-team-kit/"
+  local repo_dir="$TMP/plugins-ctk"
   local sha
   sha="$(clone_sha cursor/plugins "$repo_dir")"
-  mkdir -p "$BASE/cursor-team-kit/deslop"
-  cp "$repo_dir/cursor-team-kit/skills/deslop/SKILL.md" "$BASE/cursor-team-kit/deslop/SKILL.md"
+  rm -rf "$BASE/cursor-team-kit"
+  mkdir -p "$BASE/cursor-team-kit"
+  rsync -a --delete "$repo_dir/cursor-team-kit/skills/" "$BASE/cursor-team-kit/"
   printf '%s' "$sha"
 }
 
 write_manifest() {
   local super_sha="$1"
   local pstack_sha="$2"
-  local deslop_sha="$3"
+  local ctk_sha="$3"
   cat >"$MANIFEST" <<EOF
 schema_version: 1
 synced_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -65,9 +66,9 @@ sources:
     upstream: https://github.com/cursor/plugins/tree/main/pstack
     ref: ${pstack_sha}
     license: MIT
-  deslop:
-    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills/deslop
-    ref: ${deslop_sha}
+  cursor-team-kit:
+    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills
+    ref: ${ctk_sha}
     license: MIT
 EOF
   log "Wrote $MANIFEST"
@@ -78,9 +79,9 @@ main() {
   command -v rsync >/dev/null
   super_sha="$(sync_superpowers)"
   pstack_sha="$(sync_pstack)"
-  deslop_sha="$(sync_deslop)"
-  write_manifest "$super_sha" "$pstack_sha" "$deslop_sha"
-  log "Done. superpowers=${super_sha:0:12} pstack=${pstack_sha:0:12}"
+  ctk_sha="$(sync_cursor_team_kit)"
+  write_manifest "$super_sha" "$pstack_sha" "$ctk_sha"
+  log "Done. superpowers=${super_sha:0:12} pstack=${pstack_sha:0:12} cursor-team-kit=${ctk_sha:0:12}"
 }
 
 main "$@"

--- a/scripts/verify_learning_flywheel.py
+++ b/scripts/verify_learning_flywheel.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Verification for the self-improving flywheel.
+
+**LESS IS MORE:** This file is intentionally minimal.
+
+Instead of a custom harness, **always use the existing superpowers skill**:
+
+    superpowers:verification-before-completion
+
+When you (or any agent) want to verify a learning cycle or claim the flywheel is working:
+
+1. Read the skill: agent_fleet/base-kit/superpowers/verification-before-completion/SKILL.md
+2. Follow its Iron Law: No completion claims without fresh verification evidence.
+3. Use it to check synthesis logs in ~/.agent-fleet/learning/synthesis_logs/
+4. Use it before claiming "the flywheel works".
+
+The actual implementation lives in:
+- The `fleet-learner` persona (see personas/fleet-learner.md)
+- The dispatcher trigger (see learning/ and how it calls into level_up)
+- Existing level_up machinery for gating/promotion
+
+Run learning cycles with:
+    agent-fleet learn
+
+Then apply verification-before-completion before making any claims about results.
+
+See also:
+- superpowers:systematic-debugging (when the flywheel isn't behaving)
+- superpowers:writing-skills (when improving the fleet-learner persona)
+- superpowers:subagent-driven-development (recommended pattern for the meta-learning loop itself)
+"""
+
+from __future__ import annotations
+
+import sys
+
+# This script now exists only as a pointer to the proper skills.
+# The previous custom implementation has been removed in favor of using
+# the vendored Cursor superpowers skills (less is more).
+
+
+def main() -> int:
+    print("This verification script has been reduced per 'less is more'.")
+    print("Read: agent_fleet/base-kit/superpowers/verification-before-completion/SKILL.md")
+    print("Then run: agent-fleet learn")
+    print("Apply the skill before claiming any results about the flywheel.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_code_review_fix_equip.py
+++ b/tests/test_code_review_fix_equip.py
@@ -1,0 +1,183 @@
+# ruff: noqa: TC002
+"""Code review auto-fix phase uses dispatch equip compose body."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_fleet.code_review.fix import run_fix_phase
+from agent_fleet.config import load_fleet_config
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.hooks import FleetTask
+from agent_fleet.level_up.models import DispatchEquip
+from agent_fleet.level_up.paths import persona_dir
+from agent_fleet.personas import YamlPersonaResolver
+from agent_fleet.repo import load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        timeout_s: int,
+        memory_limit: str = "4G",
+        allowed_tools: list[str] | None = None,
+        cwd: Path | None = None,
+        model: str | None = None,
+        mode: object | None = None,
+    ) -> CursorLLMResult:
+        del max_tokens, timeout_s, memory_limit, allowed_tools, cwd, model, mode
+        self.prompts.append(prompt)
+        return CursorLLMResult(
+            stdout="fixed",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+            agent_id="fix-agent",
+        )
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+def test_fix_phase_uses_task_equip_fast_path(
+    tmp_path: Path,
+) -> None:
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    equip = DispatchEquip(
+        persona="coder",
+        base_loadout="coder",
+        skill_slots_execute=("pstack/tdd",),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="# Equip compose\n\nTDD Bug Fix",
+    )
+    task = FleetTask(
+        goal="Implement widget",
+        context="",
+        persona="coder",
+        workspace=str(tmp_path),
+        equip=equip,
+    )
+
+    run_fix_phase(
+        backend=backend,
+        resolver=resolver,
+        task=task,
+        workspace=tmp_path,
+        timeout_s=60,
+        phase_results=[{"phase": "review", "verdict": "request_changes"}],
+        repo=None,
+        fix_persona="coder",
+        attempt=1,
+    )
+
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "TDD Bug Fix" in prompt
+    assert "# Review feedback" in prompt
+    assert "# Verify failures\n(none)" in prompt
+
+
+def test_fix_phase_resolves_equip_when_fix_persona_differs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: fix-persona-mismatch\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    execute_equip = DispatchEquip(
+        persona="coder",
+        base_loadout="coder",
+        skill_slots_execute=("pstack/tdd",),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="# Execute equip\n\nExecute-only body",
+        parent_run_id="parent-run-1",
+    )
+    task = FleetTask(
+        goal="Implement widget",
+        context="ctx",
+        persona="coder",
+        workspace=str(tmp_path),
+        equip=execute_equip,
+    )
+
+    run_fix_phase(
+        backend=backend,
+        resolver=resolver,
+        task=task,
+        workspace=tmp_path,
+        timeout_s=60,
+        phase_results=[],
+        repo=repo,
+        fix_persona="reviewer",
+        attempt=2,
+    )
+
+    prompt = backend.prompts[0]
+    assert "Execute-only body" not in prompt
+    assert "# Persona" in prompt
+    assert "# Review feedback\n(none)" in prompt
+    assert "# Verify failures\n(none)" in prompt
+
+    journal_path = persona_dir("fix-persona-mismatch", "reviewer") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "parent-run-1-fix-2" for row in rows)
+
+
+def test_fix_phase_journals_run_id_without_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: fix-run-id\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    task = FleetTask(goal="Fix tests", persona="coder", workspace=str(tmp_path))
+
+    with patch("agent_fleet.code_review.fix.resolve_dispatch_equip") as mock_resolve:
+        mock_resolve.return_value = DispatchEquip(
+            persona="coder",
+            base_loadout="coder",
+            skill_slots_execute=(),
+            skill_slots_review=(),
+            level_up_generation=0,
+            compose_body="Coder body",
+        )
+        run_fix_phase(
+            backend=backend,
+            resolver=resolver,
+            task=task,
+            workspace=tmp_path,
+            timeout_s=60,
+            phase_results=[],
+            repo=repo,
+            fix_persona="reviewer",
+            attempt=3,
+        )
+
+    mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.kwargs["run_id"] == "code-review-fix-3"

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -18,6 +18,7 @@ from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.repo import load_repo_config
 from agent_fleet.skills_lib import (
+    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
     load_loadout,
     loadout_execute_skill_ids,
@@ -33,7 +34,7 @@ def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
 def test_load_coder_loadout() -> None:
     loadout = load_loadout("coder")
     execute = loadout_execute_skill_ids(loadout)
-    assert "superpowers/test-driven-development" in execute
+    assert "pstack/tdd" in execute
 
 
 def test_resolve_dispatch_equip_baseline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -50,9 +51,9 @@ def test_resolve_dispatch_equip_baseline(tmp_path: Path, monkeypatch: pytest.Mon
     assert isinstance(equip, DispatchEquip)
     assert equip.persona == "coder"
     assert equip.base_loadout == "coder"
-    assert "superpowers/test-driven-development" in equip.skill_slots_execute
+    assert "pstack/tdd" in equip.skill_slots_execute
     assert equip.parent_run_id is None
-    assert "Test-Driven Development" in equip.compose_body
+    assert "TDD Bug Fix" in equip.compose_body
 
     journal_path = persona_dir("equip-demo", "coder") / "journal.jsonl"
     assert journal_path.is_file()
@@ -83,7 +84,7 @@ def test_verify_failed_adds_systematic_debugging(
     equip = resolve_dispatch_equip(task, fleet_config, repo)
 
     assert SYSTEMATIC_DEBUGGING_SKILL in equip.skill_slots_execute
-    assert "Systematic Debugging" in equip.compose_body
+    assert "# Why" in equip.compose_body
 
 
 def test_verify_failed_skips_missing_base_kit_skill(
@@ -109,6 +110,23 @@ def test_verify_failed_skips_missing_base_kit_skill(
     equip = resolve_dispatch_equip(task, fleet_config, repo)
 
     assert SYSTEMATIC_DEBUGGING_SKILL not in equip.skill_slots_execute
+
+
+def test_pr_loop_adds_ci_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        "name: pr-loop-repo\npr_loop:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task = FleetTask(goal="Fix CI", persona="coder", workspace=str(tmp_path))
+    equip = resolve_dispatch_equip(task, fleet_config, repo)
+
+    for skill_id in PR_LOOP_EXECUTE_SKILLS:
+        assert skill_id in equip.skill_slots_execute
 
 
 def test_child_tasks_carry_parent_run_id() -> None:

--- a/tests/test_loadouts.py
+++ b/tests/test_loadouts.py
@@ -15,21 +15,21 @@ from agent_fleet.skills_lib import (
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def test_deslop_loads_from_base_kit() -> None:
+def test_unslop_loads_from_base_kit() -> None:
     dirs = base_kit_skill_dirs()
     assert dirs
-    path = resolve_skill_path("cursor-team-kit/deslop", dirs)
+    path = resolve_skill_path("pstack/unslop", dirs)
     assert path is not None
     assert path.name == "SKILL.md"
-    text = load_skill_text("cursor-team-kit/deslop", dirs)
-    assert "Remove AI code slop" in text
+    text = load_skill_text("pstack/unslop", dirs)
+    assert "slop" in text.lower()
 
 
-def test_reviewer_loadout_lists_deslop_for_review() -> None:
+def test_reviewer_loadout_lists_unslop_for_review() -> None:
     loadout = load_loadout("reviewer")
     assert loadout is not None
     review_skills = loadout["pipeline_skills"]["code_review"]["review"]
-    assert review_skills == ["cursor-team-kit/deslop"]
+    assert review_skills == ["pstack/unslop", "cursor-team-kit/deslop"]
 
 
 def test_compose_persona_body_includes_sections() -> None:

--- a/tests/test_phases_deslop.py
+++ b/tests/test_phases_deslop.py
@@ -68,7 +68,7 @@ def test_structured_review_appends_deslop_skill_from_equip(
         persona="reviewer",
         base_loadout="reviewer",
         skill_slots_execute=(),
-        skill_slots_review=("cursor-team-kit/deslop",),
+        skill_slots_review=("pstack/unslop", "cursor-team-kit/deslop"),
         level_up_generation=0,
     )
     task = FleetTask(
@@ -91,7 +91,7 @@ def test_structured_review_appends_deslop_skill_from_equip(
     assert len(backend.prompts) == 1
     prompt = backend.prompts[0]
     assert "# Review Skills" in prompt
-    assert "Remove AI code slop" in prompt
+    assert "Unslop" in prompt
 
 
 def test_legacy_review_appends_deslop_skill_from_equip(
@@ -105,7 +105,7 @@ def test_legacy_review_appends_deslop_skill_from_equip(
         persona="reviewer",
         base_loadout="reviewer",
         skill_slots_execute=(),
-        skill_slots_review=("cursor-team-kit/deslop",),
+        skill_slots_review=("pstack/unslop", "cursor-team-kit/deslop"),
         level_up_generation=0,
     )
     task = FleetTask(goal="Review slop", persona="coder", equip=equip)
@@ -129,4 +129,4 @@ def test_legacy_review_appends_deslop_skill_from_equip(
     assert len(backend.prompts) == 1
     prompt = backend.prompts[0]
     assert "# Review Skills" in prompt
-    assert "Remove AI code slop" in prompt
+    assert "Unslop" in prompt

--- a/tests/test_phases_execute_equip.py
+++ b/tests/test_phases_execute_equip.py
@@ -32,3 +32,31 @@ def test_execute_prompt_prefers_equip_compose_body() -> None:
     assert "Static persona body from resolver." not in prompt
     assert "Systematic Debugging" in prompt
     assert "Fix failing test" in prompt
+
+
+def test_execute_prompt_includes_persona_modifiers_and_closing() -> None:
+    persona = Persona(
+        name="coder",
+        prompt_path=Path("coder.md"),
+        allowed_tools=[],
+        capabilities={},
+        body="Coder body.",
+        allowed_paths=("src/",),
+        extra_instructions="Prefer small diffs.",
+    )
+    task = FleetTask(
+        goal="Implement feature",
+        context="See design doc.",
+        persona="coder",
+    )
+
+    prompt = _build_execute_prompt(persona, task)
+
+    assert prompt.index("# Persona") < prompt.index("# Additional Instructions")
+    assert prompt.index("# Additional Instructions") < prompt.index("# Scope:")
+    assert prompt.index("# Scope:") < prompt.index("# Task")
+    assert prompt.index("# Task") < prompt.index("# Context")
+    assert prompt.index("# Context") < prompt.index("Execute this task in the workspace")
+    assert "Prefer small diffs." in prompt
+    assert "only modify paths matching: src/" in prompt
+    assert "See design doc." in prompt

--- a/tests/test_pr_loop_equip.py
+++ b/tests/test_pr_loop_equip.py
@@ -1,0 +1,198 @@
+"""PR loop fix agents include dispatch equip compose body."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.pr_loop.config import PrLoopConfig
+from agent_fleet.pr_loop.lifecycle import address_review_findings, attempt_ci_fix
+from agent_fleet.repo import RepoConfig, load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        timeout_s: int,
+        memory_limit: str = "4G",
+        allowed_tools: list[str] | None = None,
+        cwd: Path | None = None,
+        model: str | None = None,
+        mode: object | None = None,
+    ) -> CursorLLMResult:
+        del max_tokens, timeout_s, memory_limit, allowed_tools, cwd, model, mode
+        self.prompts.append(prompt)
+        return CursorLLMResult(
+            stdout="done",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+            agent_id="fix-agent",
+        )
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+def _pr_loop_repo(tmp_path: Path) -> RepoConfig:
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        "name: pr-loop-equip\npr_loop:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    return load_repo_config(repo_yaml)
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    return wt
+
+
+def test_review_fix_prompt_includes_fix_ci_skill(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+    review_body = "**Risk Level:** MEDIUM\n<details><summary>MEDIUM</summary>"
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.has_blocking_findings",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_diff",
+            return_value="+added",
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_changed_files",
+            return_value=["src/a.py"],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        result = address_review_findings(
+            pr_number=42,
+            branch="fleet/coder/42-abc",
+            review_body=review_body,
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+        )
+
+    assert result.status == "no_changes"
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "# Persona" in prompt
+    assert "# Fix CI" in prompt
+    assert "# Review" in prompt
+    assert review_body in prompt
+    assert "- (none)" in prompt
+
+
+def test_ci_fix_prompt_includes_fix_ci_skill(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        result = attempt_ci_fix(
+            pr_number=7,
+            branch="fleet/coder/7-def",
+            failed_checks=["pytest"],
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+            persona="coder",
+        )
+
+    assert not result.ok
+    assert result.phase == "no_changes"
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "# Fix CI" in prompt
+    assert "Failed checks: pytest" in prompt
+    assert "- (none)" in prompt
+
+
+def test_review_fix_journals_equip_with_run_id(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_fleet.level_up.paths import persona_dir
+
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.has_blocking_findings",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_diff",
+            return_value="+added",
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_changed_files",
+            return_value=["src/a.py"],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        address_review_findings(
+            pr_number=99,
+            branch="fleet/coder/99-xyz",
+            review_body="blocking finding",
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+        )
+
+    journal_path = persona_dir("pr-loop-equip", "coder") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "pr-loop-99" for row in rows)

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -1,0 +1,51 @@
+"""Tests for shared agent prompt assembly."""
+
+from __future__ import annotations
+
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+
+
+def test_build_agent_prompt_minimal() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+    )
+
+    assert isinstance(result, AgentPrompt)
+    assert result.persona_section == "# Persona\nYou are a coder."
+    assert "# Task\nFix the bug." in result.full
+    assert result.full == result.persona_section + result.task_section
+    assert "# Context" not in result.full
+
+
+def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
+    result = build_agent_prompt(
+        persona_body="Reviewer persona.",
+        task_heading="Original Task",
+        task_body="Ship the feature.",
+        context="branch=main",
+        extra_sections=[
+            ("Additional Instructions", "Be thorough."),
+            ("Scope: only modify paths matching: src/", ""),
+        ],
+    )
+
+    assert "# Additional Instructions\nBe thorough." in result.full
+    assert "# Scope: only modify paths matching: src/" in result.full
+    assert "# Context\nbranch=main" in result.full
+    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
+    assert result.full.index("# Original Task") < result.full.index("# Context")
+
+
+def test_build_agent_prompt_strips_whitespace() -> None:
+    result = build_agent_prompt(
+        persona_body="  persona  ",
+        task_heading="Task",
+        task_body="  goal  ",
+        context="  ctx  ",
+    )
+
+    assert result.persona_section == "# Persona\npersona"
+    assert "# Task\ngoal" in result.full
+    assert "# Context\nctx" in result.full

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+from agent_fleet.prompts.agent import build_agent_prompt
 
 
 def test_build_agent_prompt_minimal() -> None:
@@ -12,40 +12,64 @@ def test_build_agent_prompt_minimal() -> None:
         task_body="Fix the bug.",
     )
 
-    assert isinstance(result, AgentPrompt)
     assert result.persona_section == "# Persona\nYou are a coder."
-    assert "# Task\nFix the bug." in result.full
-    assert result.full == result.persona_section + result.task_section
-    assert "# Context" not in result.full
+    assert result.task_section == "\n# Task\nFix the bug."
+    assert result.full == "# Persona\nYou are a coder.\n# Task\nFix the bug."
 
 
-def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
+def test_build_agent_prompt_includes_context_and_closing() -> None:
+    closing = (
+        "Execute this task in the workspace. Return a concise summary of what you "
+        "did, files changed, and any follow-up needed."
+    )
     result = build_agent_prompt(
-        persona_body="Reviewer persona.",
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        context="See auth.py",
+        closing_instruction=closing,
+    )
+
+    assert "# Context\nSee auth.py" in result.full
+    assert result.full.endswith(closing)
+    assert "# Task\nFix the bug." in result.task_section
+
+
+def test_build_agent_prompt_includes_persona_extras() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        extra_instructions="Prefer small diffs.",
+        allowed_paths=("src/**", "tests/**"),
+    )
+
+    assert "# Additional Instructions\nPrefer small diffs." in result.persona_section
+    assert "# Scope: only modify paths matching: src/**, tests/**" in result.persona_section
+
+
+def test_build_agent_prompt_supports_extra_sections() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a reviewer.",
         task_heading="Original Task",
-        task_body="Ship the feature.",
-        context="branch=main",
+        task_body="Add logging.",
         extra_sections=[
-            ("Additional Instructions", "Be thorough."),
-            ("Scope: only modify paths matching: src/", ""),
+            ("Implementation Summary", "Added structured logs."),
+            ("Review", "Check for PII in logs."),
         ],
     )
 
-    assert "# Additional Instructions\nBe thorough." in result.full
-    assert "# Scope: only modify paths matching: src/" in result.full
-    assert "# Context\nbranch=main" in result.full
-    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
-    assert result.full.index("# Original Task") < result.full.index("# Context")
+    assert "# Implementation Summary\nAdded structured logs." in result.full
+    assert "# Review\nCheck for PII in logs." in result.full
 
 
-def test_build_agent_prompt_strips_whitespace() -> None:
+def test_build_agent_prompt_skips_blank_extra_sections() -> None:
     result = build_agent_prompt(
-        persona_body="  persona  ",
+        persona_body="You are a reviewer.",
         task_heading="Task",
-        task_body="  goal  ",
-        context="  ctx  ",
+        task_body="Review changes.",
+        extra_sections=[("Review", "   "), ("Notes", "Keep it concise.")],
     )
 
-    assert result.persona_section == "# Persona\npersona"
-    assert "# Task\ngoal" in result.full
-    assert "# Context\nctx" in result.full
+    assert "# Review" not in result.full
+    assert "# Notes\nKeep it concise." in result.full

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "agent-fleet"
-version = "0.6.4"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cursor-sdk" },


### PR DESCRIPTION
## Summary

This PR introduces the foundation for a self-improving flywheel in Agent Fleet.

### Changes
- New `agent_fleet/learning/` module:
  - Cross-repo experience aggregation from the central `~/.agent-fleet/` store
  - `synthesize_fleet_skills()` and `trigger_fleet_learning_cycle()` entry points
  - LLM synthesis stub in `llm_synthesis.py`
- New `fleet-learner` persona (with loadout) designed to analyze fleet experience and propose global skill improvements
- New `agent-fleet learn` CLI command to manually trigger synthesis into the `_fleet` tier
- The architecture allows the dispatcher/orchestrator to drive skill updates autonomously

### Motivation
The existing `level_up` system has excellent gating and injection infrastructure, but skill proposal was limited to a handful of hardcoded patterns. This PR makes the *orchestrator itself* capable of improving the fleet's skills over time, using the central `~/.agent-fleet/` directory as the single source of truth across all repositories.

### Next Steps (not in this PR)
- Wire automatic triggers from the dispatcher after significant runs
- Implement real LLM-driven inductive synthesis
- Add evaluation of promoted skills

This is the first concrete step toward the "experience building, not just memory" vision discussed in the design.

## Test Plan
- `uv run ruff check` passes on changed files
- Relevant tests (`pytest -k "equip or level_up or fleet or personas"`) pass
- New CLI command `agent-fleet learn --help` works

## Related
See previous discussion on building the self-improving flywheel.