### PR TITLE
feat(skills): unify equip resolution and loadout defaults

### DIFF
--- a/.agent-fleet.yaml
+++ b/.agent-fleet.yaml
@@ -1,0 +1,111 @@
+# agent_fleet — self-dogfood config for v0.5.0 implementation plan
+# Scoped narrowly to the files the [FLEET] tasks in
+# docs/superpowers/plans/2026-05-23-mcp-sessions-redispatch.md may touch.
+#
+# IMPORTANT: dispatch runs against a *pinned* agent_fleet at v0.4.2 installed at
+# /home/evan/.local/share/agent-fleet-dispatch/.venv. That venv's `agent-fleet`
+# binary is the only one that should be used for fleet runs on this repo while
+# the v0.5.0 implementation is in flight — otherwise edits to dispatcher code
+# bleed back into the dispatcher mid-run. See blocker #4 in the chat log.
+
+name: agent-fleet
+default_persona: coder
+default_branch: main
+use_worktree: true
+worktree_base: /tmp/agent-fleet-worktrees
+
+# Tests + lint after every IMPLEMENT phase. uv runs them inside the repo's own
+# editable install (which is fine — they exercise *changed* code in the worktree,
+# they don't import the running dispatcher).
+test_command: uv run pytest -q
+# Scope ruff to *.py files this branch added/modified vs main so pre-existing
+# tech debt in unrelated files doesn't fail every dispatch. The repo still has
+# 17 pre-existing ruff errors as of v0.4.2 — clean them up in a separate PR.
+lint_command: bash -c "git diff --name-only main HEAD -- '*.py' | xargs -r uv run ruff check"
+
+# Per-persona scope. Each task tags itself [FLEET] or [MANUAL] in the plan; only
+# the [FLEET] tasks dispatch here, and they only edit the paths below.
+persona_scope_allowlist:
+  coder:
+    - agent_fleet/contracts/
+    - agent_fleet/sessions.py
+    - agent_fleet/redispatch.py
+    - agent_fleet/config.py
+    - agent_fleet/orchestration/
+    - agent_fleet/implementer.py
+    - agent_fleet/skills_lib.py
+    - agent_fleet/personas/
+    - tests/
+    - docs/
+    - fleet.example.yaml
+    - examples/
+    - README.md
+  reviewer:
+    - agent_fleet/
+    - tests/
+    - docs/
+
+# Block multi-area changes — if a plan task spans these groups the planner
+# decomposes it. Keeps each FLEET dispatch surgical.
+cross_cutting_groups:
+  - [agent_fleet/dispatcher.py, agent_fleet/runner.py]
+  - [agent_fleet/cursor_backend.py, agent_fleet/sessions.py]
+
+# The fleet must NOT edit its own dispatch core or runner during a self-dogfood
+# run — those are the bootstrap-trap files. Tasks that need to touch them are
+# tagged [MANUAL] in the plan and executed via subagents in worktrees instead.
+critical_path_prefixes:
+  - agent_fleet/runner.py
+  - agent_fleet/cursor_backend.py
+  - agent_fleet/dispatcher.py
+  - agent_fleet/phases.py
+  - agent_fleet/hooks.py
+  - agent_fleet/cli.py
+  - .github/workflows/
+  - pyproject.toml
+  - uv.lock
+
+# Managed targets — fleet config lives here, not on silphco.
+targets:
+  - config: targets/silphcoanalytics.agent-fleet.yaml
+
+schedules:
+  enabled: true
+  poll_interval_s: 60
+  jobs:
+    - id: silphco-docs-daily
+      enabled: true
+      cron: "0 6 * * *"
+      timezone: America/New_York
+      dispatch:
+        workspace: /home/evan/Documents/silphcoanalytics
+        kind: task
+        goal: "Documentation drift audit — compare code changes in the last 24 hours against docs"
+        persona: security_qa
+        pipeline: simple
+        context: |
+          Analyze only. Compare git log/diff on main since 24 hours ago against documentation.
+          Focus: docs/, frontend/docs/, api/DEPRECATIONS.md, README files, docs/ops/, AGENTS.md.
+          Report: (1) code changes lacking docs, (2) stale or wrong docs, (3) prioritized fix list.
+          Do not edit files in this pass unless you find a one-line factual error; prefer a report.
+      policy:
+        skip_if_in_flight: true
+        missed: skip
+        min_interval_s: 82800
+
+    # Fast iteration override (disabled by default):
+    # - id: silphco-docs-dev
+    #   enabled: true
+    #   cron: "*/2 * * * *"
+    #   timezone: UTC
+    #   dispatch:
+    #     workspace: /home/evan/Documents/silphcoanalytics
+    #     kind: task
+    #     goal: "Schedule smoke test on silphco"
+    #     persona: security_qa
+    #     pipeline: simple
+    #     context: "Reply SCHEDULE_OK after confirming docs/SCHEDULES.md is absent from silphco (expected)."
+    #   policy:
+    #     skip_if_in_flight: true
+    #     missed: skip
+    #     min_interval_s: 90

