### PR TITLE
feat(implementer): accept optional equip compose_body

### DIFF
--- a/agent_fleet/implementer.py
+++ b/agent_fleet/implementer.py
@@ -40,12 +40,14 @@ def implement(
     prompt_suffix: str | None = None,
     session: LLMSession | None = None,
     require_mcp_tools: bool = False,
+    compose_body: str | None = None,
 ) -> LLMResult:
     """Run the Implementer phase.
 
-    Loads the persona prompt via *persona_resolver*, builds a structured prompt
-    from *brief* and *task_spec* (allowed_paths, forbidden_paths, acceptance_criteria,
-    files_to_create, files_to_modify, test_strategy), then calls *backend.run()*.
+    Loads the persona prompt via *persona_resolver* (or *compose_body* when set),
+    builds a structured prompt from *brief* and *task_spec* (allowed_paths,
+    forbidden_paths, acceptance_criteria, files_to_create, files_to_modify,
+    test_strategy), then calls *backend.run()*.
 
     The LLM runs inside *worktree_path* (already set up by FleetRunner). This
     function does NOT manage the worktree lifecycle — that is FleetRunner's job.
@@ -56,11 +58,13 @@ def implement(
     # TODO(PR D): admit via fleet.admission.AdmissionController
     persona = persona_resolver.load(persona_name)
 
-    # Load persona prompt text; fall back to default if path doesn't exist on disk.
-    try:
-        persona_prompt = persona.prompt_path.read_text()
-    except FileNotFoundError, OSError:
-        persona_prompt = _DEFAULT_PERSONA_PROMPT
+    if compose_body and compose_body.strip():
+        persona_prompt = compose_body.strip()
+    else:
+        try:
+            persona_prompt = persona.prompt_path.read_text()
+        except FileNotFoundError, OSError:
+            persona_prompt = _DEFAULT_PERSONA_PROMPT
 
     allowed_tools = persona.allowed_tools
 

--- a/tests/test_skill_lifecycle.py
+++ b/tests/test_skill_lifecycle.py
@@ -1,0 +1,165 @@
+# ruff: noqa: TC002
+"""Skill lifecycle integration tests (equip compose_body → implementer)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.contracts.implementation_brief import ImplementationBrief
+from agent_fleet.contracts.task_spec import (
+    DecompositionDecision,
+    RiskTier,
+    Scope,
+    TaskSpec,
+)
+from agent_fleet.hooks import FleetTask, Persona
+from agent_fleet.implementer import implement
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
+from agent_fleet.repo import load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+@dataclass
+class _FakeResult:
+    stdout: str
+    stderr: str = ""
+    exit_code: int = 0
+    duration_s: float = 0.0
+    agent_id: str | None = None
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,  # noqa: ARG002
+        timeout_s: int,  # noqa: ARG002
+        memory_limit: str = "4G",  # noqa: ARG002
+        allowed_tools: list[str] | None = None,  # noqa: ARG002
+        cwd: Path | None = None,  # noqa: ARG002
+        model: str | None = None,  # noqa: ARG002
+        mode: object | None = None,  # noqa: ARG002
+    ) -> _FakeResult:
+        self.prompts.append(prompt)
+        return _FakeResult(stdout="ok")
+
+
+class _StubPersonaResolver:
+    def __init__(self, persona: Persona) -> None:
+        self._persona = persona
+
+    def load(self, name: str) -> Persona:  # noqa: ARG002
+        return self._persona
+
+    def list_personas(self) -> list[str]:
+        return [self._persona.name]
+
+
+def _brief() -> ImplementationBrief:
+    return ImplementationBrief(
+        issue_number=1,
+        summary="Fix bug",
+        files_to_create=[],
+        files_to_modify=["src/x.py"],
+        test_strategy="pytest",
+        acceptance_criteria=["tests pass"],
+        references=[],
+    )
+
+
+def _task_spec() -> TaskSpec:
+    return TaskSpec(
+        issue_number=1,
+        decomposition_decision=DecompositionDecision.SINGLE,
+        decomposition_reason="small",
+        child_issues_proposed=[],
+        scope=Scope(allowed_paths=["src/"], forbidden_paths=[]),
+        research_plan=[],
+        acceptance_criteria=["tests pass"],
+        risk_tier=RiskTier.LOW,
+        critical_paths_touched=[],
+        coordination_spec=None,
+    )
+
+
+def test_resolve_dispatch_equip_compose_body_includes_tdd_for_coder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: skill-lifecycle\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task = FleetTask(goal="Fix bug", persona="coder", workspace=str(tmp_path))
+
+    equip = resolve_dispatch_equip(task, fleet_config, repo, run_id="run-sl")
+
+    assert "pstack/tdd" in equip.skill_slots_execute
+    assert "TDD Bug Fix" in equip.compose_body
+
+
+def test_implement_accepts_compose_body_override(tmp_path: Path) -> None:
+    persona = Persona(
+        name="coder",
+        prompt_path=Path("/nonexistent/coder.md"),
+        allowed_tools=[],
+        capabilities={},
+    )
+    backend = _CapturingBackend()
+    compose_body = "# Equip compose\n\nTDD Bug Fix\n\nWrite failing test first."
+
+    implement(
+        _brief(),
+        _task_spec(),
+        tmp_path,
+        "fleet/test-branch",
+        backend=backend,
+        persona_resolver=_StubPersonaResolver(persona),
+        persona_name="coder",
+        compose_body=compose_body,
+    )
+
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "TDD Bug Fix" in prompt
+    assert "You are a helpful coding assistant." not in prompt
+
+
+def test_implement_falls_back_when_compose_body_empty(tmp_path: Path) -> None:
+    prompt_path = tmp_path / "coder.md"
+    prompt_path.write_text("Static markdown persona body.", encoding="utf-8")
+    persona = Persona(
+        name="coder",
+        prompt_path=prompt_path,
+        allowed_tools=[],
+        capabilities={},
+    )
+    backend = _CapturingBackend()
+
+    implement(
+        _brief(),
+        _task_spec(),
+        tmp_path,
+        "fleet/test-branch",
+        backend=backend,
+        persona_resolver=_StubPersonaResolver(persona),
+        persona_name="coder",
+        compose_body="",
+    )
+
+    assert "Static markdown persona body." in backend.prompts[0]
+    assert "TDD Bug Fix" not in backend.prompts[0]


### PR DESCRIPTION
## Summary
- [FLEET] Task 4: `implement()` accepts optional `compose_body` from equip
- Falls back to markdown persona prompt when compose_body empty
- Adds `tests/test_skill_lifecycle.py` (equip + implement tests)

## Remaining [MANUAL]
- Task 5: Wire `runner.py` to pass `equip.compose_body` into `implement()`

Relates to #7

## Test plan
- [x] `uv run pytest tests/test_skill_lifecycle.py -q`

Made with [Cursor](https://cursor.com)