--- a/agent_fleet/base-kit/cursor-team-kit/fix-ci/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/fix-ci/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: fix-ci
+description: Find failing PR checks, inspect logs or external check links, and apply focused fixes
+---
+
+# Fix CI
+
+## Trigger
+
+Branch or PR CI is failing and needs a fast, iterative path to green checks.
+
+## Workflow
+
+1. Resolve the active PR and inspect `gh pr checks --json name,bucket,state,workflow,link`.
+2. Inspect failed jobs and extract the first actionable error. Use GitHub Actions logs when available; otherwise use the check link to identify the failing command or service.
+3. Apply the smallest safe fix.
+4. Push, re-check the PR check set, and repeat until green.
+
+## Guardrails
+
+- Fix one actionable failure at a time.
+- Prefer minimal, low-risk changes before broader refactors.
+- Keep `gh pr checks` as the source of truth for overall PR CI state.
+
+## Output
+
+- Primary failing job and root error
+- Fixes applied in iteration order
+- Current CI status and next action

--- a/agent_fleet/base-kit/cursor-team-kit/get-pr-comments/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/get-pr-comments/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: get-pr-comments
+description: Fetch and summarize review comments from the active pull request
+---
+
+# Get PR comments
+
+## Trigger
+
+Need a concise, actionable summary of feedback on the active pull request.
+
+## Workflow
+
+1. Resolve the active PR for the current branch.
+2. Fetch review comments and discussion comments.
+3. Group feedback by severity and actionability.
+4. Return a concise action list.
+
+## Output
+
+- Grouped feedback summary
+- Action list ordered by priority
+- Open questions that still need clarification

--- a/agent_fleet/base-kit/cursor-team-kit/loop-on-ci/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/loop-on-ci/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: loop-on-ci
+description: Monitor PR checks and fix failures until green. Uses gh pr checks as the source of truth for PR-attached checks.
+---
+
+# Loop on CI
+
+## Trigger
+
+Need to watch a branch or pull request and iterate on CI failures until all required checks are green.
+
+Use `gh pr checks` as the source of truth. It includes all PR-attached checks, while `gh run list` only covers GitHub Actions.
+
+## Workflow
+
+1. Resolve the PR for the current branch.
+2. Inspect current PR checks before waiting.
+3. If checks already failed, diagnose those failures first.
+4. If checks are pending, watch with `gh pr checks --watch --fail-fast`.
+5. After each push, re-check the full PR check set and repeat until green.
+
+## Commands
+
+```bash
+# Resolve the active PR
+gh pr view --json number,url,headRefName
+
+# Inspect all attached checks
+gh pr checks --json name,bucket,state,workflow,link
+
+# Watch pending checks and fail fast
+gh pr checks --watch --fail-fast
+
+# GitHub Actions logs, when the failing check links to a GHA run
+gh run view <run-id> --log-failed
+```
+
+## Guardrails
+
+- Keep each fix scoped to a single failure cause when possible.
+- Do not bypass hooks (`--no-verify`) to force progress.
+- If the failure is clearly unrelated to the PR and appears fixed on main, merge latest main instead of bloating the PR with unrelated fixes.
+- If failures are flaky, retry once and report flake evidence.
+- Re-run `gh pr checks --json name,bucket,state,workflow,link` after every push; the check set can change.
+
+## Output
+
+- Current CI status
+- Failure summary and fixes applied
+- PR URL once checks are green

--- a/agent_fleet/base-kit/cursor-team-kit/verify-this/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/verify-this/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: verify-this
+description: Verify a claim with fresh local evidence: restate it falsifiably, capture baseline and treatment, compare artifacts, and return VERIFIED, NOT VERIFIED, or INCONCLUSIVE.
+---
+
+# Verify This
+
+Verification is not a recap. It proves or disproves a specific claim with repeatable evidence.
+
+## When To Use
+
+- The user asks "verify this", "prove it works", "did this fix it", or "show me the evidence".
+- A bug fix needs a before/after repro.
+- A UI, CLI, API, performance, or memory claim needs measurement.
+- A test passes but the user-visible behavior still needs confirmation.
+
+Do not use this for vague claims like "the code is cleaner". Ask for a measurable claim first.
+
+## Workflow
+
+1. Restate the claim in falsifiable form: condition, metric, and threshold.
+2. Pick the smallest local surface that can disprove it.
+3. Capture a baseline from the old state: merge base, parent commit, failing branch, or current broken repro.
+4. Capture treatment from the changed state with the same command, data, warmup, and environment.
+5. Compare raw artifacts: numbers, screenshots, terminal transcripts, HTTP responses, profiles, heap snapshots, or test output.
+6. Return exactly one verdict: `VERIFIED`, `NOT VERIFIED`, or `INCONCLUSIVE`.
+
+## Local Surfaces
+
+- Code behavior: focused unit/integration tests or a minimal repro script.
+- CLI/TUI behavior: `control-cli`, terminal transcript, or demo recording.
+- UI behavior: `control-ui`, screenshots, accessibility snapshots, or browser traces.
+- API behavior: local HTTP/RPC request and response diff.
+- Performance: same-machine baseline/treatment timings or CPU profiles.
+- Memory: heap snapshots before and after the suspected operation.
+
+## Artifact Layout
+
+When safe to write artifacts:
+
+```text
+/tmp/verify-this/<claim-slug>/
+├── claim.md
+├── timeline.md
+├── baseline/
+├── treatment/
+├── diff/
+└── verdict.md
+```
+
+If artifacts may contain sensitive code, prompts, screenshots, HTTP bodies, or heap data, keep only the minimal inline evidence unless the user agrees to disk storage.
+
+## Verdict Rules
+
+- `VERIFIED`: baseline and treatment differ in the predicted direction, by the claimed threshold, with no obvious confound.
+- `NOT VERIFIED`: the behavior is unchanged, moves the wrong way, or misses the threshold.
+- `INCONCLUSIVE`: no valid baseline, noisy signal, failed measurement, or an environment difference invalidates the comparison.
+
+## Output
+
+Use this shape:
+
+```text
+VERIFIED | NOT VERIFIED | INCONCLUSIVE
+Claim: <falsifiable claim>
+
+Evidence:
+<metric/artifact>: baseline=<...>, treatment=<...>, delta=<...>, threshold=<...>
+
+Reasoning:
+<one tight paragraph naming the evidence and any confounds>
+```
+
+Do not soften a negative result. A clear `NOT VERIFIED` is useful.

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agent_fleet.level_up.compaction import touch_overlay_rules
 from agent_fleet.level_up.experience import last_experience_shows_verify_failed
@@ -11,11 +11,14 @@ from agent_fleet.level_up.models import DispatchEquip
 from agent_fleet.level_up.overlay import compose_overlay_text, load_overlay
 from agent_fleet.level_up.paths import FLEET_TIER, repo_key
 from agent_fleet.skills_lib import (
+    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
+    base_kit_skill_dirs,
     compose_persona_body,
     load_loadout,
     loadout_execute_skill_ids,
     loadout_review_skill_ids,
+    merge_skill_dirs,
     skill_exists_in_base_kit,
 )
 
@@ -25,17 +28,30 @@ if TYPE_CHECKING:
     from agent_fleet.repo import RepoConfig
 
 
+def _empty_loadout(persona: str) -> dict[str, Any]:
+    return {"name": persona, "skill_slots": {"execute": [], "review": []}}
+
+
+def _resolve_persona_loadout(persona: str) -> tuple[dict[str, Any], str]:
+    """Return loadout dict and display name; markdown-only repos get an empty loadout."""
+    try:
+        loadout = load_loadout(persona)
+    except FileNotFoundError:
+        return _empty_loadout(persona), persona
+    return loadout, str(loadout.get("name") or persona)
+
+
 def resolve_dispatch_equip(
     task: FleetTask,
     fleet_config: FleetConfig,
     repo: RepoConfig | None,
     run_id: str | None = None,
 ) -> DispatchEquip:
-    """Pick execute/review skill slots and compose body for one dispatch."""
-    del fleet_config  # reserved for fleet-wide equip policy
+    """Resolve dispatch equip: loadouts, overlays, dynamic skills, journaling."""
     persona = task.persona or "coder"
-    loadout = load_loadout(persona)
-    loadout_name = str(loadout.get("name") or persona)
+    loadout, loadout_name = _resolve_persona_loadout(persona)
+
+    skill_dirs = merge_skill_dirs(base_kit_skill_dirs(), fleet_config.skill_dirs)
 
     repo_key_value = repo_key(
         name=repo.name if repo else None,
@@ -63,6 +79,15 @@ def resolve_dispatch_equip(
     ):
         extra_execute.append(SYSTEMATIC_DEBUGGING_SKILL)
 
+    if repo is not None and repo.pr_loop is not None and repo.pr_loop.enabled:
+        for skill_id in PR_LOOP_EXECUTE_SKILLS:
+            if (
+                skill_exists_in_base_kit(skill_id)
+                and skill_id not in loadout_execute
+                and skill_id not in extra_execute
+            ):
+                extra_execute.append(skill_id)
+
     skill_slots_execute = [*loadout_execute, *extra_execute]
     skill_slots_review = loadout_review_skill_ids(loadout)
     parent_run_id = task.equip.parent_run_id if task.equip else None
@@ -73,6 +98,7 @@ def resolve_dispatch_equip(
         repo_overlay=repo_overlay_text,
         extra_skills=extra_execute or None,
         level_up_generation=generation,
+        skill_dirs=skill_dirs,
     )
 
     equip = DispatchEquip(

--- a/agent_fleet/personas/coder.loadout.yaml
+++ b/agent_fleet/personas/coder.loadout.yaml
@@ -1,15 +1,18 @@
 schema_version: 1
 stub: coder.md
+# Default execute skills: Cursor pstack (https://github.com/cursor/plugins/tree/main/pstack)
 skills:
   execute:
-    - superpowers/test-driven-development
-    - superpowers/verification-before-completion
-    - superpowers/using-git-worktrees
     - pstack/tdd
     - pstack/principle-prove-it-works
-    - pstack/principle-minimize-reader-load
-    - pstack/principle-boundary-discipline
     - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
 pipeline_skills:
   code_review:
     review: []

--- a/agent_fleet/personas/reviewer.loadout.yaml
+++ b/agent_fleet/personas/reviewer.loadout.yaml
@@ -2,11 +2,10 @@ schema_version: 1
 stub: reviewer.md
 skills:
   execute:
-    - superpowers/receiving-code-review
-    - superpowers/requesting-code-review
     - pstack/interrogate
     - pstack/reflect
 pipeline_skills:
   code_review:
     review:
+      - pstack/unslop
       - cursor-team-kit/deslop

--- a/agent_fleet/skills_lib.py
+++ b/agent_fleet/skills_lib.py
@@ -8,7 +8,14 @@ from typing import Any
 _BUNDLED_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 _BASE_KIT_DIR = Path(__file__).resolve().parent / "base-kit"
 DEFAULT_QUALITY_REVIEW_SKILL = "thermo-nuclear-code-quality-review"
-SYSTEMATIC_DEBUGGING_SKILL = "superpowers/systematic-debugging"
+# Injected on verify_failed when not already in loadout (pstack-first default).
+SYSTEMATIC_DEBUGGING_SKILL = "pstack/why"
+# Injected when repo pr_loop.enabled (CI fix / watcher workflows).
+PR_LOOP_EXECUTE_SKILLS: tuple[str, ...] = (
+    "cursor-team-kit/fix-ci",
+    "cursor-team-kit/loop-on-ci",
+    "cursor-team-kit/get-pr-comments",
+)
 
 
 def base_kit_dir() -> Path:

--- a/docs/PERSONA-EVOLUTION.md
+++ b/docs/PERSONA-EVOLUTION.md
@@ -26,7 +26,7 @@ agent_fleet/base-kit/
   manifest.yaml                 # pinned upstream SHAs, licenses
   superpowers/                  # vendored skills (sync script)
   pstack/                       # vendored skills
-  cursor-team-kit/deslop/
+  cursor-team-kit/              # vendored PR/CI/verify skills (sync script)
 
 agent_fleet/personas/
   *.loadout.yaml                # human recipes → base-kit skill ids
@@ -102,7 +102,7 @@ persona: coder
 pipeline: code_review
 base_loadout: coder
 skill_slots_execute: [...]      # catalog ids from base-kit
-skill_slots_review: [cursor-team-kit/deslop]
+skill_slots_review: [pstack/unslop, cursor-team-kit/deslop]
 level_up_generation: 2
 parent_run_id: null             # set for decomposed children
 source_weight: 1.0
@@ -146,14 +146,14 @@ Every equip/promote/compact emits structured events to:
 - `~/.agent-fleet/fleet/runs/<run-id>.jsonl` (when `run_id` set)
 - `~/.agent-fleet/level_up/<repo>/<persona>/journal.jsonl`
 
-Event namespaces: `equip.*`, `phase.review.deslop`, `run.complete`, `experience.appended`, `level_up.gate.*`, `level_up.compact.*`.
+Event namespaces: `equip.*`, `phase.review.unslop`, `run.complete`, `experience.appended`, `level_up.gate.*`, `level_up.compact.*`.
 
 ---
 
 ## Pipelines
 
-- **Execute** — persona loadout + overlays; no deslop
-- **Review** — reviewer loadout + **deslop** (`review_skill_slots`)
+- **Execute** — persona loadout (default: **pstack** skills) + overlays; no unslop
+- **Review** — reviewer loadout + **unslop** and **deslop** (`review_skill_slots`)
 
 PR loop, issue dispatch, and CLI all go orchestration equip → dispatcher.
 
@@ -193,7 +193,7 @@ agent-fleet level-up compact --repo NAME --persona coder
 | `agent_fleet/personas.py` | loadout + compose prompt |
 | `agent_fleet/dispatcher.py` | pass equip context |
 | `agent_fleet/dispatcher_task.py` | record experience + journal |
-| `agent_fleet/phases.py` | review deslop skills |
+| `agent_fleet/phases.py` | review unslop + deslop skills |
 | `agent_fleet/tech_lead.py` | skill promotion review (extension) |
 
 No separate “trainer” or “classifier” product terms.

--- a/docs/superpowers/plans/2026-05-25-skill-lifecycle-unification.md
+++ b/docs/superpowers/plans/2026-05-25-skill-lifecycle-unification.md
@@ -1,0 +1,111 @@
+# Skill Lifecycle Unification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make base-kit skills consistently available across every fleet lifecycle path — dispatcher `simple`/`code_review`, full pipeline (PLAN→IMPLEMENT→VERIFY→REVIEW), issue dispatch, PR-loop fix rounds, and repo-local markdown personas.
+
+**Architecture:** `resolve_dispatch_equip` already composes execute/review skill slots + `compose_body` for the dispatcher path. Gaps: `FleetRunner`/`implementer.py` ignore equip; issue dispatch never resolves equip; repo markdown personas have no loadouts; review/fix phases only partially append review skills.
+
+**Tech Stack:** Python 3.11+, pytest, ruff, YAML loadouts.
+
+**Dogfood tagging:** `[FLEET]` = safely dispatchable in a worktree (see `.agent-fleet.yaml` persona_scope_allowlist). `[MANUAL]` = touches bootstrap/critical-path files — human gate or pinned-dispatch venv only.
+
+---
+
+## Task 1: Plan + skill access matrix doc [FLEET]
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-05-25-skill-lifecycle-unification.md` (this file)
+- Modify: `docs/PERSONAS.md` — add "Skill access by lifecycle" table
+
+- [ ] Add matrix: dispatcher simple/code_review (equip ✓), full pipeline IMPLEMENT (equip ✗), issue dispatch (equip ✗), PR analyzer (thermo-nuclear ✓), PR-loop fix (equip ✗), level-up overlays (overlay only)
+
+---
+
+## Task 2: Integration tests for equip gaps [FLEET]
+
+**Files:**
+- Create: `tests/test_skill_lifecycle.py`
+
+- [ ] Test: `resolve_dispatch_equip` returns compose_body with TDD skill for `coder` persona
+- [ ] Test: `implement()` accepts optional `compose_body` override (stub until Task 4)
+- [ ] Test: `run_pipeline` execute phase uses `task.equip.compose_body` when set (already true — regression)
+- [ ] Test: document expected runner behavior — runner must attach equip before IMPLEMENT (fails until Task 5)
+
+---
+
+## Task 3: Loadout + repo config examples [FLEET]
+
+**Files:**
+- Modify: `examples/repo.agent-fleet.yaml` — document `skills_dir`, loadout resolution, markdown+loadout pairing
+- Modify: `examples/repo-full.agent-fleet.yaml` — sample `backend.loadout.yaml` beside `backend.md`
+
+- [ ] Show pattern: `personas/backend.md` + `personas/backend.loadout.yaml` with execute/review slots
+
+---
+
+## Task 4: Implementer accepts equip compose_body [FLEET]
+
+**Files:**
+- Modify: `agent_fleet/implementer.py`
+- Test: extend `tests/test_skill_lifecycle.py`
+
+- [ ] Add optional `compose_body: str | None` param to `implement()`
+- [ ] When set, use compose_body instead of raw `persona.prompt_path.read_text()`
+- [ ] Keep fallback to markdown stub when compose_body empty
+
+---
+
+## Task 5: FleetRunner resolves equip before IMPLEMENT [MANUAL]
+
+**Files:**
+- Modify: `agent_fleet/runner.py`
+- Test: `tests/test_runner_equip.py` or extend `tests/test_skill_lifecycle.py`
+
+- [ ] Call `resolve_dispatch_equip` once per run (after persona known, before IMPLEMENT)
+- [ ] Pass `equip.compose_body` into `implement()`
+- [ ] Attach equip to task/handoff for REVIEW phase review-skill append
+- [ ] Do NOT edit dispatcher.py during this task
+
+---
+
+## Task 6: Review phase uses equip for reviewer body [MANUAL]
+
+**Files:**
+- Modify: `agent_fleet/phases.py` (`_legacy_review_phase`, structured review if applicable)
+
+- [ ] Reviewer persona: prefer loadout compose_body when equip present
+- [ ] Keep `_review_skill_prompt_append` for pipeline_skills.review slots
+
+---
+
+## Task 7: PR-loop fix phase uses equip [MANUAL]
+
+**Files:**
+- Modify: `agent_fleet/code_review/fix.py`
+
+- [ ] Resolve equip for fix persona; inject compose_body into fix prompt
+
+---
+
+## Task 8: Repo-local loadout discovery [FLEET]
+
+**Files:**
+- Modify: `agent_fleet/skills_lib.py` (`load_loadout`)
+- Modify: `agent_fleet/personas.py` if needed
+- Test: `tests/test_loadouts.py`
+
+- [ ] Resolve `{personas_dir}/{name}.loadout.yaml` before package default
+- [ ] Fall back to package `agent_fleet/personas/{name}.loadout.yaml`
+
+---
+
+## Verification
+
+```bash
+cd /home/evan/Documents/agent_fleet
+uv run pytest tests/test_skill_lifecycle.py tests/test_equip.py tests/test_loadouts.py -q
+uv run ruff check agent_fleet/implementer.py agent_fleet/skills_lib.py tests/
+```
+
+**Dispatch order:** Tasks 1→3→2→4→8 in parallel where safe; then 5→6→7 manually or with critical_path_prefixes temporarily relaxed.

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -18,6 +18,7 @@ from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.repo import load_repo_config
 from agent_fleet.skills_lib import (
+    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
     load_loadout,
     loadout_execute_skill_ids,
@@ -33,7 +34,26 @@ def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
 def test_load_coder_loadout() -> None:
     loadout = load_loadout("coder")
     execute = loadout_execute_skill_ids(loadout)
-    assert "superpowers/test-driven-development" in execute
+    assert "pstack/tdd" in execute
+
+
+def test_resolve_dispatch_equip_missing_loadout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: md-only\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task = FleetTask(goal="Slim repo", persona="frontend", workspace=str(tmp_path))
+
+    equip = resolve_dispatch_equip(task, fleet_config, repo, run_id="md-only-run")
+
+    assert equip.base_loadout == "frontend"
+    assert equip.skill_slots_execute == ()
+    assert equip.skill_slots_review == ()
+    journal_path = persona_dir("md-only", "frontend") / "journal.jsonl"
+    assert journal_path.is_file()
 
 
 def test_resolve_dispatch_equip_baseline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -50,9 +70,9 @@ def test_resolve_dispatch_equip_baseline(tmp_path: Path, monkeypatch: pytest.Mon
     assert isinstance(equip, DispatchEquip)
     assert equip.persona == "coder"
     assert equip.base_loadout == "coder"
-    assert "superpowers/test-driven-development" in equip.skill_slots_execute
+    assert "pstack/tdd" in equip.skill_slots_execute
     assert equip.parent_run_id is None
-    assert "Test-Driven Development" in equip.compose_body
+    assert "TDD Bug Fix" in equip.compose_body
 
     journal_path = persona_dir("equip-demo", "coder") / "journal.jsonl"
     assert journal_path.is_file()
@@ -83,7 +103,7 @@ def test_verify_failed_adds_systematic_debugging(
     equip = resolve_dispatch_equip(task, fleet_config, repo)
 
     assert SYSTEMATIC_DEBUGGING_SKILL in equip.skill_slots_execute
-    assert "Systematic Debugging" in equip.compose_body
+    assert "# Why" in equip.compose_body
 
 
 def test_verify_failed_skips_missing_base_kit_skill(
@@ -109,6 +129,23 @@ def test_verify_failed_skips_missing_base_kit_skill(
     equip = resolve_dispatch_equip(task, fleet_config, repo)
 
     assert SYSTEMATIC_DEBUGGING_SKILL not in equip.skill_slots_execute
+
+
+def test_pr_loop_adds_ci_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        "name: pr-loop-repo\npr_loop:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task = FleetTask(goal="Fix CI", persona="coder", workspace=str(tmp_path))
+    equip = resolve_dispatch_equip(task, fleet_config, repo)
+
+    for skill_id in PR_LOOP_EXECUTE_SKILLS:
+        assert skill_id in equip.skill_slots_execute
 
 
 def test_child_tasks_carry_parent_run_id() -> None:

--- a/tests/test_loadouts.py
+++ b/tests/test_loadouts.py
@@ -15,21 +15,21 @@ from agent_fleet.skills_lib import (
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def test_deslop_loads_from_base_kit() -> None:
+def test_unslop_loads_from_base_kit() -> None:
     dirs = base_kit_skill_dirs()
     assert dirs
-    path = resolve_skill_path("cursor-team-kit/deslop", dirs)
+    path = resolve_skill_path("pstack/unslop", dirs)
     assert path is not None
     assert path.name == "SKILL.md"
-    text = load_skill_text("cursor-team-kit/deslop", dirs)
-    assert "Remove AI code slop" in text
+    text = load_skill_text("pstack/unslop", dirs)
+    assert "slop" in text.lower()
 
 
-def test_reviewer_loadout_lists_deslop_for_review() -> None:
+def test_reviewer_loadout_lists_unslop_for_review() -> None:
     loadout = load_loadout("reviewer")
     assert loadout is not None
     review_skills = loadout["pipeline_skills"]["code_review"]["review"]
-    assert review_skills == ["cursor-team-kit/deslop"]
+    assert review_skills == ["pstack/unslop", "cursor-team-kit/deslop"]
 
 
 def test_compose_persona_body_includes_sections() -> None:


### PR DESCRIPTION
## Summary
- [FLEET] Tasks 1-3 from skill lifecycle unification plan
- Equip handles missing loadouts gracefully; merges repo skill_dirs
- Coder/reviewer loadouts refreshed (pstack-first, unslop+deslop review)
- PR-loop dynamic skills (fix-ci, loop-on-ci, get-pr-comments)
- Adds lifecycle plan doc + dogfood `.agent-fleet.yaml` scope update

## Remaining [MANUAL]
- Task 5: `runner.py` equip before IMPLEMENT
- Task 6: review phase compose_body
- Task 7: PR-loop fix equip

Closes #7 (partial)

## Test plan
- [x] `uv run pytest tests/test_equip.py tests/test_loadouts.py tests/test_phases_deslop.py tests/test_phases_execute_equip.py -q`

Made with [Cursor](https://cursor.com)