### PR TITLE
Agent-fleet integration: persona registry, scout loadouts, workstreams

### DIFF
--- a/.agent-fleet.yaml
+++ b/.agent-fleet.yaml
@@ -1,0 +1,79 @@
+# Agent-fleet self-hosting — integration workstreams
+name: agent-fleet
+default_persona: coder
+default_branch: feature/flywheel-less-is-more
+
+personas_dir: agents/personas
+
+test_command: pytest -q
+lint_command: ruff check agent_fleet tests
+
+use_worktree: true
+worktree_base: /home/evan/Documents/agent-fleet/.worktrees/fleet-runs
+
+capacity:
+  max_dispatches: 8
+
+code_review:
+  auto_fix: true
+  max_fix_attempts: 2
+  fix_persona: coder
+
+workstreams:
+  plan: docs/superpowers/plans/2026-05-25-agent-fleet-integration.md
+  base_branch: feature/flywheel-less-is-more
+  default_target_branch: feature/agent-fleet-integration
+  pipeline: code_review
+  sequential_stack: true
+  items:
+    - id: registry
+      persona: fleet-registry
+      target_branch: feature/agent-fleet-integration
+      goal: |
+        Add tests/test_persona_registry.py that resolves every persona listed in
+        agents/personas and every fleet.yaml entry that points at agents/personas.
+        Prune ~/.agent-fleet/fleet.yaml entries for personas with no .md file.
+        Document persona resolution (repo dir then package fallback) in FLEET-CONFIG.md.
+        Ensure agent-fleet workstream subcommand is registered in cli.py.
+    - id: scout-loadouts
+      persona: fleet-scout-loadouts
+      target_branch: feature/agent-fleet-integration
+      goal: |
+        Add agent_fleet/personas/*.loadout.yaml for pr-analyzer, explorer, tech-scout,
+        product-scout (match coder/reviewer schema). Extend test_loadouts.py. Update
+        docs/PERSONAS.md. Do not touch uv.lock.
+    - id: skills-stack
+      persona: fleet-skills-stack
+      target_branch: feature/skills-personas
+      base_branch: feature/skills-pr-loop
+      goal: |
+        Harvest PR4 scout loadouts from .worktrees/fleet-runs/task-2-6316c6c3 if present
+        (use agent-fleet workstream harvest). Merge skills integration commits from
+        feature/skills-pr-loop into feature/skills-personas. Run test_loadouts.py.
+
+persona_scope_allowlist:
+  fleet-registry:
+    - agent_fleet/cli.py
+    - agent_fleet/config.py
+    - agent_fleet/skills_lib.py
+    - agent_fleet/orchestration/equip.py
+    - agent_fleet/personas.py
+    - agent_fleet/workstreams/
+    - tests/test_persona_registry.py
+    - tests/test_fleet.py
+    - docs/FLEET-CONFIG.md
+    - docs/WORKSTREAMS.md
+  fleet-scout-loadouts:
+    - agent_fleet/personas/
+    - tests/test_loadouts.py
+    - docs/PERSONAS.md
+  fleet-skills-stack:
+    - agents/personas/
+    - docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+  coder:
+    - agent_fleet/
+  reviewer:
+    - agent_fleet/
+
+critical_path_prefixes:
+  - .github/workflows/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Built on **[Cursor SDK](https://github.com/cursor/cursor-sdk)** (`cursor-sdk`). 
 | Docs | |
 |------|---|
 | [Quickstart](docs/QUICKSTART.md) | First run in ~15 minutes |
+| [Fleet config](docs/FLEET-CONFIG.md) | Global paths, `personas_dir`, import shadow |
 | [New repo setup](docs/NEW-REPO.md) | `.agent-fleet.yaml`, GHA, PR loop |
 | [Personas](docs/PERSONAS.md) | Fleet cookbook |
 
@@ -72,11 +73,13 @@ cd agent-fleet
 pip install -e ".[dev]"    # or: uv sync --frozen --group dev
 
 export CURSOR_API_KEY=your_key_here
-mkdir -p ~/.hermes/coding_fleet
-cp fleet.example.yaml ~/.hermes/coding_fleet/fleet.yaml
-# ~/.hermes/coding_fleet/ = global fleet config (personas, max_parallel), not your repo
+mkdir -p ~/.agent-fleet
+cp fleet.example.yaml ~/.agent-fleet/fleet.yaml
+# ~/.agent-fleet/fleet.yaml = global fleet config (personas, max_parallel), not your repo
 # edit fleet.yaml: default_model: composer-2.5-fast
 ```
+
+> **Import shadow:** Do not clone into `~/Documents/agent_fleet` (underscore). That path name matches the Python package and can shadow the installed `agent_fleet` module when used as cwd or on `PYTHONPATH`. Prefer `~/agent-fleet-dev` or any hyphenated path. Check with `python3 scripts/check-import-shadow.py` — see [docs/FLEET-CONFIG.md](docs/FLEET-CONFIG.md#import-shadow).
 
 ### 2. Verify install
 
@@ -129,7 +132,7 @@ Expect JSON with `status: completed` or a typed failure (`scope_violation`, `ver
 | PR loop watcher | `agent-fleet loop` / `agent-fleet-pr-loop` | Poll `fleet/*` PRs → fix findings → CI → optional merge |
 | Issue trigger | `agent-fleet-watch` | `/agent --persona …` on issue comments → full pipeline |
 
-**Concurrency** (`~/.hermes/coding_fleet/fleet.yaml`) — starting point for a typical 16–32 GB laptop:
+**Concurrency** (`~/.agent-fleet/fleet.yaml`) — starting point for a typical 16–32 GB laptop:
 
 ```yaml
 default_backend: cursor
@@ -182,7 +185,7 @@ Examples: [`examples/repo.agent-fleet.yaml`](examples/repo.agent-fleet.yaml) · 
 
 ## Personas
 
-Registry: `~/.hermes/coding_fleet/fleet.yaml`. Bundled prompts in `agent_fleet/personas/` (`coder`, `reviewer`, `pr-analyzer`, …). Repo `personas/` and `.agent-fleet.yaml` scope override global `allowed_paths`.
+Registry: `~/.agent-fleet/fleet.yaml` (see [docs/FLEET-CONFIG.md](docs/FLEET-CONFIG.md)). Bundled prompts in `agent_fleet/personas/` (`coder`, `reviewer`, `pr-analyzer`, …). Repo `personas/` and `.agent-fleet.yaml` scope override global `allowed_paths`.
 
 ```yaml
 default_backend: cursor

--- a/agent_fleet/base-kit/cursor-team-kit/check-compiler-errors/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/check-compiler-errors/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: check-compiler-errors
+description: Run compile and type-check commands and report failures
+---
+
+# Check compiler errors
+
+## Trigger
+
+Compile or type-check failures are blocking local validation or CI.
+
+## Workflow
+
+1. Run the repo's compile and type-check commands.
+2. Summarize errors by file and type.
+3. Fix the highest-confidence issues first.
+4. Re-run checks until clean or blocked.
+
+## Output
+
+- Current compile and type-check status
+- Error summary grouped by file and category
+- Fixes applied and remaining blockers

--- a/agent_fleet/base-kit/cursor-team-kit/control-cli/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/control-cli/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: control-cli
+description: Build or adapt a local harness to drive, inspect, and profile an interactive CLI or TUI without external services. Use for CLI UX checks, startup regressions, memory leaks, hangs, prompt flows, or terminal demos.
+---
+
+# Control CLI
+
+Use a repeatable local harness to exercise an interactive CLI instead of poking at it manually. First reuse the repo's own test/demo harness if it exists; otherwise assemble a temporary harness from standard local tools.
+
+## What It Is Used For
+
+- Reproducing CLI/TUI bugs with deterministic input.
+- Verifying keyboard flows, prompts, interrupts, resize behavior, and terminal layout.
+- Capturing before/after transcripts for bug fixes.
+- Profiling startup time, slow operations, hangs, or memory growth.
+- Recording a short terminal demo when output is easier to show than explain.
+
+## Harness Loop
+
+1. Identify the command under test and the smallest reproducible workspace.
+2. Discover existing local harnesses: package scripts, e2e tests, demo recorders, expect scripts, or PTY helpers.
+3. If no harness exists, launch the CLI in an isolated terminal session with deterministic env vars.
+4. Capture the current screen before interacting.
+5. Send one action at a time: text, Enter, arrows, Escape, Ctrl-C, resize.
+6. Wait for a concrete screen pattern or prompt before the next action.
+7. Save the transcript and any profile artifacts.
+8. Kill the session cleanly.
+
+## Harness Options
+
+- Repo-native harness: prefer checked-in scripts because they know the app's startup, env, and prompts.
+- `tmux`: managed sessions, `capture-pane`, `send-keys`, attach/detach.
+- PTY probe: use a short Python, Node, or Expect script when tmux is unavailable.
+- Runtime inspector: use Node or Bun inspector for CPU profiles, heap snapshots, and live evaluation.
+- Terminal recorder: use repo-local demo tools or asciinema-compatible tools when the user asks for a demo.
+
+## Minimal tmux Harness
+
+```bash
+SESSION="cli-harness-$(date +%s)"
+tmux new-session -d -s "$SESSION" -- <command-under-test>
+tmux capture-pane -pt "$SESSION"
+tmux send-keys -t "$SESSION" "help" Enter
+tmux capture-pane -pt "$SESSION"
+tmux kill-session -t "$SESSION"
+```
+
+For Node CLIs:
+
+```bash
+NODE_OPTIONS="--inspect=127.0.0.1:0" tmux new-session -d -s "$SESSION" -- <node-cli-command>
+```
+
+Read the terminal output to find the inspector URL, then use Chrome DevTools-compatible tooling if profiling is needed.
+
+## Minimal PTY Harness
+
+Use a PTY script when you need deterministic waits in a repo that does not have tmux or a demo harness. Keep it temporary unless the user asks to add a reusable test.
+
+```python
+import os
+import pty
+import select
+import subprocess
+import time
+
+master_fd, slave_fd = pty.openpty()
+proc = subprocess.Popen(
+    ["<command>", "<arg>"],
+    stdin=slave_fd,
+    stdout=slave_fd,
+    stderr=slave_fd,
+    close_fds=True,
+)
+os.close(slave_fd)
+
+deadline = time.time() + 30
+buffer = b""
+while time.time() < deadline:
+    ready, _, _ = select.select([master_fd], [], [], 0.25)
+    if not ready:
+        continue
+    chunk = os.read(master_fd, 4096)
+    buffer += chunk
+    if b"<ready text>" in buffer:
+        os.write(master_fd, b"help\n")
+        break
+
+print(buffer.decode(errors="replace"))
+proc.terminate()
+os.close(master_fd)
+```
+
+If the CLI needs richer terminal control, use `pty.fork()` or an existing PTY library.
+
+## Profiling Recipes
+
+- Startup regression: capture baseline and treatment startup timings under the same machine, env, and command.
+- Slow operation: start a CPU profile, perform the operation, stop the profile, and compare top self-time functions.
+- Memory leak: force GC if available, take a heap snapshot, perform the operation repeatedly, force GC again, and take another snapshot.
+- Hang: capture the screen, active handles/resources, and a stack/CPU sample before interrupting.
+
+## Guardrails
+
+- Prefer deterministic waits over sleeps. If you must sleep, explain why.
+- Do not send credentials or destructive commands into a controlled session.
+- Keep the harness in `/tmp` unless the repo already has a testing/demo harness.
+- Do not hard-code paths from another repository. Adapt commands to the current repo's scripts and runtime.
+- Clean up tmux sessions, temp dirs, inspector processes, and demo artifacts unless the user asks to keep them.

--- a/agent_fleet/base-kit/cursor-team-kit/control-ui/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/control-ui/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: control-ui
+description: Build or adapt a local browser/CDP harness to drive and inspect a web, IDE, or Electron UI. Use for local UI verification, screenshots, accessibility snapshots, perf profiles, visual diffs, or reproducing UI bugs.
+---
+
+# Control UI
+
+Use local browser automation to verify UI behavior with evidence. First reuse the repo's own Playwright, browser, or Electron harness if it exists; otherwise assemble a temporary local harness around the app's dev server or Chromium debug port.
+
+## What It Is Used For
+
+- Reproducing UI bugs that depend on real browser focus, keyboard input, scrolling, resizing, or rendering.
+- Verifying visual or accessibility changes with screenshots and snapshots.
+- Checking local web, IDE, or Electron behavior before shipping.
+- Capturing console logs, network logs, CPU profiles, traces, or heap snapshots.
+- Creating before/after evidence for `verify-this`.
+
+## Setup Pattern
+
+1. Start the app locally using the repo's documented dev command.
+2. Discover existing local harnesses: Playwright tests, Cypress specs, Storybook, browser scripts, Electron launch scripts, or snapshot tools.
+3. For a web app, connect to the local URL with the existing browser tooling.
+4. For Electron/Chromium, enable a remote debugging port when supported.
+5. Select the correct page by stable app markers, not by tab order alone.
+6. Prefer accessibility roles, labels, and stable `data-*` selectors over coordinates.
+
+## Generic Web Harness
+
+Use the repo's installed browser tooling when possible. If the repo already has Playwright, a minimal one-off probe looks like:
+
+```javascript
+import { chromium } from "playwright";
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+await page.goto("http://127.0.0.1:<port>");
+await page.getByRole("button", { name: /submit/i }).click();
+await page.screenshot({ path: "/tmp/ui-harness-after.png", fullPage: true });
+await browser.close();
+```
+
+Do not add Playwright as a project dependency just for this probe unless the user asks. Prefer existing dev dependencies or external browser tools already available in the environment.
+
+## Generic CDP Harness
+
+For Electron or a Chromium app launched with `--remote-debugging-port=<port>`, connect over CDP:
+
+```javascript
+import { chromium } from "playwright";
+
+const browser = await chromium.connectOverCDP("http://127.0.0.1:<debug-port>");
+const pages = browser.contexts().flatMap((context) => context.pages());
+let page;
+for (const candidate of pages) {
+  if (await candidate.locator("<app-root-selector>").count()) {
+    page = candidate;
+    break;
+  }
+}
+
+if (!page) {
+  console.log(await Promise.all(pages.map(async (p) => ({
+    title: await p.title(),
+    url: p.url(),
+  }))));
+  throw new Error("No matching app page found");
+}
+
+await page.screenshot({ path: "/tmp/ui-harness-cdp.png", fullPage: true });
+await browser.close();
+```
+
+Replace `<app-root-selector>` with a stable marker from the current repo, such as a root app node, landmark, or product-specific `data-*` attribute.
+
+## Interaction Loop
+
+1. Capture a page snapshot or screenshot before acting.
+2. Choose a target from the latest page structure.
+3. Perform exactly one structural action: click, type, keypress, drag, scroll, navigate, or resize.
+4. Capture a fresh snapshot/screenshot.
+5. Verify the expected state change.
+6. Save artifacts for before/after comparisons when the user asked for proof.
+
+## CDP Capabilities
+
+Use raw CDP only when higher-level browser APIs are insufficient:
+
+- Performance: CPU profiles, traces, paint flashing, FPS meter, layout shift inspection.
+- Memory: heap snapshots and forced GC for leak investigations.
+- Network: request blocking, throttling, cache disablement, request/response logs.
+- Rendering: viewport changes, color scheme emulation, reduced motion, accessibility checks.
+- Debugging: console streaming, exception capture, DOM snapshots.
+
+## Page Selection
+
+When multiple app windows/tabs share a debug port:
+
+- Prefer a positive marker for the surface under test, such as an app root selector.
+- Use a negative marker to avoid the wrong surface when necessary.
+- If no page matches, list available page titles and URLs instead of guessing.
+
+## Guardrails
+
+- Do not rely on stale element references after navigation or structural changes.
+- Avoid coordinate clicks unless a fresh screenshot was captured immediately before the click.
+- Keep test data local and disposable.
+- Do not store screenshots or heap snapshots from privacy-sensitive workspaces unless the user explicitly agrees.
+- Do not hard-code selectors, ports, or script paths from another repository. Discover the current repo's local app markers.
+- Clean up dev servers, debug sessions, and temp profiles when done.

--- a/agent_fleet/base-kit/cursor-team-kit/fix-ci/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/fix-ci/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: fix-ci
+description: Find failing PR checks, inspect logs or external check links, and apply focused fixes
+---
+
+# Fix CI
+
+## Trigger
+
+Branch or PR CI is failing and needs a fast, iterative path to green checks.
+
+## Workflow
+
+1. Resolve the active PR and inspect `gh pr checks --json name,bucket,state,workflow,link`.
+2. Inspect failed jobs and extract the first actionable error. Use GitHub Actions logs when available; otherwise use the check link to identify the failing command or service.
+3. Apply the smallest safe fix.
+4. Push, re-check the PR check set, and repeat until green.
+
+## Guardrails
+
+- Fix one actionable failure at a time.
+- Prefer minimal, low-risk changes before broader refactors.
+- Keep `gh pr checks` as the source of truth for overall PR CI state.
+
+## Output
+
+- Primary failing job and root error
+- Fixes applied in iteration order
+- Current CI status and next action

--- a/agent_fleet/base-kit/cursor-team-kit/fix-merge-conflicts/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/fix-merge-conflicts/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: fix-merge-conflicts
+description: Resolve merge conflicts non-interactively, validate build and tests, and finalize conflict resolution
+---
+
+# Fix merge conflicts
+
+## Trigger
+
+Branch has unresolved merge conflicts and needs a reliable path to a buildable state.
+
+## Workflow
+
+1. Detect all conflicting files from git status and conflict markers.
+2. Resolve each conflict with minimal, correctness-first edits.
+3. Prefer preserving both sides when safe. Otherwise, choose the variant that compiles and keeps public behavior stable.
+4. Regenerate lockfiles with package manager tools instead of hand-editing.
+5. Run compile, lint, and relevant tests.
+6. Stage resolved files and summarize key decisions.
+
+## Guardrails
+
+- Keep changes minimal and readable.
+- Do not leave conflict markers in any file.
+- Avoid broad refactors while resolving conflicts.
+- Do not push or tag during conflict resolution.
+
+## Output
+
+- Files resolved
+- Notable resolution choices
+- Build/test outcome

--- a/agent_fleet/base-kit/cursor-team-kit/get-pr-comments/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/get-pr-comments/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: get-pr-comments
+description: Fetch and summarize review comments from the active pull request
+---
+
+# Get PR comments
+
+## Trigger
+
+Need a concise, actionable summary of feedback on the active pull request.
+
+## Workflow
+
+1. Resolve the active PR for the current branch.
+2. Fetch review comments and discussion comments.
+3. Group feedback by severity and actionability.
+4. Return a concise action list.
+
+## Output
+
+- Grouped feedback summary
+- Action list ordered by priority
+- Open questions that still need clarification

--- a/agent_fleet/base-kit/cursor-team-kit/loop-on-ci/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/loop-on-ci/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: loop-on-ci
+description: Monitor PR checks and fix failures until green. Uses gh pr checks as the source of truth for PR-attached checks.
+---
+
+# Loop on CI
+
+## Trigger
+
+Need to watch a branch or pull request and iterate on CI failures until all required checks are green.
+
+Use `gh pr checks` as the source of truth. It includes all PR-attached checks, while `gh run list` only covers GitHub Actions.
+
+## Workflow
+
+1. Resolve the PR for the current branch.
+2. Inspect current PR checks before waiting.
+3. If checks already failed, diagnose those failures first.
+4. If checks are pending, watch with `gh pr checks --watch --fail-fast`.
+5. After each push, re-check the full PR check set and repeat until green.
+
+## Commands
+
+```bash
+# Resolve the active PR
+gh pr view --json number,url,headRefName
+
+# Inspect all attached checks
+gh pr checks --json name,bucket,state,workflow,link
+
+# Watch pending checks and fail fast
+gh pr checks --watch --fail-fast
+
+# GitHub Actions logs, when the failing check links to a GHA run
+gh run view <run-id> --log-failed
+```
+
+## Guardrails
+
+- Keep each fix scoped to a single failure cause when possible.
+- Do not bypass hooks (`--no-verify`) to force progress.
+- If the failure is clearly unrelated to the PR and appears fixed on main, merge latest main instead of bloating the PR with unrelated fixes.
+- If failures are flaky, retry once and report flake evidence.
+- Re-run `gh pr checks --json name,bucket,state,workflow,link` after every push; the check set can change.
+
+## Output
+
+- Current CI status
+- Failure summary and fixes applied
+- PR URL once checks are green

--- a/agent_fleet/base-kit/cursor-team-kit/make-pr-easy-to-review/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/make-pr-easy-to-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: make-pr-easy-to-review
+description: Prepare PRs for review by cleaning noisy history, improving PR descriptions, and adding reviewer guidance without changing code behavior. Use for "make this easy to review", "tidy this PR", "clean up commits", or "annotate the diff".
+---
+
+# Make PR Easy to Review
+
+Prepare a PR so a reviewer can quickly understand the intent, important files, and risk. The default goal is reviewability without behavior changes.
+
+## Workflow
+
+1. Resolve the target PR from the user-provided URL or current branch.
+2. Inspect commits, diff size, changed paths, generated files, and PR description.
+3. Identify reviewability issues: noisy commits, stale description, unrelated changes, mixed mechanical and logic changes, missing tests, or unclear reviewer entry points.
+4. Propose a plan before rewriting history or force-pushing.
+5. Apply safe improvements, then verify the tree or diff still matches the intended code.
+
+## History Cleanup
+
+Only rewrite history when the user asks for it or agrees to the plan. Before rewriting:
+
+```bash
+gh pr view <PR> --json title,headRefName,baseRefName,state,commits
+git fetch origin <headRefName> <baseRefName>
+ORIGINAL_TREE=$(git rev-parse origin/<headRefName>^{tree})
+```
+
+Good commit groupings usually follow dependency order:
+
+1. Schema/storage or generated API definitions.
+2. Core logic.
+3. Wiring and integration.
+4. UI or surface behavior.
+5. Tests.
+
+After rewriting, verify content identity:
+
+```bash
+echo "Original tree: $ORIGINAL_TREE"
+echo "Current tree:  $(git rev-parse HEAD^{tree})"
+git diff origin/<headRefName> --stat
+```
+
+Do not push if the tree changed unintentionally.
+
+## Reviewer Guidance
+
+When code behavior should stay untouched, prefer PR description and review notes:
+
+- Add a TL;DR that matches the actual diff.
+- Separate core files from generated or mechanical files.
+- Call out risky behavior changes, migration order, rollout plan, and test coverage.
+- Link issue trackers, dashboards, or design docs when they explain intent.
+
+## Guardrails
+
+- Never hide meaningful behavior changes inside "cleanup".
+- Do not bypass hooks unless the user explicitly asks.
+- If the PR is too large to make reviewable with notes, recommend splitting instead of polishing around the problem.

--- a/agent_fleet/base-kit/cursor-team-kit/new-branch-and-pr/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/new-branch-and-pr/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: new-branch-and-pr
+description: Create a fresh branch, complete work, and open a pull request
+---
+
+# New branch and PR
+
+## Trigger
+
+Starting work that should be shipped through a clean branch and pull request workflow.
+
+## Workflow
+
+1. Ensure the working tree is clean or explicitly handled.
+2. Create a descriptive branch from the latest main.
+3. Complete implementation and tests.
+4. Commit focused changes and push.
+5. Create a concise PR with summary and test notes.
+
+## Guardrails
+
+- Keep branch scope focused on one change set.
+- Include verification notes before requesting review.
+
+## Output
+
+- New branch name
+- PR summary and test notes
+- PR URL

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: pr-review-canvas
+disable-model-invocation: true
+description: Generate an interactive PR review walkthrough as an HTML page. Fetches PR data via gh API, categorizes files into core vs mechanical changes, adds reviewer annotations, and renders diffs with moved-code detection. Use when the user pastes a GitHub PR URL and asks for a review, walkthrough, or summary, or says "review this PR".
+---
+
+# PR Review Canvas
+
+Generate an interactive HTML review of a GitHub PR that reads like a peer walking you through what matters.
+
+## Workflow
+
+### 1. Fetch PR data
+
+Run these `gh api` calls in parallel:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number} --jq '{title, body, user: .user.login, state, additions, deletions, changed_files, base: .base.ref, head: .head.ref}'
+gh api repos/{owner}/{repo}/pulls/{number}/files --paginate --jq '.[] | {filename, status, additions, deletions, patch}'
+gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {user: .user.login, body, path, line}'
+```
+
+### 2. Analyze the PR and write the body HTML
+
+Read the diffs, understand the PR, and write the `<body>` content directly as HTML. You have full creative freedom -- the goal is to explain the PR clearly to a reviewer. Use whatever structure best fits the PR.
+
+**Typical structure** (adapt as needed):
+- Header with title, PR number, author, stats
+- Summary box explaining what the PR does in plain English
+- Core file sections with annotations and diffs
+- Mechanical/boilerplate files collapsed by default
+- Review checklist at the bottom
+
+**But you can also add:**
+- **Pseudocode summaries** for verbose code -- show the algorithm in plain English or short pseudocode, with the real diff collapsed below (use a `.bp-section` card labeled "Show full implementation"). Great when 150 lines of retry/backoff/error-handling code is really just "fetch with exponential backoff and circuit breaker."
+- Diagrams (inline SVG, mermaid via CDN, ASCII art in `<pre>`)
+- Flowcharts showing before/after control flow
+- Tables comparing old vs new behavior
+- Callout boxes for warnings, questions, or gotchas
+- Interactive widgets if they help
+- Anything else that makes the review clearer
+
+**Pseudocode pattern example:**
+```html
+<div class="file-card">
+  <div class="file-hdr" onclick="toggle(this)">
+    <span class="fname">retryClient.ts</span>
+    <div class="fstats"><span class="pill add">+173</span><span class="pill del">&minus;11</span><span class="chev open">&#9654;</span></div>
+  </div>
+  <div class="file-body open">
+    <div class="file-note">
+      <strong>What this does in plain English:</strong>
+      <pre style="margin-top:8px;color:var(--text);font-size:12px;line-height:1.6;">
+fetch(url):
+  if circuit breaker is open → fail fast
+  retry up to N times:
+    try fetch with timeout
+    on success → close circuit breaker, return
+    on retryable error → wait (exponential backoff + jitter)
+    on non-retryable error → throw
+  circuit breaker records failure</pre>
+    </div>
+    <div class="bp-section" style="margin:0;border:0;border-radius:0;">
+      <div class="bp-hdr" onclick="toggleBP(this)">
+        <span>Show full implementation (+173 lines)</span><span class="chev">&#9654;</span>
+      </div>
+      <div class="bp-body"><div data-diff="retryClient"></div></div>
+    </div>
+  </div>
+</div>
+```
+
+### 3. Available CSS classes and JS utilities
+
+Read [styles.css](styles.css) and [renderer.js](renderer.js) from this skill directory. These give you a prebuilt dark-themed toolkit. Inject them into [template.html](template.html) verbatim.
+
+**CSS classes you can use:**
+
+| Class | Purpose |
+|-------|---------|
+| `.header`, `.header h1`, `.header-meta` | Page header |
+| `.pill.add`, `.pill.del`, `.pill.files` | Stat badges (+N, -N, N files) |
+| `.content` | Centered content wrapper (max 900px) |
+| `.summary` | Summary/TL;DR box |
+| `.section-title` | Section heading with bottom border |
+| `.ic` | Inline code reference (mono, blue, dark bg) |
+| `.file-card`, `.file-hdr`, `.file-body` | Collapsible file card (use `onclick="toggle(this)"` on `.file-hdr`) |
+| `.file-note` | Sticky reviewer annotation inside a file card |
+| `.bp-section`, `.bp-hdr`, `.bp-body` | Collapsed boilerplate card (use `onclick="toggleBP(this)"`) |
+| `.bp-note` | Note inside a boilerplate card |
+| `.verdict` | Review checklist box |
+
+**JS functions available:**
+
+| Function | Usage |
+|----------|-------|
+| `toggle(hdrElement)` | Toggle a `.file-body` open/closed |
+| `toggleBP(hdrElement)` | Toggle a `.bp-body` open/closed |
+| `renderDiff(target, diffInput)` | Render a unified diff. `target` can be a DOM element, string ID, or CSS selector. `diffInput` can be a raw patch string OR an array of lines -- both work. Automatically filters imports, collapses whitespace-only changes, detects moved code (blue/purple tint). |
+| `esc(string)` | HTML-escape a string |
+
+**Rendering diffs -- use `data-diff` attributes with auto-discovery.**
+Put `<div data-diff="KEY"></div>` placeholders in your body HTML wherever you want a diff rendered. The renderer finds them automatically after DOM load and fills them from the `<script id="pr-diffs-json" type="application/json">` element in `template.html`.
+
+**CRITICAL: Patch strings can contain `</script>` in addition to newlines, backslashes, and quotes.** Even `json.dumps(...)` is not enough if you paste raw output into executable `<script>` because HTML parsing can terminate the tag early. Never manually embed patch strings in JS/JSON. Instead, use this safe approach:
+
+1. During the fetch step, save patches to a JSON file using `jq` (which handles escaping correctly):
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/files --paginate \
+  --jq '[.[] | {key: (.filename | gsub("[^a-zA-Z0-9]"; "_")), value: (.patch // "")}] | from_entries' \
+  > /tmp/pr-patches-{number}.json
+```
+
+2. During assembly, use Python to safely inject the JSON into `template.html`:
+```bash
+python3 <<'PY'
+import json
+from pathlib import Path
+
+patches = json.loads(Path('/tmp/pr-patches-{number}.json').read_text())
+html = Path('/tmp/pr-review-{number}-body.html').read_text()
+css = Path('styles.css').read_text()
+js = Path('renderer.js').read_text()
+tmpl = Path('template.html').read_text()
+
+# Prevent literal </script> from terminating HTML script tags early.
+safe_json = json.dumps(patches).replace('<', '\\u003c').replace('>', '\\u003e').replace('&', '\\u0026')
+
+out = (
+  tmpl.replace('/* INJECT_CSS */', css)
+      .replace('/* INJECT_JS */', js)
+      .replace('<!-- INJECT_BODY -->', html)
+      .replace('{"__PR_DIFFS_PLACEHOLDER__":true}', safe_json)
+)
+
+Path('/tmp/pr-review-{number}.html').write_text(out)
+PY
+```
+
+This guarantees valid JSON and script-safe HTML embedding. The agent writes body HTML to a temp file, then Python assembles everything safely.
+
+The diff data keys should match the `data-diff` attribute values in the HTML:
+```html
+<div data-diff="path_to_file_ts"></div>
+```
+
+Since renderer.js loads in `<head>`, you can also call `renderDiff(target, lines)` directly from inline `<script>` tags if needed for custom use cases. The function accepts a DOM element, ID string, or CSS selector as `target`, and a string or array as `lines`.
+
+**You're not limited to these.** Add your own inline `<style>` blocks, `<script>` blocks, SVGs, diagrams, or anything else. The prebuilt pieces save time but don't constrain you.
+
+### 4. Assemble and serve
+
+1. Write your body HTML (everything that goes inside `<body>`) to `/tmp/pr-review-{number}-body.html`
+2. Save patches to `/tmp/pr-patches-{number}.json` using the `jq` command from step 3 above
+3. Run the Python assembly script from step 3 above (reads styles.css, renderer.js, template.html from this skill directory, injects body + patches safely, writes final HTML)
+4. Start a local server on a fixed port:
+   ```bash
+   cd /tmp && python3 -m http.server 8432 --bind 127.0.0.1
+   ```
+   Run this backgrounded, then navigate the in-app browser to `http://127.0.0.1:8432/pr-review-{number}.html`.
+
+   **Why a fixed port and `cd /tmp`:** Background shells have no TTY, so Python buffers its startup message ("Serving HTTP on...") indefinitely — using port 0 means you can never read which port was chosen. And `--directory /tmp` works but `cd /tmp` is more robust across Python versions. If port 8432 is taken, try 8433, 8434, etc.
+
+### Diff features (handled automatically by renderer.js)
+
+- Filters out import-only lines
+- Collapses whitespace-only changes into context lines
+- Detects moved code blocks (3+ consecutive lines deleted in one place and added identically elsewhere) -- renders in blue/purple instead of red/green
+- Near-matches (moved + small edit) get a different purple tint
+
+### Style notes
+
+- Dark theme: `#1a1a1a` background, Inter body font, IBM Plex Mono for code
+- Use `var(--warning)` for orange, `var(--success)` for green, `var(--danger)` for red, `var(--accent)` for blue
+- Sticky file headers (`position: sticky; top: 0`) and notes (`top: 35px`) pin while scrolling
+- Core files expanded by default (`.file-body.open`), mechanical files collapsed

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/renderer.js
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/renderer.js
@@ -1,0 +1,170 @@
+function toggle(hdr) {
+  var b = hdr.nextElementSibling, c = hdr.querySelector('.chev');
+  b.classList.toggle('open'); c.classList.toggle('open');
+}
+function toggleBP(hdr) {
+  var b = hdr.nextElementSibling, c = hdr.querySelector('.chev');
+  b.classList.toggle('open'); c.classList.toggle('open');
+}
+
+function isImport(line) {
+  var s = line.replace(/^[+ -]/, '').trim();
+  return s.startsWith('import ') || s.startsWith('import{') || s.startsWith('} from ');
+}
+
+function isWhitespaceOnly(del, add) {
+  return del.replace(/^-/, '').replace(/\s/g, '') === add.replace(/^\+/, '').replace(/\s/g, '');
+}
+
+function esc(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function normWs(s) {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function toLines(input) {
+  if (!input) return [];
+  if (Array.isArray(input)) return input;
+  if (typeof input === 'string') return input.split('\n');
+  return [];
+}
+
+function loadPrDiffs() {
+  var el = document.getElementById('pr-diffs-json');
+  if (!el) return null;
+  try {
+    return JSON.parse(el.textContent || '');
+  } catch (err) {
+    console.error('Failed to parse PR diff JSON payload', err);
+    return null;
+  }
+}
+
+function detectMoves(dels, adds) {
+  var TH = 3;
+  var md = {}, ma = {};
+  for (var di = 0; di < dels.length; di++) {
+    if (md[di]) continue;
+    var db = [di];
+    for (var d2 = di+1; d2 < dels.length && d2-di < 40; d2++) {
+      if (dels[d2].consecutive && !md[d2]) db.push(d2); else break;
+    }
+    if (db.length < TH) continue;
+    var dn = db.map(function(i){ return normWs(dels[i].code); });
+    for (var ai = 0; ai < adds.length; ai++) {
+      if (ma[ai]) continue;
+      var ab = [ai];
+      for (var a2 = ai+1; a2 < adds.length && a2-ai < 40; a2++) {
+        if (adds[a2].consecutive && !ma[a2]) ab.push(a2); else break;
+      }
+      if (ab.length < TH) continue;
+      var an = ab.map(function(i){ return normWs(adds[i].code); });
+      var ml = Math.min(dn.length, an.length), mc = 0;
+      for (var m = 0; m < ml; m++) { if (dn[m] === an[m]) mc++; }
+      if (mc >= TH && mc >= ml * 0.7) {
+        for (var k = 0; k < ml; k++) {
+          md[db[k]] = { exact: dn[k] === an[k] };
+          ma[ab[k]] = { exact: dn[k] === an[k] };
+        }
+        break;
+      }
+    }
+  }
+  return { movedDels: md, movedAdds: ma };
+}
+
+/**
+ * renderDiff(target, diffInput)
+ *   target: DOM element, string ID, or CSS selector
+ *   diffInput: array of diff lines, OR a single string (will be split on \n)
+ */
+function renderDiff(target, diffInput) {
+  var el;
+  if (typeof target === 'string') {
+    el = document.getElementById(target) || document.querySelector(target);
+  } else {
+    el = target;
+  }
+  if (!el) return;
+
+  var lines = toLines(diffInput);
+  if (!lines.length) { el.innerHTML = '<div style="padding:12px;color:#777;font-size:12px;">No diff data</div>'; return; }
+
+  var filtered = lines.filter(function(l) {
+    if (l.startsWith('--- ') || l.startsWith('+++ ') || l.startsWith('@@') || l.startsWith('diff ')) return true;
+    return !isImport(l);
+  });
+
+  var wsOut = [];
+  for (var wi = 0; wi < filtered.length; wi++) {
+    if (filtered[wi].startsWith('-')) {
+      var dr = [filtered[wi]], wj = wi+1;
+      while (wj < filtered.length && filtered[wj].startsWith('-')) { dr.push(filtered[wj]); wj++; }
+      var ar = [], wk = wj;
+      while (wk < filtered.length && filtered[wk].startsWith('+')) { ar.push(filtered[wk]); wk++; }
+      if (dr.length === ar.length && dr.length > 0) {
+        var allWs = true;
+        for (var wc = 0; wc < dr.length; wc++) { if (!isWhitespaceOnly(dr[wc], ar[wc])) { allWs = false; break; } }
+        if (allWs) { for (var wx = 0; wx < ar.length; wx++) wsOut.push(' ' + ar[wx].slice(1)); wi = wk-1; continue; }
+      }
+    }
+    wsOut.push(filtered[wi]);
+  }
+
+  var dels = [], adds = [], parsed = [];
+  var oL = 0, nL = 0, pD = false, pA = false;
+  for (var pi = 0; pi < wsOut.length; pi++) {
+    var line = wsOut[pi];
+    if (line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('diff ')) continue;
+    if (line.startsWith('@@')) {
+      var hm = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)/);
+      if (hm) { oL = parseInt(hm[1]); nL = parseInt(hm[2]); }
+      parsed.push({ type: 'hunk', text: line }); pD = false; pA = false; continue;
+    }
+    if (line.startsWith('+')) {
+      var ae = { type:'add', code:line.slice(1), newLine:nL, consecutive:pA, idx:parsed.length };
+      adds.push(ae); parsed.push(ae); nL++; pA = true; pD = false;
+    } else if (line.startsWith('-')) {
+      var de = { type:'del', code:line.slice(1), oldLine:oL, consecutive:pD, idx:parsed.length };
+      dels.push(de); parsed.push(de); oL++; pD = true; pA = false;
+    } else {
+      var c = line.startsWith(' ') ? line.slice(1) : line;
+      parsed.push({ type:'ctx', code:c, oldLine:oL, newLine:nL }); oL++; nL++; pD = false; pA = false;
+    }
+  }
+
+  var mv = detectMoves(dels, adds);
+  var rows = [];
+  for (var ri = 0; ri < parsed.length; ri++) {
+    var p = parsed[ri];
+    if (p.type === 'hunk') {
+      rows.push('<tr class="diff-hunk"><td class="diff-ln"></td><td class="diff-ln"></td><td class="diff-code">' + esc(p.text) + '</td></tr>');
+    } else if (p.type === 'add') {
+      var ai2 = -1; for (var fa=0;fa<adds.length;fa++) if(adds[fa].idx===p.idx){ai2=fa;break;}
+      var cls = (mv.movedAdds[ai2]) ? (mv.movedAdds[ai2].exact ? 'diff-moved-add' : 'diff-moved-add-edited') : 'diff-add';
+      rows.push('<tr class="'+cls+'"><td class="diff-ln"></td><td class="diff-ln">'+p.newLine+'</td><td class="diff-code">'+esc(p.code)+'</td></tr>');
+    } else if (p.type === 'del') {
+      var di2 = -1; for(var fd=0;fd<dels.length;fd++) if(dels[fd].idx===p.idx){di2=fd;break;}
+      var cls2 = (mv.movedDels[di2]) ? (mv.movedDels[di2].exact ? 'diff-moved-del' : 'diff-moved-del-edited') : 'diff-del';
+      rows.push('<tr class="'+cls2+'"><td class="diff-ln">'+p.oldLine+'</td><td class="diff-ln"></td><td class="diff-code">'+esc(p.code)+'</td></tr>');
+    } else {
+      rows.push('<tr class="diff-ctx"><td class="diff-ln">'+p.oldLine+'</td><td class="diff-ln">'+p.newLine+'</td><td class="diff-code">'+esc(p.code)+'</td></tr>');
+    }
+  }
+  el.innerHTML = '<table class="diff-table"><tbody>' + rows.join('') + '</tbody></table>';
+}
+
+/* Auto-discovery: after DOM loads, find all [data-diff] elements and render diffs from pr-diffs-json. */
+document.addEventListener('DOMContentLoaded', function() {
+  var prDiffs = loadPrDiffs();
+  if (!prDiffs) return;
+  var els = document.querySelectorAll('[data-diff]');
+  for (var i = 0; i < els.length; i++) {
+    var key = els[i].getAttribute('data-diff');
+    if (key && Object.prototype.hasOwnProperty.call(prDiffs, key)) {
+      renderDiff(els[i], prDiffs[key]);
+    }
+  }
+});

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/styles.css
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/styles.css
@@ -1,0 +1,96 @@
+:root {
+  --bg: #1a1a1a;
+  --surface: #222;
+  --surface-raised: #2a2a2a;
+  --border: #333;
+  --text: #bbb;
+  --text-muted: #777;
+  --text-bright: #e5e5e5;
+  --accent: #7aa2f7;
+  --warning: #e0a458;
+  --success: #73b87e;
+  --danger: #e06060;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', -apple-system, sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.header {
+  border-bottom: 1px solid var(--border);
+  padding: 24px 32px 20px;
+}
+.header h1 { font-size: 20px; font-weight: 600; color: var(--text-bright); margin-bottom: 4px; }
+.header-meta { font-size: 12px; color: var(--text-muted); display: flex; gap: 16px; align-items: center; margin-top: 8px; }
+.pill { display: inline-flex; padding: 1px 8px; border-radius: 10px; font-family: 'IBM Plex Mono', monospace; font-size: 11px; font-weight: 500; }
+.pill.add { background: #73b87e22; color: var(--success); }
+.pill.del { background: #e0606022; color: var(--danger); }
+.pill.files { background: #7aa2f722; color: var(--accent); }
+.content { max-width: 900px; margin: 0 auto; padding: 24px 20px 60px; }
+.summary { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 16px 20px; margin-bottom: 28px; font-size: 13px; line-height: 1.6; }
+.summary strong { color: var(--text-bright); }
+.summary ul { margin-top: 8px; padding-left: 18px; }
+.summary li { margin-bottom: 4px; }
+.section-title { font-size: 14px; font-weight: 600; color: var(--text-bright); margin: 28px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+.ic { font-family: 'IBM Plex Mono', monospace; font-size: 11px; background: var(--surface-raised); padding: 1px 5px; border-radius: 3px; color: var(--accent); }
+
+.file-card { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; margin-bottom: 12px; }
+.file-hdr {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 14px; background: var(--surface-raised); border-bottom: 1px solid var(--border);
+  cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 12; border-radius: 6px 6px 0 0;
+}
+.file-hdr:hover { background: #303030; }
+.file-hdr .fname { font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: var(--accent); }
+.file-hdr .fstats { display: flex; gap: 6px; align-items: center; }
+.file-hdr .chev { color: var(--text-muted); transition: transform 0.15s; font-size: 11px; margin-left: 10px; }
+.file-hdr .chev.open { transform: rotate(90deg); }
+.file-body { display: none; }
+.file-body.open { display: block; }
+.file-note {
+  padding: 10px 14px; font-size: 13px; color: var(--text); line-height: 1.55;
+  border-bottom: 1px solid var(--border); background: var(--surface);
+  position: sticky; top: 35px; z-index: 11;
+}
+.file-note strong { color: var(--text-bright); }
+.file-note ul { margin-top: 6px; padding-left: 18px; }
+.file-note li { margin-bottom: 3px; }
+
+.bp-section { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; margin-bottom: 8px; }
+.bp-hdr { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px; cursor: pointer; user-select: none; font-size: 12px; color: var(--text-muted); }
+.bp-hdr:hover { background: var(--surface-raised); }
+.bp-hdr .chev { color: var(--text-muted); transition: transform 0.15s; font-size: 11px; }
+.bp-hdr .chev.open { transform: rotate(90deg); }
+.bp-body { display: none; border-top: 1px solid var(--border); }
+.bp-body.open { display: block; }
+.bp-note { padding: 8px 14px; font-size: 12px; color: var(--text-muted); line-height: 1.5; border-bottom: 1px solid var(--border); background: var(--bg); }
+
+.diff-table { width: 100%; border-collapse: collapse; font-family: 'IBM Plex Mono', monospace; font-size: 12px; line-height: 20px; table-layout: fixed; tab-size: 4; }
+.diff-table td { vertical-align: top; white-space: pre; }
+.diff-ln { width: 40px; min-width: 40px; max-width: 40px; text-align: right; padding: 0 6px 0 0; color: #555; background: var(--surface); user-select: none; }
+.diff-code { padding: 0 12px; color: var(--text); background: var(--bg); overflow-x: auto; }
+tr.diff-add .diff-ln { color: #5a8a5a; background: #1a2a1a; }
+tr.diff-add .diff-code { background: #1a2a1a; color: #c8e6c8; }
+tr.diff-del .diff-ln { color: #8a5a5a; background: #2a1a1a; }
+tr.diff-del .diff-code { background: #2a1a1a; color: #e6c8c8; }
+tr.diff-ctx .diff-ln { background: var(--surface); }
+tr.diff-ctx .diff-code { background: var(--bg); color: var(--text-muted); }
+tr.diff-hunk td { background: var(--surface-raised); color: var(--text-muted); font-size: 11px; padding: 3px 12px; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+tr.diff-hunk .diff-ln { background: var(--surface-raised); }
+tr.diff-moved-del .diff-ln { color: #6a6a8a; background: #1a1a2a; }
+tr.diff-moved-del .diff-code { background: #1a1a2a; color: #a8a8d0; }
+tr.diff-moved-add .diff-ln { color: #6a6a8a; background: #1a1a2a; }
+tr.diff-moved-add .diff-code { background: #1a1a2a; color: #a8a8d0; }
+tr.diff-moved-del-edited .diff-ln { color: #7a6a8a; background: #221a2a; }
+tr.diff-moved-del-edited .diff-code { background: #221a2a; color: #c0a8d0; }
+tr.diff-moved-add-edited .diff-ln { color: #7a6a8a; background: #221a2a; }
+tr.diff-moved-add-edited .diff-code { background: #221a2a; color: #c0a8d0; }
+
+.verdict { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 16px 20px; margin-top: 28px; }
+.verdict h3 { font-size: 14px; font-weight: 600; color: var(--text-bright); margin-bottom: 8px; }
+.verdict ul { padding-left: 18px; }
+.verdict li { font-size: 13px; margin-bottom: 6px; line-height: 1.5; }
+.verdict li strong { color: var(--text-bright); }

--- a/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/template.html
+++ b/agent_fleet/base-kit/cursor-team-kit/pr-review-canvas/template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* INJECT_CSS */
+</style>
+<script>
+/* INJECT_JS */
+</script>
+</head>
+<body>
+<!-- INJECT_BODY -->
+<script id="pr-diffs-json" type="application/json" data-pr-diffs>{"__PR_DIFFS_PLACEHOLDER__":true}</script>
+</body>
+</html>

--- a/agent_fleet/base-kit/cursor-team-kit/review-and-ship/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/review-and-ship/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: review-and-ship
+description: Review the current branch for bugs, intent fit, and test coverage; run or write tests; commit focused work; open or update a PR.
+---
+
+# Review and ship
+
+## Trigger
+
+Reviewing changes before shipping. Close key issues, verify behavior, and open or update a PR.
+
+## Workflow
+
+1. Gather context: diff against base branch, uncommitted changes, recent commits, changed files, and user intent from recent relevant chats if useful.
+2. Run targeted tests for changed behavior. If no focused tests exist, decide whether to add them or document the gap.
+3. Review for correctness, regressions, security, and intent fit. Use parallel subagents for larger diffs.
+4. Fix critical issues before finalizing and re-run affected tests.
+5. Commit selective files with a concise message.
+6. Push branch and open or update a PR.
+
+## Suggested Checks
+
+```bash
+git fetch origin main
+git diff origin/main...HEAD
+git status
+gh pr checks --json name,bucket,state,workflow,link
+```
+
+## Guardrails
+
+- Prioritize correctness, security, and regressions over style-only comments.
+- Keep commits focused and avoid unrelated file changes.
+- If pre-commit checks fail, fix the issues rather than bypassing hooks.
+- Use `gh pr checks` instead of GitHub Actions-only commands when judging PR readiness.
+
+## Output
+
+- Findings summary (critical, warning, note)
+- Tests run and outcomes
+- PR URL

--- a/agent_fleet/base-kit/cursor-team-kit/run-smoke-tests/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/run-smoke-tests/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: run-smoke-tests
+description: Run Playwright smoke tests, debug failures, and verify fixes
+---
+
+# Run smoke tests
+
+## Trigger
+
+Need end-to-end smoke verification before or after changes.
+
+## Workflow
+
+1. Build prerequisites for the target app.
+2. Run the relevant smoke suite or a focused test file.
+3. If failing, inspect traces/logs and isolate the root cause.
+4. Apply a minimal fix and rerun until stable.
+
+## Example Commands
+
+```bash
+# Run full smoke suite
+npm run smoketest
+
+# Run a specific smoke test file
+npm run smoketest -- path/to/test.spec.ts
+
+# Faster iteration when build artifacts are ready
+npm run smoketest-no-compile -- path/to/test.spec.ts
+```
+
+## Guardrails
+
+- Prefer deterministic waits and assertions over brittle timeouts.
+- Re-run passing fixes to reduce flaky false positives.
+- Quarantine tests only when explicitly requested and documented.
+
+## Output
+
+- Test results summary
+- Root cause and fix
+- Remaining flake risk (if any)

--- a/agent_fleet/base-kit/cursor-team-kit/thermo-nuclear-code-quality-review/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: thermo-nuclear-code-quality-review
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+disable-model-invocation: true
+---
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+   - Do not stop at "this could be a bit cleaner."
+   - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+   - Prefer the solution that makes the code feel inevitable in hindsight.
+   - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+   - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+   - Treat this as a strong code-quality smell by default.
+   - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+   - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+   - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+   - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+   - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+   - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+   - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+   - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+   - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+   - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+   - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+   - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+   - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+   - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+   - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+   - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+   - Prefer existing canonical utilities/helpers over bespoke one-offs.
+   - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+   - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+   - If related updates can leave state half-applied, push for a more atomic structure.
+   - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/agent_fleet/base-kit/cursor-team-kit/verify-this/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/verify-this/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: verify-this
+description: Verify a claim with fresh local evidence: restate it falsifiably, capture baseline and treatment, compare artifacts, and return VERIFIED, NOT VERIFIED, or INCONCLUSIVE.
+---
+
+# Verify This
+
+Verification is not a recap. It proves or disproves a specific claim with repeatable evidence.
+
+## When To Use
+
+- The user asks "verify this", "prove it works", "did this fix it", or "show me the evidence".
+- A bug fix needs a before/after repro.
+- A UI, CLI, API, performance, or memory claim needs measurement.
+- A test passes but the user-visible behavior still needs confirmation.
+
+Do not use this for vague claims like "the code is cleaner". Ask for a measurable claim first.
+
+## Workflow
+
+1. Restate the claim in falsifiable form: condition, metric, and threshold.
+2. Pick the smallest local surface that can disprove it.
+3. Capture a baseline from the old state: merge base, parent commit, failing branch, or current broken repro.
+4. Capture treatment from the changed state with the same command, data, warmup, and environment.
+5. Compare raw artifacts: numbers, screenshots, terminal transcripts, HTTP responses, profiles, heap snapshots, or test output.
+6. Return exactly one verdict: `VERIFIED`, `NOT VERIFIED`, or `INCONCLUSIVE`.
+
+## Local Surfaces
+
+- Code behavior: focused unit/integration tests or a minimal repro script.
+- CLI/TUI behavior: `control-cli`, terminal transcript, or demo recording.
+- UI behavior: `control-ui`, screenshots, accessibility snapshots, or browser traces.
+- API behavior: local HTTP/RPC request and response diff.
+- Performance: same-machine baseline/treatment timings or CPU profiles.
+- Memory: heap snapshots before and after the suspected operation.
+
+## Artifact Layout
+
+When safe to write artifacts:
+
+```text
+/tmp/verify-this/<claim-slug>/
+├── claim.md
+├── timeline.md
+├── baseline/
+├── treatment/
+├── diff/
+└── verdict.md
+```
+
+If artifacts may contain sensitive code, prompts, screenshots, HTTP bodies, or heap data, keep only the minimal inline evidence unless the user agrees to disk storage.
+
+## Verdict Rules
+
+- `VERIFIED`: baseline and treatment differ in the predicted direction, by the claimed threshold, with no obvious confound.
+- `NOT VERIFIED`: the behavior is unchanged, moves the wrong way, or misses the threshold.
+- `INCONCLUSIVE`: no valid baseline, noisy signal, failed measurement, or an environment difference invalidates the comparison.
+
+## Output
+
+Use this shape:
+
+```text
+VERIFIED | NOT VERIFIED | INCONCLUSIVE
+Claim: <falsifiable claim>
+
+Evidence:
+<metric/artifact>: baseline=<...>, treatment=<...>, delta=<...>, threshold=<...>
+
+Reasoning:
+<one tight paragraph naming the evidence and any confounds>
+```
+
+Do not soften a negative result. A clear `NOT VERIFIED` is useful.

--- a/agent_fleet/base-kit/cursor-team-kit/weekly-review/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/weekly-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: weekly-review
+description: Produce a weekly synthesis of authored commits with highlights by bugfix, tech debt, and net-new work
+---
+
+# Weekly review
+
+## Trigger
+
+Need a weekly recap of shipped work for status updates, retros, or planning.
+
+## Workflow
+
+1. Determine the current git user email from repo config.
+2. Collect authored commits from the last 7-10 days on the primary branch context.
+3. Exclude merge commits.
+4. Group meaningful changes into 2-5 concise bullets.
+5. Add a short classification paragraph covering:
+   - likely bug fixes
+   - likely tech debt work
+   - likely net-new functionality
+
+## Guardrails
+
+- Keep the recap short and executive-readable.
+- Base claims only on commit history and diffs.
+- If git email is missing, ask the user to set it before proceeding.
+
+## Output
+
+- 2-5 bullet weekly summary
+- Brief classification paragraph (bugfix / tech debt / net-new)

--- a/agent_fleet/base-kit/cursor-team-kit/what-did-i-get-done/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/what-did-i-get-done/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: what-did-i-get-done
+description: Summarize authored commits over a user-specified time period into a concise update
+---
+
+# What did I get done
+
+## Trigger
+
+Need a short, high-signal summary of work completed in a specific time range (for example: yesterday, last 3 days, or last week).
+
+## Workflow
+
+1. Resolve the requested time window into concrete dates.
+2. Read commits authored by the current git user email within that range.
+3. Exclude merge commits and uncommitted changes.
+4. Synthesize the most important shipped changes into a concise status update.
+5. Include the actual date range used in the final summary.
+
+## Guardrails
+
+- Be extremely concise and information-dense.
+- Prioritize substantial behavior or architecture changes.
+- Omit cosmetic-only changes (formatting, imports, minor renames).
+- Do not infer intent or motivation. Describe changes functionally.
+
+## Output
+
+- One short summary suitable for a status update
+- Real date range
+- Optional 2-5 bullets for major changes only

--- a/agent_fleet/base-kit/cursor-team-kit/workflow-from-chats/SKILL.md
+++ b/agent_fleet/base-kit/cursor-team-kit/workflow-from-chats/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: workflow-from-chats
+description: Extract durable working preferences from recent Cursor chats and convert them into skills, rules, or workflow docs. Use when asked to learn preferences, mine feedback, personalize workflows, or generate team/person-specific agent guidance.
+---
+
+# Workflow From Chats
+
+Infer durable working preferences from recent chats. Do not summarize chats; extract reusable workflow guidance.
+
+## Scope
+
+- Default to the last 7 days unless the user asks for a different window.
+- Read parent transcripts and relevant subagent transcripts. Use subagent content as evidence, but cite only parent conversations.
+- Do not expose local transcript paths, secrets, customer data, private chat content, or credentials.
+
+## Workflow
+
+1. State the target workflow or preference surface in one paragraph.
+2. Build an internal transcript inventory: title/topic, parent conversation ID, approximate date, completion state, relevant subagents, and why it may contain preference evidence.
+3. Scan for explicit preferences, corrections, and workflow markers such as "I prefer", "always", "never", "not what I asked", "stop", "review", "PR", "CI", "logs", and "skill".
+4. Extract preference atoms: trigger, workflow step, decision rule, quality bar, stop condition, evidence, and confidence.
+5. Rate confidence as strong, medium, weak, or contradicted.
+6. Cluster by workflow shape rather than transcript: shipping, review, simplification, debugging, capture, communication, delegation, or validation.
+7. Choose the artifact: new skill, skill edit, rule, workflow doc, or no artifact.
+8. Draft only the reusable guidance. Filter anecdotes that will not help future tasks.
+
+## Confidence
+
+- Strong: explicit user preference, workflow-changing correction, repeated parent-chat pattern, or direct request to encode behavior.
+- Medium: accepted workflow, repeated tool/model/validation preference, or subagent consensus that the parent used successfully.
+- Weak: agent-chosen behavior with no user feedback, one ambiguous transcript, or a likely task-specific correction.
+- Contradicted: evidence points in incompatible directions; ask the user before writing files.
+
+## Artifact Choice
+
+- Skill: recurring multi-step workflow with clear triggers.
+- Rule: general behavior that should apply broadly.
+- Workflow doc: useful context that is not reliably triggerable.
+- No artifact: situational, stale, or low-confidence observation.
+
+## Output
+
+Return a concise synthesis first:
+
+- Target workflow.
+- Evidence corpus with parent conversation citations only.
+- Preference profile.
+- Adopt, consider, dismissed.
+- Proposed artifacts.
+- Open questions only if they block writing.

--- a/agent_fleet/base-kit/manifest.yaml
+++ b/agent_fleet/base-kit/manifest.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-synced_at: "2026-05-25T21:11:33Z"
+synced_at: "2026-05-26T01:43:46Z"
 sources:
   superpowers:
     upstream: https://github.com/obra/superpowers
@@ -7,9 +7,9 @@ sources:
     license: MIT
   pstack:
     upstream: https://github.com/cursor/plugins/tree/main/pstack
-    ref: 11ecc12a3ffc037b4ef3b64de2be449668e8afc7
+    ref: a9e675642ea4297553a4d8c23f5d8a5b004f6626
     license: MIT
-  deslop:
-    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills/deslop
-    ref: 11ecc12a3ffc037b4ef3b64de2be449668e8afc7
+  cursor-team-kit:
+    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills
+    ref: a9e675642ea4297553a4d8c23f5d8a5b004f6626
     license: MIT

--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -611,6 +611,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     learn_p.set_defaults(func=cmd_learn)
 
+    from agent_fleet.workstreams.cli import register_workstream_commands
+
+    register_workstream_commands(sub)
+
     args = parser.parse_args(argv)
     return args.func(args)
 

--- a/agent_fleet/code_review/fix.py
+++ b/agent_fleet/code_review/fix.py
@@ -90,11 +90,7 @@ def _resolve_fix_equip(
         title=task.title,
         equip=task.equip,
     )
-    run_id = (
-        f"{parent_run_id}-fix-{attempt}"
-        if parent_run_id
-        else f"code-review-fix-{attempt}"
-    )
+    run_id = f"{parent_run_id}-fix-{attempt}" if parent_run_id else f"code-review-fix-{attempt}"
     return resolve_dispatch_equip(fix_task, fleet_config, repo, run_id=run_id)
 
 
@@ -138,12 +134,18 @@ def run_fix_phase(
         task_heading="Task",
         task_body="You are fixing issues found during an automated code review pipeline.",
         context=task.context.strip() or "(none)",
+        extra_instructions=persona.extra_instructions,
+        allowed_paths=persona.allowed_paths,
         extra_sections=[
             ("Original task", task.goal.strip()),
             ("Review feedback", review_block or "(none)"),
             ("Verify failures", verify_block or "(none)"),
             ("Instructions", instructions),
         ],
+        closing_instruction=(
+            "Apply the fixes in the workspace. Return a concise summary of what you "
+            "changed and any verify commands you ran."
+        ),
     ).full
 
     result = backend.run(

--- a/agent_fleet/code_review/fix.py
+++ b/agent_fleet/code_review/fix.py
@@ -6,11 +6,17 @@ import textwrap
 from typing import TYPE_CHECKING, Any
 
 from agent_fleet.agent_mode import parse_agent_mode
+from agent_fleet.config import load_fleet_config
+from agent_fleet.hooks import FleetTask
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
+from agent_fleet.prompts.agent import build_agent_prompt
+from agent_fleet.repo import merge_repo_into_fleet_config
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from agent_fleet.hooks import FleetTask, LLMBackend
+    from agent_fleet.hooks import LLMBackend
+    from agent_fleet.level_up.models import DispatchEquip
     from agent_fleet.personas import YamlPersonaResolver
     from agent_fleet.repo import RepoConfig
 
@@ -60,6 +66,38 @@ def _verify_feedback(phase_results: list[dict[str, Any]]) -> str:
     return "\n\n".join(lines)
 
 
+def _resolve_fix_equip(
+    *,
+    task: FleetTask,
+    fix_persona: str,
+    repo: RepoConfig | None,
+    attempt: int,
+) -> DispatchEquip:
+    if fix_persona == task.persona and task.equip is not None:
+        return task.equip
+
+    fleet_config = load_fleet_config()
+    if repo is not None:
+        fleet_config = merge_repo_into_fleet_config(fleet_config, repo)
+
+    parent_run_id = task.equip.parent_run_id if task.equip else None
+    fix_task = FleetTask(
+        goal=task.goal,
+        context=task.context,
+        persona=fix_persona,
+        workspace=task.workspace,
+        pipeline=task.pipeline,
+        title=task.title,
+        equip=task.equip,
+    )
+    run_id = (
+        f"{parent_run_id}-fix-{attempt}"
+        if parent_run_id
+        else f"code-review-fix-{attempt}"
+    )
+    return resolve_dispatch_equip(fix_task, fleet_config, repo, run_id=run_id)
+
+
 def run_fix_phase(
     *,
     backend: LLMBackend,
@@ -76,33 +114,37 @@ def run_fix_phase(
     persona = resolver.load(fix_persona)
     review_block = _review_feedback(phase_results)
     verify_block = _verify_feedback(phase_results)
+    equip = _resolve_fix_equip(
+        task=task,
+        fix_persona=fix_persona,
+        repo=repo,
+        attempt=attempt,
+    )
 
     verify_commands = ""
     if repo and repo.verify_commands:
         verify_commands = "\n".join(f"- `{cmd}`" for cmd in repo.verify_commands)
 
-    prompt = textwrap.dedent(f"""\
-        You are fixing issues found during an automated code review pipeline.
-
-        ## Original task
-        {task.goal.strip()}
-
-        ## Context
-        {task.context.strip() or "(none)"}
-
-        ## Review feedback
-        {review_block or "(none — focus on verify failures below)"}
-
-        ## Verify failures
-        {verify_block or "(none)"}
-
-        ## Instructions
+    instructions = textwrap.dedent(f"""\
         1. Fix every valid blocking issue above with minimal diffs.
         2. Do NOT commit or push — the orchestrator handles git.
         3. Run these verify commands before finishing:
-        {verify_commands or "- (none configured)"}
+        {verify_commands or "- (none)"}
         4. Fix attempt {attempt} — address root causes, not symptoms.
     """)
+
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body="You are fixing issues found during an automated code review pipeline.",
+        context=task.context.strip() or "(none)",
+        extra_sections=[
+            ("Original task", task.goal.strip()),
+            ("Review feedback", review_block or "(none)"),
+            ("Verify failures", verify_block or "(none)"),
+            ("Instructions", instructions),
+        ],
+    ).full
 
     result = backend.run(
         prompt,

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -28,6 +28,7 @@ from agent_fleet.redispatch import dispatch_with_retry
 from agent_fleet.repo import RepoConfig, find_repo_config, merge_repo_into_fleet_config
 from agent_fleet.runner import run_full_pipeline
 from agent_fleet.verify_core import is_git_repo
+from agent_fleet.worktree import maybe_commit_recoverable_worktree, should_keep_task_worktree
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -53,7 +54,8 @@ def _normalize_tasks(
     workspace: str | None,
     pipeline: str | None,
     tasks: list[dict[str, object]] | None,
-) -> list[FleetTask]:
+) -> tuple[list[FleetTask], list[str | None]]:
+    base_branches: list[str | None] = []
     if tasks:
         normalized: list[FleetTask] = []
         for entry in tasks:
@@ -62,6 +64,7 @@ def _normalize_tasks(
             task_goal = str(entry.get("goal") or "").strip()
             if not task_goal:
                 continue
+            base_branches.append(_optional_entry_str(entry.get("base_branch"), None))
             normalized.append(
                 FleetTask(
                     goal=task_goal,
@@ -72,7 +75,7 @@ def _normalize_tasks(
                 )
             )
         if normalized:
-            return normalized
+            return normalized, base_branches
     if goal and goal.strip():
         return [
             FleetTask(
@@ -82,8 +85,39 @@ def _normalize_tasks(
                 workspace=workspace,
                 pipeline=pipeline,
             )
-        ]
+        ], [None]
     raise ValueError("Provide either 'goal' (single task) or 'tasks' (batch).")
+
+
+def _scope_prefixes_for_persona(repo: RepoConfig, persona: str) -> frozenset[str]:
+    allowlist = repo.persona_scope_allowlist.get(persona)
+    if not allowlist:
+        return frozenset()
+    return frozenset(str(prefix).rstrip("/") for prefix in allowlist)
+
+
+def _scope_prefixes_overlap(a: str, b: str) -> bool:
+    return a == b or a.startswith(f"{b}/") or b.startswith(f"{a}/")
+
+
+def _warn_parallel_scope_overlap(repo: RepoConfig, tasks: list[FleetTask]) -> None:
+    """Log when parallel batch personas share scope allowlist prefixes."""
+    personas = [task.persona for task in tasks]
+    overlaps: list[str] = []
+    for i, persona_a in enumerate(personas):
+        prefixes_a = _scope_prefixes_for_persona(repo, persona_a)
+        for persona_b in personas[i + 1 :]:
+            prefixes_b = _scope_prefixes_for_persona(repo, persona_b)
+            for prefix_a in prefixes_a:
+                for prefix_b in prefixes_b:
+                    if _scope_prefixes_overlap(prefix_a, prefix_b):
+                        overlaps.append(f"{persona_a} ↔ {persona_b} (prefix {prefix_a!r})")
+                        break
+    if overlaps:
+        logger.warning(
+            "Parallel batch may collide on shared persona scope prefixes: %s",
+            "; ".join(overlaps[:5]),
+        )
 
 
 class FleetDispatcher:
@@ -340,6 +374,7 @@ class FleetDispatcher:
         batch_size: int = 1,
         same_workspace_tasks: int = 1,
         handoff: HandoffNote | None = None,
+        base_branch: str | None = None,
     ) -> FleetTaskResult:
         start = time.monotonic()
         fleet_log = FleetLogger.for_dispatch(
@@ -410,6 +445,7 @@ class FleetDispatcher:
                     batch_size=batch_size,
                     same_workspace_tasks=same_workspace_tasks,
                     worktree_lock=self._worktree_lock,
+                    base_branch=base_branch,
                 )
                 if wt_error:
                     return FleetTaskResult(
@@ -515,13 +551,18 @@ class FleetDispatcher:
                         pr_loop_status=pr_loop_status,
                     )
 
-                keep_worktree = result.status in {"completed", "merged"} or (
-                    code_review_cfg is not None
-                    and code_review_cfg.auto_push
-                    and task_workspace is not None
-                    and task_workspace.isolated
+                keep_worktree = should_keep_task_worktree(
+                    result.status,
+                    auto_push=bool(code_review_cfg and code_review_cfg.auto_push),
+                    isolated=bool(task_workspace and task_workspace.isolated),
+                    has_changes=bool(result.changed_files or result.files_modified),
                 )
                 if task_workspace is not None:
+                    maybe_commit_recoverable_worktree(
+                        task_workspace,
+                        result.status,
+                        goal=task.goal,
+                    )
                     task_workspace.teardown(keep=keep_worktree)
                 return result
             except Exception as exc:
@@ -554,7 +595,7 @@ class FleetDispatcher:
         pipeline: str | None = None,
         tasks: list[dict[str, object]] | None = None,
     ) -> list[FleetTaskResult]:
-        normalized = _normalize_tasks(
+        normalized, base_branches = _normalize_tasks(
             goal=goal,
             context=context,
             persona=persona,
@@ -569,6 +610,11 @@ class FleetDispatcher:
 
         batch_size = len(normalized)
         workspace_counts = self._workspace_task_counts(normalized)
+
+        if batch_size > 1:
+            first_repo = find_repo_config(self._resolve_workspace(normalized[0]))
+            if first_repo is not None:
+                _warn_parallel_scope_overlap(first_repo, normalized)
 
         if batch_size == 1:
             task = normalized[0]
@@ -598,6 +644,7 @@ class FleetDispatcher:
                     task,
                     batch_size=batch_size,
                     same_workspace_tasks=workspace_counts[self._workspace_key(task)],
+                    base_branch=base_branches[idx] if idx < len(base_branches) else None,
                 ): idx
                 for idx, task in enumerate(normalized)
             }

--- a/agent_fleet/dispatcher_task.py
+++ b/agent_fleet/dispatcher_task.py
@@ -46,6 +46,7 @@ def prepare_task_workspace_if_needed(
     batch_size: int,
     same_workspace_tasks: int,
     worktree_lock: threading.Lock,
+    base_branch: str | None = None,
 ) -> tuple[Path, TaskWorkspace | None, str | None]:
     """Return (run_workspace, task_workspace, error_message)."""
     force_parallel = batch_size > 1 and same_workspace_tasks > 1
@@ -72,6 +73,7 @@ def prepare_task_workspace_if_needed(
                 git_repo,
                 task_index=task_index,
                 force_isolation=force_parallel,
+                base_branch=base_branch,
             )
     except RuntimeError as exc:
         return workspace, None, str(exc)

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -1,4 +1,9 @@
-"""Resolve dispatch equip: loadouts, overlays, dynamic skills, journaling."""
+"""Resolve dispatch equip: loadouts, overlays, dynamic skills, journaling.
+
+Call :func:`resolve_dispatch_equip` once per dispatch (dispatcher, PR loop, fix phase
+when ``fix_persona != task.persona``). Reuse ``task.equip`` on the execute and
+code-review fix fast paths when the persona matches.
+"""
 
 from __future__ import annotations
 

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -7,6 +7,7 @@ code-review fix fast paths when the persona matches.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agent_fleet.level_up.compaction import touch_overlay_rules
@@ -40,12 +41,12 @@ def _empty_loadout(persona: str) -> dict[str, Any]:
 def _resolve_persona_loadout(
     persona: str,
     *,
-    personas_dir: str | None = None,
+    personas_dir: Path | str | None = None,
 ) -> tuple[dict[str, Any], str]:
     """Return loadout dict and display name; markdown-only repos get an empty loadout."""
     kwargs: dict[str, Any] = {}
     if personas_dir is not None:
-        kwargs["personas_dir"] = personas_dir
+        kwargs["personas_dir"] = Path(personas_dir) if isinstance(personas_dir, str) else personas_dir
     try:
         loadout = load_loadout(persona, **kwargs)
     except FileNotFoundError:

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -38,9 +38,11 @@ def resolve_dispatch_equip(
     run_id: str | None = None,
 ) -> DispatchEquip:
     """Pick execute/review skill slots and compose body for one dispatch."""
-    del fleet_config  # reserved for fleet-wide equip policy
     persona = task.persona or "coder"
-    loadout = load_loadout(persona)
+    personas_dir = fleet_config.personas_dir
+    if repo is not None and repo.personas_dir is not None:
+        personas_dir = repo.personas_dir
+    loadout = load_loadout(persona, personas_dir=personas_dir)
     loadout_name = str(loadout.get("name") or persona)
 
     repo_key_value = repo_key(

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -11,6 +11,7 @@ from agent_fleet.level_up.models import DispatchEquip
 from agent_fleet.level_up.overlay import compose_overlay_text, load_overlay
 from agent_fleet.level_up.paths import FLEET_TIER, repo_key
 from agent_fleet.skills_lib import (
+    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
     compose_persona_body,
     load_loadout,
@@ -62,6 +63,15 @@ def resolve_dispatch_equip(
         and SYSTEMATIC_DEBUGGING_SKILL not in loadout_execute
     ):
         extra_execute.append(SYSTEMATIC_DEBUGGING_SKILL)
+
+    if repo is not None and repo.pr_loop is not None and repo.pr_loop.enabled:
+        for skill_id in PR_LOOP_EXECUTE_SKILLS:
+            if (
+                skill_exists_in_base_kit(skill_id)
+                and skill_id not in loadout_execute
+                and skill_id not in extra_execute
+            ):
+                extra_execute.append(skill_id)
 
     skill_slots_execute = [*loadout_execute, *extra_execute]
     skill_slots_review = loadout_review_skill_ids(loadout)

--- a/agent_fleet/personas.py
+++ b/agent_fleet/personas.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import yaml
 
-from agent_fleet.config import FleetConfig, PersonaSpec
+from agent_fleet.config import FleetConfig, PersonaSpec, load_fleet_config
 from agent_fleet.hooks import Persona
 from agent_fleet.level_up.models import LevelUpOverlay
 from agent_fleet.level_up.overlay import compose_overlay_text, load_overlay
@@ -222,3 +222,50 @@ class YamlPersonaResolver:
             extra_instructions=spec.extra_instructions,
             mcp_servers=list(spec.mcp_servers),
         )
+
+
+def persona_prompt_resolves(_name: str, spec: PersonaSpec, cfg: FleetConfig) -> bool:
+    """Return True when the persona prompt resolves to an existing markdown or skill file."""
+    try:
+        _resolve_prompt_path(spec, cfg)
+    except ValueError:
+        return False
+    return True
+
+
+def prune_fleet_yaml_personas(path: Path) -> list[str]:
+    """Remove fleet.yaml persona entries whose prompt .md is missing from all search dirs.
+
+    Returns the list of pruned persona names. Rewrites *path* only when entries are removed.
+    """
+    if not path.is_file():
+        return []
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        return []
+    personas_raw = raw.get("personas")
+    if not isinstance(personas_raw, dict) or not personas_raw:
+        return []
+
+    cfg = load_fleet_config(path)
+    pruned: list[str] = []
+    kept: dict[str, Any] = {}
+    for name, entry in personas_raw.items():
+        if isinstance(entry, str):
+            spec = PersonaSpec(prompt=entry)
+        elif isinstance(entry, dict):
+            spec = PersonaSpec(prompt=str(entry.get("prompt") or f"{name}.md"))
+        else:
+            kept[name] = entry
+            continue
+        if persona_prompt_resolves(name, spec, cfg):
+            kept[name] = entry
+        else:
+            pruned.append(name)
+
+    if not pruned:
+        return []
+
+    raw["personas"] = kept
+    path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return pruned

--- a/agent_fleet/personas.py
+++ b/agent_fleet/personas.py
@@ -23,6 +23,14 @@ _DEFAULT_ALLOWED_TOOLS = ["read_file", "write_file", "run_command"]
 _PACKAGE_PERSONAS = Path(__file__).resolve().parent / "personas"
 
 
+def _persona_search_dirs(cfg: FleetConfig) -> tuple[Path, ...]:
+    """Search repo/local personas_dir first, then bundled package personas."""
+    primary = cfg.personas_dir
+    if primary.resolve() == _PACKAGE_PERSONAS.resolve():
+        return (primary,)
+    return (primary, _PACKAGE_PERSONAS)
+
+
 def read_persona_body(persona: Persona) -> str:
     """Return the composed persona prompt (loadout + overlays) or prompt file contents."""
     if persona.body is not None:
@@ -31,23 +39,33 @@ def read_persona_body(persona: Persona) -> str:
 
 
 def load_loadout(name: str, *, personas_dir: Path | None = None) -> dict[str, Any] | None:
-    base = personas_dir or _PACKAGE_PERSONAS
-    path = base / f"{name}.loadout.yaml"
-    if not path.is_file():
-        return None
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError(f"Invalid loadout {path}: expected mapping")
-    return data
+    bases: list[Path] = []
+    if personas_dir is not None:
+        bases.append(personas_dir)
+    if personas_dir is None or personas_dir.resolve() != _PACKAGE_PERSONAS.resolve():
+        bases.append(_PACKAGE_PERSONAS)
+    for base in bases:
+        path = base / f"{name}.loadout.yaml"
+        if not path.is_file():
+            continue
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid loadout {path}: expected mapping")
+        return data
+    return None
 
 
-def _loadout_stub_path(loadout: dict[str, Any], personas_dir: Path) -> Path | None:
+def _loadout_stub_path(
+    loadout: dict[str, Any],
+    personas_dirs: tuple[Path, ...],
+) -> Path | None:
     stub = loadout.get("stub")
     if not stub:
         return None
-    stub_path = personas_dir / str(stub)
-    if stub_path.is_file():
-        return stub_path.resolve()
+    for personas_dir in personas_dirs:
+        stub_path = personas_dir / str(stub)
+        if stub_path.is_file():
+            return stub_path.resolve()
     return None
 
 
@@ -80,20 +98,22 @@ def _resolve_prompt_path(spec: PersonaSpec, cfg: FleetConfig) -> Path:
         return direct
     if direct.exists():
         return direct.resolve()
-    in_personas = cfg.personas_dir / prompt
-    if in_personas.exists():
-        return in_personas.resolve()
-    if not prompt.endswith(".md"):
-        with_suffix = cfg.personas_dir / f"{prompt}.md"
-        if with_suffix.exists():
-            return with_suffix.resolve()
+    for personas_dir in _persona_search_dirs(cfg):
+        in_personas = personas_dir / prompt
+        if in_personas.exists():
+            return in_personas.resolve()
+        if not prompt.endswith(".md"):
+            with_suffix = personas_dir / f"{prompt}.md"
+            if with_suffix.exists():
+                return with_suffix.resolve()
     if spec.skill:
         skill_path = find_skill_path(spec.skill, cfg.skill_dirs)
         if skill_path:
             return skill_path
+    searched = ", ".join(str(path) for path in _persona_search_dirs(cfg))
     raise ValueError(
         f"Persona prompt not found: {prompt!r} "
-        f"(searched personas_dir={cfg.personas_dir}, skill={spec.skill!r})"
+        f"(searched personas_dirs=[{searched}], skill={spec.skill!r})"
     )
 
 
@@ -119,10 +139,12 @@ class YamlPersonaResolver:
 
     def list_personas(self) -> list[str]:
         names = set(self._config.personas.keys())
-        if self._config.personas_dir.exists():
-            for path in sorted(self._config.personas_dir.glob("*.md")):
+        for personas_dir in _persona_search_dirs(self._config):
+            if not personas_dir.exists():
+                continue
+            for path in sorted(personas_dir.glob("*.md")):
                 names.add(path.stem)
-            for path in sorted(self._config.personas_dir.glob("*.loadout.yaml")):
+            for path in sorted(personas_dir.glob("*.loadout.yaml")):
                 names.add(path.stem.replace(".loadout", ""))
         return sorted(names)
 
@@ -148,7 +170,7 @@ class YamlPersonaResolver:
                 repo_key,
                 name,
             )
-            stub_path = _loadout_stub_path(loadout, self._config.personas_dir)
+            stub_path = _loadout_stub_path(loadout, _persona_search_dirs(self._config))
             stub_text = (
                 stub_path.read_text(encoding="utf-8").strip() if stub_path is not None else None
             )

--- a/agent_fleet/personas/coder.loadout.yaml
+++ b/agent_fleet/personas/coder.loadout.yaml
@@ -1,15 +1,18 @@
 schema_version: 1
 stub: coder.md
+# Default execute skills: Cursor pstack (https://github.com/cursor/plugins/tree/main/pstack)
 skills:
   execute:
-    - superpowers/test-driven-development
-    - superpowers/verification-before-completion
-    - superpowers/using-git-worktrees
     - pstack/tdd
     - pstack/principle-prove-it-works
-    - pstack/principle-minimize-reader-load
-    - pstack/principle-boundary-discipline
     - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
 pipeline_skills:
   code_review:
     review: []

--- a/agent_fleet/personas/explorer.loadout.yaml
+++ b/agent_fleet/personas/explorer.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: explorer.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/why
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/personas/pr-analyzer.loadout.yaml
+++ b/agent_fleet/personas/pr-analyzer.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: pr-analyzer.md
+skills:
+  execute:
+    - pstack/interrogate
+    - pstack/how
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/personas/product-scout.loadout.yaml
+++ b/agent_fleet/personas/product-scout.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: product-scout.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/reflect
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/personas/reviewer.loadout.yaml
+++ b/agent_fleet/personas/reviewer.loadout.yaml
@@ -2,11 +2,10 @@ schema_version: 1
 stub: reviewer.md
 skills:
   execute:
-    - superpowers/receiving-code-review
-    - superpowers/requesting-code-review
     - pstack/interrogate
     - pstack/reflect
 pipeline_skills:
   code_review:
     review:
+      - pstack/unslop
       - cursor-team-kit/deslop

--- a/agent_fleet/personas/tech-scout.loadout.yaml
+++ b/agent_fleet/personas/tech-scout.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: tech-scout.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/figure-it-out
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -8,6 +8,7 @@ from agent_fleet.agent_mode import parse_agent_mode
 from agent_fleet.contracts.review import ReviewVerdict
 from agent_fleet.personas import read_persona_body
 from agent_fleet.pr_review.runner import run_pr_review
+from agent_fleet.prompts.agent import build_agent_prompt
 from agent_fleet.reviewer import aggregate_verdict
 from agent_fleet.reviewer import review as structured_review
 from agent_fleet.scope import files_outside_allowed_paths
@@ -43,24 +44,23 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    parts = [
-        "# Persona",
-        body.strip(),
-    ]
+    extra_sections: list[tuple[str, str]] = []
     if persona.extra_instructions.strip():
-        parts.extend(["", "# Additional Instructions", persona.extra_instructions.strip()])
+        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
     if persona.allowed_paths:
         paths = ", ".join(persona.allowed_paths)
-        parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
-    parts.extend(["", "# Task", task.goal.strip()])
-    if task.context.strip():
-        parts.extend(["", "# Context", task.context.strip()])
-    parts.append("")
-    parts.append(
-        "Execute this task in the workspace. Return a concise summary of what you "
+        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
+    prompt = build_agent_prompt(
+        persona_body=body,
+        task_heading="Task",
+        task_body=task.goal,
+        context=task.context,
+        extra_sections=extra_sections or None,
+    )
+    return prompt.full + (
+        "\n\nExecute this task in the workspace. Return a concise summary of what you "
         "did, files changed, and any follow-up needed."
     )
-    return "\n".join(parts)
 
 
 def run_execute_phase(

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -44,23 +44,18 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    extra_sections: list[tuple[str, str]] = []
-    if persona.extra_instructions.strip():
-        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
-    if persona.allowed_paths:
-        paths = ", ".join(persona.allowed_paths)
-        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
-    prompt = build_agent_prompt(
+    return build_agent_prompt(
         persona_body=body,
         task_heading="Task",
         task_body=task.goal,
         context=task.context,
-        extra_sections=extra_sections or None,
-    )
-    return prompt.full + (
-        "\n\nExecute this task in the workspace. Return a concise summary of what you "
-        "did, files changed, and any follow-up needed."
-    )
+        extra_instructions=persona.extra_instructions,
+        allowed_paths=persona.allowed_paths,
+        closing_instruction=(
+            "Execute this task in the workspace. Return a concise summary of what you "
+            "did, files changed, and any follow-up needed."
+        ),
+    ).full
 
 
 def run_execute_phase(

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -58,6 +58,39 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
     ).full
 
 
+def _build_legacy_review_prompt(
+    persona: Persona,
+    task: FleetTask,
+    implementation_summary: str,
+) -> str:
+    review_context = task.context
+    skill_append = _review_skill_prompt_append(task)
+    if skill_append:
+        review_context = (
+            f"{skill_append}\n\n{review_context}".strip()
+            if review_context.strip()
+            else skill_append
+        )
+    return build_agent_prompt(
+        persona_body=read_persona_body(persona),
+        task_heading="Original Task",
+        task_body=task.goal,
+        context=review_context,
+        extra_instructions=persona.extra_instructions,
+        allowed_paths=persona.allowed_paths,
+        extra_sections=[
+            (
+                "Implementation Summary",
+                implementation_summary.strip() or "(no implementation output to review)",
+            ),
+        ],
+        closing_instruction=(
+            "Review the implementation. List issues by severity (blocker/major/minor), "
+            "note missing tests, and give a clear verdict: APPROVE or REQUEST_CHANGES."
+        ),
+    ).full
+
+
 def run_execute_phase(
     *,
     backend: LLMBackend,
@@ -456,28 +489,7 @@ def _legacy_review_phase(
     session: LLMSession | None = None,
 ) -> dict[str, Any]:
     persona = resolver.load(reviewer_persona)
-    body = read_persona_body(persona)
-    prompt_parts = [
-        "# Persona",
-        body.strip(),
-    ]
-    skill_append = _review_skill_prompt_append(task)
-    if skill_append:
-        prompt_parts.extend(["", skill_append])
-    prompt_parts.extend(
-        [
-            "",
-            "# Original Task",
-            task.goal.strip(),
-            "",
-            "# Implementation Summary",
-            implementation_summary.strip() or "(no implementation output to review)",
-            "",
-            "Review the implementation. List issues by severity (blocker/major/minor), "
-            "note missing tests, and give a clear verdict: APPROVE or REQUEST_CHANGES.",
-        ]
-    )
-    prompt = "\n".join(prompt_parts)
+    prompt = _build_legacy_review_prompt(persona, task, implementation_summary)
     if session is not None:
         result = session.send(
             prompt,

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING
 from agent_fleet.agent_mode import parse_agent_mode
 from agent_fleet.backends import make_backend
 from agent_fleet.config import FleetConfig, load_fleet_config
+from agent_fleet.hooks import FleetTask
 from agent_fleet.observability.fleet_logger import FleetLogger
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.pr_loop import github_ops
 from agent_fleet.pr_loop.github_ops import CommitPushResult
@@ -22,6 +24,7 @@ from agent_fleet.pr_loop.review_parse import (
     has_blocking_findings,
     parse_review_risk,
 )
+from agent_fleet.prompts.agent import build_agent_prompt
 from agent_fleet.repo import RepoConfig, merge_repo_into_fleet_config
 from agent_fleet.scope import files_outside_allowed_paths
 from agent_fleet.state import (
@@ -322,26 +325,53 @@ def address_review_findings(
 
     pr_files_block = "\n".join(f"- `{path}`" for path in pr_files) or "- (unknown)"
 
-    prompt = textwrap.dedent(f"""\
-        The PR analyzer posted review findings on PR #{pr_number}. Address every
-        blocking finding in the review comment below.
+    fix_task = FleetTask(
+        goal=f"Fix PR #{pr_number} review findings",
+        context=f"branch={branch}",
+        persona=fix_persona_name,
+        workspace=str(worktree),
+    )
+    equip = resolve_dispatch_equip(
+        fix_task,
+        fleet_config,
+        repo,
+        run_id=f"pr-loop-{pr_number}",
+    )
 
-        ## Review
-        {review_body}
+    extra_sections: list[tuple[str, str]] = [
+        ("Review", review_body),
+        ("PR changed files (only edit these or subpaths)", pr_files_block),
+    ]
+    if commit_failure_block.strip():
+        extra_sections.append(
+            (
+                "Previous commit/push failure (must fix before finishing)",
+                commit_failure_block.strip(),
+            )
+        )
 
-        ## PR changed files (only edit these or subpaths)
-        {pr_files_block}
-        {commit_failure_block}
-        ## Instructions
+    instructions_body = textwrap.dedent(f"""\
         1. Read each finding and fix valid issues in the relevant files above.
         2. Do NOT edit files outside this PR's changed paths.
         3. Run verify commands before finishing:
-        {verify_block or "- (none configured)"}
+        {verify_block or "- (none)"}
         4. Pre-commit and commit preflight must pass (same gates as git commit):
-        {preflight_block or verify_block or "- pre-commit hooks on changed files (automatic)"}
+        {preflight_block or verify_block or "- (none)"}
         5. Do NOT commit or push — the orchestrator commits after this phase.
         6. If a finding is a false positive, note it but do not change code for it.
     """)
+    extra_sections.append(("Instructions", instructions_body))
+
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body=(
+            f"The PR analyzer posted review findings on PR #{pr_number}. "
+            "Address every blocking finding in the review comment below."
+        ),
+        context=f"branch={branch}",
+        extra_sections=extra_sections,
+    ).full
 
     logger.info(
         "Review fix PR #%s persona=%s worktree=%s pr_files=%d",
@@ -440,24 +470,49 @@ def attempt_ci_fix(
     verify_block = "\n".join(f"- `{cmd}`" for cmd in repo.verify_commands) or "- (none)"
     failure_block = ""
     if commit_error_context:
-        failure_block = textwrap.dedent(f"""
-
-        ## Previous commit/push failure
-        ```
-        {commit_error_context[:6000]}
-        ```
+        failure_block = textwrap.dedent(f"""\
+            ```
+            {commit_error_context[:6000]}
+            ```
         """)
-    prompt = textwrap.dedent(f"""\
+
+    fix_task = FleetTask(
+        goal=f"Fix CI failures on PR #{pr_number}",
+        context=(
+            f"branch={branch}; failed_checks={', '.join(failed_checks)}; ci_fix"
+        ),
+        persona=fix_persona_name,
+        workspace=str(worktree),
+    )
+    equip = resolve_dispatch_equip(
+        fix_task,
+        fleet_config,
+        repo,
+        run_id=f"pr-loop-{pr_number}",
+    )
+
+    extra_sections: list[tuple[str, str]] = []
+    if failure_block.strip():
+        extra_sections.append(("Previous commit/push failure", failure_block.strip()))
+
+    task_body = textwrap.dedent(f"""\
         CI failed on PR #{pr_number}. Fix the failures caused by this branch.
 
         Failed checks: {", ".join(failed_checks)}
-        {failure_block}
+
         Verify commands:
         {verify_block}
 
         Do NOT commit or push — the orchestrator commits after this phase.
         Do NOT weaken CI workflows to make checks pass.
     """)
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body=task_body,
+        context=f"branch={branch}; ci_fix",
+        extra_sections=extra_sections,
+    ).full
     logger.info(
         "CI fix PR #%s persona=%s worktree=%s checks=%s",
         pr_number,

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -478,9 +478,7 @@ def attempt_ci_fix(
 
     fix_task = FleetTask(
         goal=f"Fix CI failures on PR #{pr_number}",
-        context=(
-            f"branch={branch}; failed_checks={', '.join(failed_checks)}; ci_fix"
-        ),
+        context=(f"branch={branch}; failed_checks={', '.join(failed_checks)}; ci_fix"),
         persona=fix_persona_name,
         workspace=str(worktree),
     )

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt builders for fleet agent dispatch."""
+
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+
+__all__ = ["AgentPrompt", "build_agent_prompt"]

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,4 +1,4 @@
-"""Prompt builders for fleet agent dispatch."""
+"""Shared prompt builders for agent dispatch paths."""
 
 from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
 

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,0 +1,40 @@
+"""Shared prompt assembly for persona-backed agent dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentPrompt:
+    full: str
+    persona_section: str
+    task_section: str
+
+
+def build_agent_prompt(
+    *,
+    persona_body: str,
+    task_heading: str,
+    task_body: str,
+    context: str = "",
+    extra_sections: list[tuple[str, str]] | None = None,
+) -> AgentPrompt:
+    """Layer persona (skills+stub+overlays) then structured task sections."""
+    persona_section = "\n".join(["# Persona", persona_body.strip()])
+
+    parts: list[str] = []
+    for heading, body in extra_sections or []:
+        if body.strip():
+            parts.extend(["", f"# {heading}", body.strip()])
+        else:
+            parts.extend(["", f"# {heading}"])
+
+    parts.extend(["", f"# {task_heading}", task_body.strip()])
+
+    if context.strip():
+        parts.extend(["", "# Context", context.strip()])
+
+    task_section = "\n".join(parts)
+    full = persona_section + task_section
+    return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,4 +1,4 @@
-"""Shared prompt assembly for persona-backed agent dispatch."""
+"""Shared agent prompt assembly for execute and fix dispatch paths."""
 
 from __future__ import annotations
 
@@ -18,23 +18,32 @@ def build_agent_prompt(
     task_heading: str,
     task_body: str,
     context: str = "",
+    extra_instructions: str = "",
+    allowed_paths: tuple[str, ...] | list[str] = (),
+    closing_instruction: str = "",
     extra_sections: list[tuple[str, str]] | None = None,
 ) -> AgentPrompt:
     """Layer persona (skills+stub+overlays) then structured task sections."""
-    persona_section = "\n".join(["# Persona", persona_body.strip()])
+    persona_parts = [
+        "# Persona",
+        persona_body.strip(),
+    ]
+    if extra_instructions.strip():
+        persona_parts.extend(["", "# Additional Instructions", extra_instructions.strip()])
+    if allowed_paths:
+        paths = ", ".join(allowed_paths)
+        persona_parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
+    persona_section = "\n".join(persona_parts)
 
-    parts: list[str] = []
+    task_parts: list[str] = ["", f"# {task_heading}", task_body.strip()]
+    if context.strip():
+        task_parts.extend(["", "# Context", context.strip()])
     for heading, body in extra_sections or []:
         if body.strip():
-            parts.extend(["", f"# {heading}", body.strip()])
-        else:
-            parts.extend(["", f"# {heading}"])
+            task_parts.extend(["", f"# {heading}", body.strip()])
+    if closing_instruction.strip():
+        task_parts.extend(["", closing_instruction.strip()])
+    task_section = "\n".join(task_parts)
 
-    parts.extend(["", f"# {task_heading}", task_body.strip()])
-
-    if context.strip():
-        parts.extend(["", "# Context", context.strip()])
-
-    task_section = "\n".join(parts)
-    full = persona_section + task_section
+    full = f"{persona_section}{task_section}"
     return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,4 +1,22 @@
-"""Shared agent prompt assembly for execute and fix dispatch paths."""
+"""Shared agent prompt assembly for persona dispatches.
+
+Every ``backend.run()`` / ``session.send()`` path that represents a persona doing
+work should build its prompt via :func:`build_agent_prompt` with
+``persona_body=equip.compose_body`` (from :func:`resolve_dispatch_equip` or
+``task.equip``) when equip is available.
+
+In-scope call sites (this package):
+
+- ``phases.run_execute_phase`` — equip compose body + ``build_agent_prompt``
+- ``phases._legacy_review_phase`` — reviewer persona + review skills in context
+- ``code_review.fix.run_fix_phase`` — equip via ``_resolve_fix_equip`` + ``build_agent_prompt``
+
+Out-of-scope but audited (must stay aligned when touched elsewhere):
+
+- ``pr_loop.lifecycle`` — review/CI fix agents (equip + ``build_agent_prompt``)
+- ``reviewer.review`` — structured review; review skills via ``task_context``
+- ``planner`` / ``implementer`` / ``researcher`` / scouts — pipeline-specific, no equip yet
+"""
 
 from __future__ import annotations
 

--- a/agent_fleet/scope.py
+++ b/agent_fleet/scope.py
@@ -3,6 +3,27 @@
 from __future__ import annotations
 
 
+def _normalize_scope_path(path: str) -> str:
+    return path.strip().rstrip("/")
+
+
+def path_allowed_by_prefix(changed: str, prefix: str) -> bool:
+    """True when *changed* is the same path, under *prefix*, or a parent directory of it."""
+    changed_n = _normalize_scope_path(changed)
+    prefix_n = _normalize_scope_path(prefix)
+    if not prefix_n:
+        return True
+    if not changed_n:
+        return True
+    if changed_n == prefix_n:
+        return True
+    if changed_n.startswith(f"{prefix_n}/"):
+        return True
+    if prefix_n.startswith(f"{changed_n}/"):
+        return True
+    return changed_n.startswith(prefix_n)
+
+
 def files_outside_allowed_paths(
     allowed_paths: tuple[str, ...] | list[str],
     changed_files: list[str],
@@ -16,5 +37,5 @@ def files_outside_allowed_paths(
     return tuple(
         path
         for path in changed_files
-        if not any(path.startswith(prefix) for prefix in allowed_paths)
+        if not any(path_allowed_by_prefix(path, prefix) for prefix in allowed_paths)
     )

--- a/agent_fleet/skills_lib.py
+++ b/agent_fleet/skills_lib.py
@@ -117,10 +117,10 @@ def skill_exists_in_base_kit(skill_id: str) -> bool:
     return resolve_skill_path(skill_id, base_kit_skill_dirs()) is not None
 
 
-def load_loadout(name: str) -> dict[str, Any]:
+def load_loadout(name: str, *, personas_dir: Path | None = None) -> dict[str, Any]:
     from agent_fleet.personas import load_loadout as _load_persona_loadout
 
-    loadout = _load_persona_loadout(name)
+    loadout = _load_persona_loadout(name, personas_dir=personas_dir)
     if loadout is None:
         raise FileNotFoundError(f"Loadout not found for persona {name!r}")
     return loadout

--- a/agent_fleet/skills_lib.py
+++ b/agent_fleet/skills_lib.py
@@ -8,7 +8,14 @@ from typing import Any
 _BUNDLED_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 _BASE_KIT_DIR = Path(__file__).resolve().parent / "base-kit"
 DEFAULT_QUALITY_REVIEW_SKILL = "thermo-nuclear-code-quality-review"
-SYSTEMATIC_DEBUGGING_SKILL = "superpowers/systematic-debugging"
+# Injected on verify_failed when not already in loadout (pstack-first default).
+SYSTEMATIC_DEBUGGING_SKILL = "pstack/why"
+# Injected when repo pr_loop.enabled (CI fix / watcher workflows).
+PR_LOOP_EXECUTE_SKILLS: tuple[str, ...] = (
+    "cursor-team-kit/fix-ci",
+    "cursor-team-kit/loop-on-ci",
+    "cursor-team-kit/get-pr-comments",
+)
 
 
 def base_kit_dir() -> Path:

--- a/agent_fleet/workstreams/__init__.py
+++ b/agent_fleet/workstreams/__init__.py
@@ -1,0 +1,20 @@
+"""Repo-defined workstream batches — first-class multi-task fleet dispatch."""
+
+from agent_fleet.workstreams.config import (
+    WorkstreamItem,
+    WorkstreamsConfig,
+    load_workstreams_config,
+)
+from agent_fleet.workstreams.dispatch import run_workstreams
+from agent_fleet.workstreams.harvest import harvest_worktree
+from agent_fleet.workstreams.scope import find_scope_overlaps, validate_parallel_batch
+
+__all__ = [
+    "WorkstreamItem",
+    "WorkstreamsConfig",
+    "find_scope_overlaps",
+    "harvest_worktree",
+    "load_workstreams_config",
+    "run_workstreams",
+    "validate_parallel_batch",
+]

--- a/agent_fleet/workstreams/__main__.py
+++ b/agent_fleet/workstreams/__main__.py
@@ -1,0 +1,6 @@
+"""Module entrypoint: python -m agent_fleet.workstreams."""
+
+from agent_fleet.workstreams.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_fleet/workstreams/cli.py
+++ b/agent_fleet/workstreams/cli.py
@@ -1,0 +1,252 @@
+"""CLI handlers for agent-fleet workstream subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+from agent_fleet.repo import REPO_CONFIG_NAMES, find_repo_config
+from agent_fleet.workstreams.config import WorkstreamsConfig, load_workstreams_config
+from agent_fleet.workstreams.dispatch import (
+    build_workstream_tasks,
+    run_workstreams,
+    workstreams_status,
+)
+from agent_fleet.workstreams.harvest import harvest_worktree, plan_harvest
+
+
+def load_repo_workstreams(repo_root: Path) -> WorkstreamsConfig | None:
+    """Load workstreams from repo config without requiring RepoConfig.workstreams."""
+    for name in REPO_CONFIG_NAMES:
+        path = repo_root / name
+        if not path.exists():
+            continue
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(raw, dict):
+            return None
+        return load_workstreams_config(raw)
+    return None
+
+
+def cmd_workstream_list(args: argparse.Namespace) -> int:
+    workspace = _resolve_workspace(args)
+    repo = find_repo_config(workspace)
+    if repo is None:
+        print(json.dumps({"enabled": False, "items": []}, indent=2))
+        return 0
+    config = load_repo_workstreams(repo.repo_root)
+    if config is None:
+        print(json.dumps({"enabled": False, "items": []}, indent=2))
+        return 0
+    print(workstreams_status(repo, config))
+    return 0
+
+
+def cmd_workstream_run(args: argparse.Namespace) -> int:
+    workspace = _resolve_workspace(args)
+    repo = find_repo_config(workspace)
+    if repo is None:
+        print("error: no .agent-fleet.yaml found", file=sys.stderr)
+        return 1
+    config = load_repo_workstreams(repo.repo_root)
+    if config is None:
+        print("error: no workstreams configured in .agent-fleet.yaml", file=sys.stderr)
+        return 1
+
+    if args.all:
+        item_ids = config.ids()
+    elif args.id:
+        item_ids = args.id
+    else:
+        print("error: pass workstream id(s) or --all", file=sys.stderr)
+        return 1
+
+    try:
+        if args.dry_run:
+            tasks = build_workstream_tasks(
+                repo=repo,
+                config=config,
+                item_ids=item_ids,
+                parallel=bool(args.parallel),
+            )
+            print(json.dumps(tasks, indent=2, default=str))
+            return 0
+
+        results = run_workstreams(
+            repo=repo,
+            config=config,
+            item_ids=item_ids,
+            parallel=bool(args.parallel),
+            fleet_config_path=args.config,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps([r.__dict__ for r in results], indent=2, default=str))
+    failed = [r for r in results if r.status != "completed"]
+    return 1 if failed else 0
+
+
+def cmd_workstream_harvest(args: argparse.Namespace) -> int:
+    workspace = _resolve_workspace(args)
+    repo = find_repo_config(workspace)
+    if repo is None:
+        print("error: no .agent-fleet.yaml found", file=sys.stderr)
+        return 1
+
+    worktree = Path(args.worktree).expanduser().resolve()
+    base = args.base or repo.default_branch
+    try:
+        if args.dry_run:
+            plan = plan_harvest(
+                repo_root=repo.repo_root,
+                worktree_path=worktree,
+                target_branch=args.target,
+                base_branch=base,
+            )
+            print(
+                json.dumps(
+                    {
+                        "dry_run": True,
+                        "target_branch": plan.target_branch,
+                        "source_sha": plan.source_sha,
+                        "source_branch": plan.source_branch,
+                        "base_branch": plan.base_branch,
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+
+        sha = harvest_worktree(
+            repo_root=repo.repo_root,
+            worktree_path=worktree,
+            target_branch=args.target,
+            base_branch=base,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({"target_branch": args.target, "merge_commit": sha}, indent=2))
+    return 0
+
+
+def build_workstream_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog or "agent-fleet workstream",
+        description="Run repo-defined workstream batches from .agent-fleet.yaml",
+    )
+    parser.add_argument("--workspace", help="Repo path (default: cwd)")
+    parser.add_argument("--config", help="Path to fleet.yaml")
+    ws_sub = parser.add_subparsers(dest="workstream_command", required=True)
+
+    def _add_workspace_flags(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--workspace",
+            help="Repo path (default: cwd or parent workstream --workspace)",
+        )
+        subparser.add_argument("--config", help="Path to fleet.yaml")
+
+    list_p = ws_sub.add_parser("list", help="List configured workstreams")
+    _add_workspace_flags(list_p)
+    list_p.set_defaults(func=cmd_workstream_list)
+
+    run_p = ws_sub.add_parser("run", help="Dispatch one or more workstreams")
+    run_p.add_argument("id", nargs="*", help="Workstream id(s)")
+    run_p.add_argument("--all", action="store_true", help="Run every configured workstream")
+    run_p.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Dispatch concurrently (blocked when scopes overlap)",
+    )
+    run_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print task payloads without dispatching",
+    )
+    _add_workspace_flags(run_p)
+    run_p.set_defaults(func=cmd_workstream_run)
+
+    harvest_p = ws_sub.add_parser(
+        "harvest",
+        help="Merge a fleet-run worktree onto a feature branch",
+    )
+    harvest_p.add_argument("worktree", help="Path to fleet worktree")
+    harvest_p.add_argument("--target", required=True, help="Target branch to merge into")
+    harvest_p.add_argument("--base", help="Base ref when creating target branch")
+    harvest_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show merge plan without checking out or merging",
+    )
+    _add_workspace_flags(harvest_p)
+    harvest_p.set_defaults(func=cmd_workstream_harvest)
+    return parser
+
+
+def register_workstream_commands(sub: argparse._SubParsersAction) -> None:
+    ws = sub.add_parser(
+        "workstream",
+        help="Run repo-defined workstream batches from .agent-fleet.yaml",
+    )
+    ws.add_argument("--workspace", help="Repo path (default: cwd)")
+    ws.add_argument("--config", help="Path to fleet.yaml")
+    ws_sub = ws.add_subparsers(dest="workstream_command", required=True)
+
+    def _add_workspace_flags(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--workspace",
+            help="Repo path (default: cwd or parent workstream --workspace)",
+        )
+        parser.add_argument("--config", help="Path to fleet.yaml")
+
+    list_p = ws_sub.add_parser("list", help="List configured workstreams")
+    _add_workspace_flags(list_p)
+    list_p.set_defaults(func=cmd_workstream_list)
+
+    run_p = ws_sub.add_parser("run", help="Dispatch one or more workstreams")
+    run_p.add_argument("id", nargs="*", help="Workstream id(s)")
+    run_p.add_argument("--all", action="store_true", help="Run every configured workstream")
+    run_p.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Dispatch concurrently (blocked when scopes overlap)",
+    )
+    run_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print task payloads without dispatching",
+    )
+    _add_workspace_flags(run_p)
+    run_p.set_defaults(func=cmd_workstream_run)
+
+    harvest_p = ws_sub.add_parser(
+        "harvest",
+        help="Merge a fleet-run worktree onto a feature branch",
+    )
+    harvest_p.add_argument("worktree", help="Path to fleet worktree")
+    harvest_p.add_argument("--target", required=True, help="Target branch to merge into")
+    harvest_p.add_argument("--base", help="Base ref when creating target branch")
+    harvest_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show merge plan without checking out or merging",
+    )
+    _add_workspace_flags(harvest_p)
+    harvest_p.set_defaults(func=cmd_workstream_harvest)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_workstream_parser(prog="python -m agent_fleet.workstreams")
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+def _resolve_workspace(args: argparse.Namespace) -> Path:
+    return Path(args.workspace or Path.cwd()).resolve()

--- a/agent_fleet/workstreams/config.py
+++ b/agent_fleet/workstreams/config.py
@@ -1,0 +1,87 @@
+"""Workstream configuration from .agent-fleet.yaml."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WorkstreamItem:
+    id: str
+    persona: str
+    goal: str
+    target_branch: str | None = None
+    base_branch: str | None = None
+    pipeline: str | None = None
+    context: str = ""
+
+
+@dataclass(frozen=True)
+class WorkstreamsConfig:
+    """Named batch of fleet tasks declared in repo config."""
+
+    plan: str | None = None
+    base_branch: str | None = None
+    default_target_branch: str | None = None
+    pipeline: str = "code_review"
+    sequential_stack: bool = True
+    items: tuple[WorkstreamItem, ...] = ()
+
+    def get(self, item_id: str) -> WorkstreamItem | None:
+        for item in self.items:
+            if item.id == item_id:
+                return item
+        return None
+
+    def ids(self) -> list[str]:
+        return [item.id for item in self.items]
+
+
+def load_workstreams_config(raw: dict[str, Any] | None) -> WorkstreamsConfig | None:
+    section = (raw or {}).get("workstreams")
+    if not section or section is False:
+        return None
+    if not isinstance(section, dict):
+        return None
+
+    items_raw = section.get("items") or section.get("workstreams") or []
+    items: list[WorkstreamItem] = []
+    for entry in items_raw:
+        if not isinstance(entry, dict):
+            continue
+        item_id = str(entry.get("id") or "").strip()
+        persona = str(entry.get("persona") or "").strip()
+        goal = str(entry.get("goal") or "").strip()
+        if not item_id or not persona or not goal:
+            continue
+        items.append(
+            WorkstreamItem(
+                id=item_id,
+                persona=persona,
+                goal=goal,
+                target_branch=_optional_str(entry.get("target_branch")),
+                base_branch=_optional_str(entry.get("base_branch")),
+                pipeline=_optional_str(entry.get("pipeline")),
+                context=str(entry.get("context") or ""),
+            )
+        )
+
+    if not items:
+        return None
+
+    return WorkstreamsConfig(
+        plan=_optional_str(section.get("plan")),
+        base_branch=_optional_str(section.get("base_branch")),
+        default_target_branch=_optional_str(section.get("default_target_branch")),
+        pipeline=str(section.get("pipeline") or "code_review"),
+        sequential_stack=bool(section.get("sequential_stack", True)),
+        items=tuple(items),
+    )
+
+
+def _optional_str(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/agent_fleet/workstreams/dispatch.py
+++ b/agent_fleet/workstreams/dispatch.py
@@ -1,0 +1,137 @@
+"""Build and run workstream task batches via the fleet dispatcher."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from agent_fleet.dispatcher import dispatch_tasks
+from agent_fleet.workstreams.scope import validate_parallel_batch
+
+if TYPE_CHECKING:
+    from agent_fleet.hooks import FleetTaskResult
+    from agent_fleet.repo import RepoConfig
+    from agent_fleet.workstreams.config import WorkstreamItem, WorkstreamsConfig
+
+
+def build_workstream_context(
+    *,
+    repo: RepoConfig,
+    config: WorkstreamsConfig,
+    item: WorkstreamItem,
+    parallel: bool,
+) -> str:
+    base = item.base_branch or config.base_branch or repo.default_branch
+    target = item.target_branch or config.default_target_branch or repo.default_branch
+    parts = [
+        f"Workstream: {item.id}",
+        f"Persona: {item.persona}",
+    ]
+    if config.plan:
+        parts.append(f"Plan: {config.plan}")
+    parts.extend(
+        [
+            f"Base branch: {base}",
+            f"Target branch: {target}",
+        ]
+    )
+    if parallel:
+        parts.append("Parallel batch: stay within persona scope allowlist.")
+    if item.context.strip():
+        parts.append(item.context.strip())
+    parts.append("Run pytest and ruff on touched files. Commit on target branch before finishing.")
+    return "\n".join(parts)
+
+
+def build_workstream_tasks(
+    *,
+    repo: RepoConfig,
+    config: WorkstreamsConfig,
+    item_ids: list[str],
+    parallel: bool,
+) -> list[dict[str, object]]:
+    selected: list[WorkstreamItem] = []
+    for item_id in item_ids:
+        item = config.get(item_id)
+        if item is None:
+            raise ValueError(f"Unknown workstream id: {item_id!r}")
+        selected.append(item)
+
+    validate_parallel_batch(repo, selected, sequential_stack=config.sequential_stack and parallel)
+
+    tasks: list[dict[str, object]] = []
+    for item in selected:
+        base = item.base_branch or config.base_branch or repo.default_branch
+        pipeline = item.pipeline or config.pipeline
+        tasks.append(
+            {
+                "goal": item.goal,
+                "context": build_workstream_context(
+                    repo=repo,
+                    config=config,
+                    item=item,
+                    parallel=parallel,
+                ),
+                "persona": item.persona,
+                "workspace": str(repo.repo_root),
+                "pipeline": pipeline,
+                "base_branch": base,
+            }
+        )
+    return tasks
+
+
+def run_workstreams(
+    *,
+    repo: RepoConfig,
+    config: WorkstreamsConfig,
+    item_ids: list[str],
+    parallel: bool = False,
+    fleet_config_path: str | None = None,
+) -> list[FleetTaskResult]:
+    """Dispatch one or more configured workstreams."""
+    tasks = build_workstream_tasks(
+        repo=repo,
+        config=config,
+        item_ids=item_ids,
+        parallel=parallel,
+    )
+    if parallel:
+        return dispatch_tasks(
+            tasks=tasks,
+            config_path=fleet_config_path,
+            pipeline=config.pipeline,
+        )
+
+    results: list[FleetTaskResult] = []
+    for task in tasks:
+        batch = dispatch_tasks(
+            tasks=[task],
+            config_path=fleet_config_path,
+            pipeline=str(task.get("pipeline") or config.pipeline),
+        )
+        results.extend(batch)
+        last = batch[-1] if batch else None
+        if last and last.status != "completed" and config.sequential_stack:
+            break
+    return results
+
+
+def workstreams_status(repo: RepoConfig, config: WorkstreamsConfig) -> str:
+    payload = {
+        "plan": config.plan,
+        "base_branch": config.base_branch or repo.default_branch,
+        "default_target_branch": config.default_target_branch,
+        "sequential_stack": config.sequential_stack,
+        "pipeline": config.pipeline,
+        "items": [
+            {
+                "id": item.id,
+                "persona": item.persona,
+                "target_branch": item.target_branch or config.default_target_branch,
+                "base_branch": item.base_branch or config.base_branch or repo.default_branch,
+            }
+            for item in config.items
+        ],
+    }
+    return json.dumps(payload, indent=2)

--- a/agent_fleet/workstreams/harvest.py
+++ b/agent_fleet/workstreams/harvest.py
@@ -1,0 +1,120 @@
+"""Merge fleet-run worktree branches onto feature branches."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — used at runtime, not only in annotations
+
+
+@dataclass(frozen=True)
+class HarvestPlan:
+    repo_root: Path
+    worktree_path: Path
+    source_sha: str
+    source_branch: str
+    target_branch: str
+    base_branch: str
+
+
+def _run_git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def plan_harvest(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    target_branch: str,
+    base_branch: str | None = None,
+) -> HarvestPlan:
+    """Validate inputs and return the merge plan without mutating git state."""
+    repo_root = repo_root.resolve()
+    worktree_path = worktree_path.resolve()
+    if not worktree_path.is_dir():
+        raise FileNotFoundError(f"Worktree not found: {worktree_path}")
+
+    git_dir = _run_git(["rev-parse", "--git-dir"], cwd=worktree_path)
+    if git_dir.returncode != 0:
+        raise RuntimeError(f"Not a git worktree: {worktree_path}")
+
+    head = _run_git(["rev-parse", "HEAD"], cwd=worktree_path)
+    if head.returncode != 0:
+        raise RuntimeError(f"Could not read worktree HEAD: {head.stderr.strip()}")
+    source_sha = head.stdout.strip()
+
+    branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=worktree_path)
+    source_branch = branch.stdout.strip() if branch.returncode == 0 else source_sha
+    if source_branch == "HEAD":
+        source_branch = source_sha
+
+    base = base_branch or "main"
+    return HarvestPlan(
+        repo_root=repo_root,
+        worktree_path=worktree_path,
+        source_sha=source_sha,
+        source_branch=source_branch,
+        target_branch=target_branch,
+        base_branch=base,
+    )
+
+
+def harvest_worktree(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    target_branch: str,
+    base_branch: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Merge the worktree HEAD onto target_branch. Returns merged commit sha."""
+    plan = plan_harvest(
+        repo_root=repo_root,
+        worktree_path=worktree_path,
+        target_branch=target_branch,
+        base_branch=base_branch,
+    )
+    if dry_run:
+        return plan.source_sha
+
+    exists = _run_git(["rev-parse", "--verify", plan.target_branch], cwd=plan.repo_root)
+    if exists.returncode != 0:
+        base_ref = _run_git(["rev-parse", "--verify", plan.base_branch], cwd=plan.repo_root)
+        start = base_ref.stdout.strip() if base_ref.returncode == 0 else "HEAD"
+        created = _run_git(["branch", plan.target_branch, start], cwd=plan.repo_root)
+        if created.returncode != 0:
+            raise RuntimeError(
+                f"Could not create {plan.target_branch}: {created.stderr.strip()}"
+            )
+
+    checkout = _run_git(["checkout", plan.target_branch], cwd=plan.repo_root)
+    if checkout.returncode != 0:
+        raise RuntimeError(
+            f"Could not checkout {plan.target_branch}: {checkout.stderr.strip()}"
+        )
+
+    merge = _run_git(
+        [
+            "merge",
+            "--no-ff",
+            plan.source_sha,
+            "-m",
+            f"harvest: merge fleet work from {plan.source_branch}",
+        ],
+        cwd=plan.repo_root,
+    )
+    if merge.returncode != 0:
+        _run_git(["merge", "--abort"], cwd=plan.repo_root)
+        raise RuntimeError(
+            f"Merge failed for {plan.target_branch} ← {plan.source_sha}: "
+            f"{merge.stderr.strip()}"
+        )
+
+    sha = _run_git(["rev-parse", "HEAD"], cwd=plan.repo_root)
+    return sha.stdout.strip() if sha.returncode == 0 else plan.source_sha

--- a/agent_fleet/workstreams/harvest.py
+++ b/agent_fleet/workstreams/harvest.py
@@ -89,15 +89,11 @@ def harvest_worktree(
         start = base_ref.stdout.strip() if base_ref.returncode == 0 else "HEAD"
         created = _run_git(["branch", plan.target_branch, start], cwd=plan.repo_root)
         if created.returncode != 0:
-            raise RuntimeError(
-                f"Could not create {plan.target_branch}: {created.stderr.strip()}"
-            )
+            raise RuntimeError(f"Could not create {plan.target_branch}: {created.stderr.strip()}")
 
     checkout = _run_git(["checkout", plan.target_branch], cwd=plan.repo_root)
     if checkout.returncode != 0:
-        raise RuntimeError(
-            f"Could not checkout {plan.target_branch}: {checkout.stderr.strip()}"
-        )
+        raise RuntimeError(f"Could not checkout {plan.target_branch}: {checkout.stderr.strip()}")
 
     merge = _run_git(
         [
@@ -112,8 +108,7 @@ def harvest_worktree(
     if merge.returncode != 0:
         _run_git(["merge", "--abort"], cwd=plan.repo_root)
         raise RuntimeError(
-            f"Merge failed for {plan.target_branch} ← {plan.source_sha}: "
-            f"{merge.stderr.strip()}"
+            f"Merge failed for {plan.target_branch} ← {plan.source_sha}: {merge.stderr.strip()}"
         )
 
     sha = _run_git(["rev-parse", "HEAD"], cwd=plan.repo_root)

--- a/agent_fleet/workstreams/scope.py
+++ b/agent_fleet/workstreams/scope.py
@@ -51,10 +51,7 @@ def validate_parallel_batch(
     overlaps = find_scope_overlaps(repo, personas)
     if not overlaps:
         return
-    lines = [
-        f"{a} ↔ {b} (prefix {prefix!r})"
-        for a, b, prefix in overlaps[:5]
-    ]
+    lines = [f"{a} ↔ {b} (prefix {prefix!r})" for a, b, prefix in overlaps[:5]]
     extra = len(overlaps) - len(lines)
     suffix = f" (+{extra} more)" if extra > 0 else ""
     raise ValueError(

--- a/agent_fleet/workstreams/scope.py
+++ b/agent_fleet/workstreams/scope.py
@@ -1,0 +1,65 @@
+"""Scope overlap detection for parallel workstream batches."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_fleet.repo import RepoConfig
+    from agent_fleet.workstreams.config import WorkstreamItem
+
+
+def scope_prefixes_for_persona(repo: RepoConfig, persona: str) -> frozenset[str]:
+    allowlist = repo.persona_scope_allowlist.get(persona)
+    if not allowlist:
+        return frozenset()
+    return frozenset(str(prefix).rstrip("/") for prefix in allowlist)
+
+
+def _prefixes_overlap(a: str, b: str) -> bool:
+    return a == b or a.startswith(f"{b}/") or b.startswith(f"{a}/")
+
+
+def find_scope_overlaps(
+    repo: RepoConfig,
+    personas: list[str],
+) -> list[tuple[str, str, str]]:
+    """Return (persona_a, persona_b, shared_prefix) for overlapping allowlists."""
+    overlaps: list[tuple[str, str, str]] = []
+    for i, persona_a in enumerate(personas):
+        prefixes_a = scope_prefixes_for_persona(repo, persona_a)
+        for persona_b in personas[i + 1 :]:
+            prefixes_b = scope_prefixes_for_persona(repo, persona_b)
+            for prefix_a in prefixes_a:
+                for prefix_b in prefixes_b:
+                    if _prefixes_overlap(prefix_a, prefix_b):
+                        overlaps.append((persona_a, persona_b, prefix_a))
+                        break
+    return overlaps
+
+
+def validate_parallel_batch(
+    repo: RepoConfig,
+    items: list[WorkstreamItem],
+    *,
+    sequential_stack: bool,
+) -> None:
+    """Raise ValueError when parallel dispatch would share scope prefixes."""
+    if not sequential_stack or len(items) <= 1:
+        return
+    personas = [item.persona for item in items]
+    overlaps = find_scope_overlaps(repo, personas)
+    if not overlaps:
+        return
+    lines = [
+        f"{a} ↔ {b} (prefix {prefix!r})"
+        for a, b, prefix in overlaps[:5]
+    ]
+    extra = len(overlaps) - len(lines)
+    suffix = f" (+{extra} more)" if extra > 0 else ""
+    raise ValueError(
+        "Parallel workstream dispatch blocked by overlapping persona scopes: "
+        + "; ".join(lines)
+        + suffix
+        + ". Run sequentially or adjust persona_scope_allowlist."
+    )

--- a/agent_fleet/worktree.py
+++ b/agent_fleet/worktree.py
@@ -30,6 +30,41 @@ class TaskWorkspace:
         self.git_ops.teardown_workspace(self.path)
 
 
+_RECOVERABLE_WORKTREE_STATUSES = frozenset({"review_changes_requested", "verify_failed"})
+
+
+def should_keep_task_worktree(
+    status: str,
+    *,
+    auto_push: bool = False,
+    isolated: bool = False,
+    has_changes: bool = False,
+) -> bool:
+    """Return True when an isolated worktree should survive teardown."""
+    if status in {"completed", "merged"}:
+        return True
+    if auto_push and isolated:
+        return True
+    return status in _RECOVERABLE_WORKTREE_STATUSES and has_changes
+
+
+def maybe_commit_recoverable_worktree(
+    task_workspace: TaskWorkspace,
+    status: str,
+    *,
+    goal: str,
+) -> str | None:
+    """Commit uncommitted changes before teardown on recoverable soft failures."""
+    if (
+        status not in _RECOVERABLE_WORKTREE_STATUSES
+        or not task_workspace.isolated
+        or task_workspace.git_ops is None
+    ):
+        return None
+    message = f"fleet: auto-commit after {status}\n\n{goal.strip()[:500]}"
+    return task_workspace.git_ops.commit_changes(task_workspace.path, message)
+
+
 def should_isolate_worktree(
     repo: RepoConfig | None,
     *,
@@ -47,6 +82,7 @@ def prepare_task_workspace(
     *,
     task_index: int,
     force_isolation: bool = False,
+    base_branch: str | None = None,
 ) -> TaskWorkspace:
     """Create an isolated worktree for a fleet task, or return the repo root."""
     repo_root = repo.repo_root.resolve()
@@ -73,7 +109,7 @@ def prepare_task_workspace(
     worktree = git_ops.setup_workspace(
         repo_root,
         run_id,
-        repo.default_branch,
+        base_branch or repo.default_branch,
         branch_name=branch_name,
     )
     return TaskWorkspace(

--- a/agents/personas/_skills_common.yaml
+++ b/agents/personas/_skills_common.yaml
@@ -1,0 +1,16 @@
+# Shared execute skill ids for skills-buildout personas (reference only; copied into loadouts)
+execute:
+  - pstack/tdd
+  - pstack/principle-prove-it-works
+  - pstack/principle-fix-root-causes
+  - pstack/principle-boundary-discipline
+  - pstack/principle-minimize-reader-load
+  - pstack/principle-never-block-on-the-human
+  - pstack/principle-guard-the-context-window
+  - cursor-team-kit/verify-this
+  - pstack/how
+  - pstack/figure-it-out
+  - superpowers/verification-before-completion
+  - superpowers/using-git-worktrees
+  - superpowers/subagent-driven-development
+  - superpowers/executing-plans

--- a/agents/personas/fleet-registry.loadout.yaml
+++ b/agents/personas/fleet-registry.loadout.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+stub: fleet-registry.md
+skills:
+  execute:
+    - pstack/tdd
+    - cursor-team-kit/verify-this
+    - superpowers/verification-before-completion
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/fleet-registry.md
+++ b/agents/personas/fleet-registry.md
@@ -1,0 +1,11 @@
+## Role
+
+Harden persona registry so self-dispatch cannot fail at review/equip.
+
+## Scope
+
+Validation test, fleet.yaml hygiene, workstream CLI wiring docs.
+
+## Done when
+
+test_persona_registry passes; ghost fleet personas removed; docs updated.

--- a/agents/personas/fleet-scout-loadouts.loadout.yaml
+++ b/agents/personas/fleet-scout-loadouts.loadout.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+stub: fleet-scout-loadouts.md
+skills:
+  execute:
+    - pstack/tdd
+    - cursor-team-kit/verify-this
+    - superpowers/writing-skills
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/fleet-scout-loadouts.md
+++ b/agents/personas/fleet-scout-loadouts.md
@@ -1,0 +1,11 @@
+## Role
+
+Add missing scout persona loadouts in the bundled package.
+
+## Scope
+
+pr-analyzer, explorer, tech-scout, product-scout loadout YAML + tests.
+
+## Done when
+
+All four scouts have loadouts; test_loadouts passes; no uv.lock changes.

--- a/agents/personas/fleet-skills-stack.loadout.yaml
+++ b/agents/personas/fleet-skills-stack.loadout.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+stub: fleet-skills-stack.md
+skills:
+  execute:
+    - pstack/tdd
+    - cursor-team-kit/verify-this
+    - superpowers/executing-plans
+    - superpowers/subagent-driven-development
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/fleet-skills-stack.md
+++ b/agents/personas/fleet-skills-stack.md
@@ -1,0 +1,15 @@
+## Role
+
+Integrate skills buildout stack — PR4 loadouts and branch merges.
+
+## Scope
+
+Harvest fleet worktree task-2-6316c6c3; merge skills-personas branch.
+
+## Done when
+
+Scout loadouts harvested onto feature/skills-personas; skills-pr-loop merged; test_loadouts green.
+
+## Status
+
+Complete — PR4 scout loadouts on `feature/skills-personas`; `feature/skills-pr-loop` merged; `pytest tests/test_loadouts.py` green (10 passed).

--- a/agents/personas/reviewer.loadout.yaml
+++ b/agents/personas/reviewer.loadout.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+stub: reviewer.md
+skills:
+  execute:
+    - pstack/interrogate
+    - pstack/reflect
+pipeline_skills:
+  code_review:
+    review:
+      - pstack/unslop
+      - cursor-team-kit/deslop

--- a/agents/personas/reviewer.md
+++ b/agents/personas/reviewer.md
@@ -1,0 +1,37 @@
+## Role
+
+Code reviewer. You do not implement — you evaluate changes for correctness, safety, and maintainability.
+
+## Expertise
+
+- Spotting logic bugs, edge cases, and missing tests
+- Security and data-handling review
+- API contract and naming consistency
+- Scope creep detection
+
+## Read-only
+
+- Do not edit, create, or delete files.
+- Do not create branches, commits, or worktree changes.
+- Put all notes in your summary only.
+
+## Review checklist
+
+1. **Scope**: Did the implementer change ONLY what was asked? Flag any scope creep.
+2. **Correctness**: Logic bugs, edge cases, off-by-one errors.
+3. **Tests**: Are there tests? Do they cover the important cases?
+4. **Contracts**: API changes break callers? Schema changes backward-compatible?
+5. **Conventions**: Does the code match existing style and patterns in the repo?
+
+## Methodology
+
+1. Read the implementation summary (and diff if available in the workspace).
+2. For branch/worktree runs, prefer `git diff main...HEAD` to scope the review.
+3. Classify findings: blocker, major, minor, nit.
+4. Check for missing tests and documentation.
+5. Verify scope — no unrelated changes.
+6. Give a verdict: APPROVE or REQUEST_CHANGES.
+
+## Output
+
+Structured review with severity-tagged findings, scope assessment, and a clear verdict.

--- a/agents/personas/skills-canonical.loadout.yaml
+++ b/agents/personas/skills-canonical.loadout.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+stub: skills-canonical.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-minimize-reader-load
+    - cursor-team-kit/verify-this
+    - cursor-team-kit/deslop
+    - pstack/how
+    - pstack/why
+    - superpowers/verification-before-completion
+    - superpowers/requesting-code-review
+pipeline_skills:
+  code_review:
+    review:
+      - cursor-team-kit/deslop
+      - pstack/unslop

--- a/agents/personas/skills-canonical.md
+++ b/agents/personas/skills-canonical.md
@@ -1,0 +1,23 @@
+## Role
+
+Implement **PR5**: canonical thermo-nuclear skill id + extended dynamic equip conditions.
+
+## Scope
+
+- `agent_fleet/skills_lib.py`, `agent_fleet/pr_review/`, remove duplicate bundled skill if base-kit resolves
+- `agent_fleet/orchestration/equip.py` — worktree / CI-fix dynamic skills
+- `tests/test_skills_quality.py`, equip tests
+
+## Branch
+
+**`feature/skills-canonical`**
+
+## Plan
+
+PR5 section in buildout plan doc.
+
+## Done when
+
+- Single thermo-nuclear resolution path
+- Extended dynamic equip tested
+- Full `pytest -q` green

--- a/agents/personas/skills-foundation.loadout.yaml
+++ b/agents/personas/skills-foundation.loadout.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+stub: skills-foundation.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
+    - superpowers/verification-before-completion
+    - superpowers/using-git-worktrees
+    - superpowers/writing-plans
+    - superpowers/executing-plans
+    - superpowers/subagent-driven-development
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/skills-foundation.md
+++ b/agents/personas/skills-foundation.md
@@ -1,0 +1,28 @@
+## Role
+
+Implement **PR1** of the skills integration buildout: base-kit catalog sync, curated default loadouts, and dynamic equip rules.
+
+## Scope
+
+- `scripts/sync-base-kit.sh`, `agent_fleet/base-kit/`
+- `agent_fleet/personas/coder.loadout.yaml`, `reviewer.loadout.yaml`
+- `agent_fleet/skills_lib.py`, `agent_fleet/orchestration/equip.py`
+- `tests/test_loadouts.py`, `tests/test_equip.py`, `tests/test_phases_deslop.py`
+- `docs/AGENT-FLEET-DEV.md`, `docs/PERSONA-EVOLUTION.md`
+
+## Branch
+
+Work on **`feature/skills-foundation`**. Do not start PR2–PR5 work in this branch.
+
+## Plan
+
+Read `docs/superpowers/plans/2026-05-25-skills-integration-buildout.md` — PR1 section only.
+
+## Done when
+
+- `./scripts/sync-base-kit.sh` vendored; manifest updated
+- Coder loadout is pstack-first (no superpowers duplication)
+- Reviewer review phase: `pstack/unslop` + `cursor-team-kit/deslop`
+- Dynamic equip: `pstack/why` on verify_failed; pr_loop CI skills when enabled
+- `pytest tests/test_loadouts.py tests/test_equip.py tests/test_phases_deslop.py -q` passes
+- Changes committed on `feature/skills-foundation`

--- a/agents/personas/skills-personas.loadout.yaml
+++ b/agents/personas/skills-personas.loadout.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+stub: skills-personas.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/figure-it-out
+    - pstack/interrogate
+    - pstack/reflect
+    - superpowers/writing-skills
+    - superpowers/brainstorming
+    - superpowers/receiving-code-review
+pipeline_skills:
+  code_review:
+    review:
+      - pstack/unslop

--- a/agents/personas/skills-personas.md
+++ b/agents/personas/skills-personas.md
@@ -1,0 +1,22 @@
+## Role
+
+Implement **PR4**: loadouts for all bundled personas (pr-analyzer, explorer, tech-scout, product-scout).
+
+## Scope
+
+- `agent_fleet/personas/*.loadout.yaml` (package bundled personas)
+- `tests/test_loadouts.py` — parametrize all loadouts resolve
+- `docs/PERSONAS.md`
+
+## Branch
+
+**`feature/skills-personas`**
+
+## Plan
+
+PR4 section in buildout plan doc.
+
+## Done when
+
+- Every bundled persona has a loadout; all skill ids resolve under base-kit
+- Tests + docs updated

--- a/agents/personas/skills-pr-loop.loadout.yaml
+++ b/agents/personas/skills-pr-loop.loadout.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+stub: skills-pr-loop.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-never-block-on-the-human
+    - cursor-team-kit/verify-this
+    - cursor-team-kit/fix-ci
+    - cursor-team-kit/loop-on-ci
+    - cursor-team-kit/get-pr-comments
+    - pstack/how
+    - pstack/why
+    - superpowers/systematic-debugging
+    - superpowers/subagent-driven-development
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/skills-pr-loop.md
+++ b/agents/personas/skills-pr-loop.md
@@ -1,0 +1,23 @@
+## Role
+
+Implement **PR3**: wire `resolve_dispatch_equip()` + composed persona body into PR loop fix agents and code_review auto-fix.
+
+## Scope
+
+- `agent_fleet/pr_loop/lifecycle.py` — `address_review_findings`, `attempt_ci_fix`
+- `agent_fleet/code_review/fix.py`
+- `tests/test_pr_loop_equip.py`, `tests/test_code_review_fix_equip.py`
+
+## Branch
+
+**`feature/skills-pr-loop`**
+
+## Plan
+
+PR3 section in `docs/superpowers/plans/2026-05-25-skills-integration-buildout.md`.
+
+## Done when
+
+- Fix-agent prompts include equip compose body (skills visible in prompt)
+- Tests prove fix-ci / skill markers present
+- `pytest -q` green on branch

--- a/agents/personas/skills-prompt-builder.loadout.yaml
+++ b/agents/personas/skills-prompt-builder.loadout.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+stub: skills-prompt-builder.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/architect
+    - superpowers/subagent-driven-development
+    - superpowers/executing-plans
+    - superpowers/verification-before-completion
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/skills-prompt-builder.md
+++ b/agents/personas/skills-prompt-builder.md
@@ -1,0 +1,21 @@
+## Role
+
+Implement **PR2**: shared `build_agent_prompt()` and refactor execute prompt assembly.
+
+## Scope
+
+- Create `agent_fleet/prompts/agent.py`, `tests/test_prompts_agent.py`
+- Refactor `agent_fleet/phases.py` `_build_execute_prompt` to use it (behavior-preserving)
+
+## Branch
+
+**`feature/skills-prompt-builder`** — branch from merged PR1 or rebase onto `feature/skills-foundation` if PR1 not merged yet.
+
+## Plan
+
+`docs/superpowers/plans/2026-05-25-skills-integration-buildout.md` — PR2 section.
+
+## Done when
+
+- Tests pass; no behavior change to equip compose order
+- Committed on `feature/skills-prompt-builder`

--- a/docs/AGENT-FLEET-DEV.md
+++ b/docs/AGENT-FLEET-DEV.md
@@ -70,6 +70,7 @@ max_parallel: 5
 
 ```bash
 uv run --directory ~/agent-fleet-dev agent-fleet paths
+python3 ~/agent-fleet-dev/scripts/check-import-shadow.py
 ```
 
 Upgrading an old machine with Hermes-hosted config:
@@ -142,6 +143,8 @@ Hermes gets the **cursor-fleet** plugin only. Config stays in `~/.agent-fleet/fl
 | `~/.agent-fleet/skills/` | Optional user skill overrides |
 
 ### Bundled personas (`fleet.example.yaml`)
+
+Leave `personas_dir` unset in global `~/.agent-fleet/fleet.yaml` — bundled personas load from the installed package. For repo-local personas, set `personas_dir` in `.agent-fleet.yaml` (relative to repo root). Details: [FLEET-CONFIG.md](FLEET-CONFIG.md).
 
 | Persona | Role |
 |---------|------|

--- a/docs/AGENT-FLEET-DEV.md
+++ b/docs/AGENT-FLEET-DEV.md
@@ -1,0 +1,188 @@
+# agent-fleet-dev — fresh install walkthrough
+
+Install agent-fleet from scratch on a new machine or side-by-side with production. Uses **`~/agent-fleet-dev`** as the git checkout name.
+
+Hermes is **optional** (Phase 7). Fleet storage lives under **`~/.agent-fleet/`** only.
+
+---
+
+## Phase 0 — Prerequisites
+
+| Requirement | Check |
+|-------------|--------|
+| Python **3.14** | `python3 --version` |
+| **git** + **gh** | `gh auth status` |
+| **uv** (recommended) | `uv --version` |
+| **Cursor API key** | [dashboard/integrations](https://cursor.com/dashboard/integrations) |
+
+```bash
+export CURSOR_API_KEY="..."
+```
+
+Or copy from an existing fleet `.env` (same key the silphco watcher uses):
+
+```bash
+grep '^CURSOR_API_KEY=' /path/to/existing/.env > ~/agent-fleet-dev/.env
+chmod 600 ~/agent-fleet-dev/.env
+```
+
+Load before runs:
+
+```bash
+set -a && source ~/agent-fleet-dev/.env && set +a
+```
+
+---
+
+## Phase 1 — Clone and install
+
+```bash
+git clone https://github.com/Evan-Kim2028/agent-fleet.git ~/agent-fleet-dev
+cd ~/agent-fleet-dev
+uv sync --frozen --group dev
+```
+
+Verify the CLI points at this checkout:
+
+```bash
+uv run agent-fleet paths
+python3 -c "import agent_fleet; print(agent_fleet.__version__, agent_fleet.__file__)"
+uv run agent-fleet personas
+```
+
+---
+
+## Phase 2 — Global config (`~/.agent-fleet/`)
+
+```bash
+mkdir -p ~/.agent-fleet
+cp ~/agent-fleet-dev/fleet.example.yaml ~/.agent-fleet/fleet.yaml
+```
+
+Minimal edits:
+
+```yaml
+default_backend: cursor
+default_model: composer-2.5-fast
+default_persona: coder
+max_parallel: 5
+```
+
+```bash
+uv run --directory ~/agent-fleet-dev agent-fleet paths
+```
+
+Upgrading an old machine with Hermes-hosted config:
+
+```bash
+uv run --directory ~/agent-fleet-dev agent-fleet migrate-home
+```
+
+---
+
+## Phase 3 — Smoke test
+
+```bash
+set -a && source ~/agent-fleet-dev/.env && set +a
+
+export REPO=/home/evan/Documents/lake-of-rage
+
+uv run --directory ~/agent-fleet-dev agent-fleet run \
+  "Add a trivial smoke test under packages/lakestore/tests/" \
+  --workspace "$REPO" \
+  --persona lakestore \
+  --pipeline simple
+```
+
+Check:
+
+- JSON result with `phases`
+- Log: `~/.agent-fleet/runs/<run-id>.jsonl`
+
+---
+
+## Phase 4 — Repo factory
+
+```bash
+uv run --directory ~/agent-fleet-dev agent-fleet init "$REPO"
+# edit $REPO/.agent-fleet.yaml — scope, verify_commands, level_up
+```
+
+---
+
+## Phase 5 — Background watcher (optional)
+
+```ini
+# ~/.config/systemd/user/agent-fleet-watch.service
+ExecStart=/home/you/.local/bin/uv run --directory /home/you/agent-fleet-dev agent-fleet-watch --workspace %REPO%
+EnvironmentFile=%REPO%/.env
+```
+
+---
+
+## Phase 6 — Hermes (optional interface)
+
+```bash
+cd ~/agent-fleet-dev && ./scripts/deploy-hermes.sh
+```
+
+Hermes gets the **cursor-fleet** plugin only. Config stays in `~/.agent-fleet/fleet.yaml`.
+
+---
+
+## Defaults reference
+
+### Storage (`agent-fleet paths`)
+
+| Path | Purpose |
+|------|---------|
+| `~/.agent-fleet/fleet.yaml` | Global personas, models, pipelines |
+| `~/.agent-fleet/runs/` | Per-dispatch JSONL logs |
+| `~/.agent-fleet/level_up/` | Persona learning (journal, experience, overlays) |
+| `~/.agent-fleet/skills/` | Optional user skill overrides |
+
+### Bundled personas (`fleet.example.yaml`)
+
+| Persona | Role |
+|---------|------|
+| `coder` | Implementer (default) |
+| `reviewer` | Diff review |
+| `pr-analyzer` | Two-pass PR analysis |
+| `explorer` | Read-only exploration |
+| `product-scout` / `tech-scout` | Scout pipeline |
+
+### Pipelines
+
+| Pipeline | Phases |
+|----------|--------|
+| `simple` | execute |
+| `code_review` | execute → review |
+| `full` | plan → research → synthesize → implement → verify → review |
+
+### Default skills (pstack)
+
+Execute loadouts use **[Cursor pstack](https://github.com/cursor/plugins/tree/main/pstack)** skills vendored in `agent_fleet/base-kit/pstack/`:
+
+**Coder:** `pstack/tdd`, verification principles, `principle-never-block-on-the-human`, `principle-guard-the-context-window`, `cursor-team-kit/verify-this`, `pstack/how`, `pstack/figure-it-out`
+
+**Reviewer:** `pstack/interrogate`, `pstack/reflect` · review phase: `pstack/unslop`, `cursor-team-kit/deslop`
+
+**Dynamic (on verify failure):** `pstack/why` appended to execute slots
+
+**Dynamic (when `pr_loop.enabled`):** `cursor-team-kit/fix-ci`, `loop-on-ci`, `get-pr-comments` appended to execute slots
+
+**Base-kit catalog:** full `pstack/`, `superpowers/`, and `cursor-team-kit/` skill trees (sync via `./scripts/sync-base-kit.sh`)
+
+**Superpowers** remain in `base-kit/superpowers/` for optional custom loadouts; not in default loadouts.
+
+Refresh vendored skills: `./scripts/sync-base-kit.sh`
+
+---
+
+## Daily dev loop
+
+```bash
+cd ~/agent-fleet-dev && git pull && uv sync --frozen --group dev
+pytest -q
+systemctl --user restart agent-fleet-watch.service   # if using watcher
+```

--- a/docs/AGENT-FLEET-DEV.md
+++ b/docs/AGENT-FLEET-DEV.md
@@ -159,8 +159,30 @@ Leave `personas_dir` unset in global `~/.agent-fleet/fleet.yaml` — bundled per
 | Pipeline | Phases |
 |----------|--------|
 | `simple` | execute |
-| `code_review` | execute → review |
+| `code_review` | execute → review (optional auto-fix loop via `code_review.auto_fix`) |
 | `full` | plan → research → synthesize → implement → verify → review |
+
+### Equip + prompt path
+
+Persona dispatches resolve skills via `resolve_dispatch_equip()` (dispatcher) and assemble
+prompts with `build_agent_prompt()` (`agent_fleet/prompts/agent.py`).
+
+| Call site | Equip | `build_agent_prompt` |
+|-----------|-------|----------------------|
+| `phases.run_execute_phase` | `task.equip.compose_body` | yes |
+| `phases._legacy_review_phase` | review skills via `task.equip.skill_slots_review` | yes |
+| `code_review.fix.run_fix_phase` | `_resolve_fix_equip` / `task.equip` fast path | yes |
+| `pr_loop.lifecycle` (review + CI fix) | `resolve_dispatch_equip` per attempt | yes |
+
+Structured review (`reviewer.review`) injects review skills through `task_context`; planner,
+implementer, researcher, and scout paths are pipeline-specific and do not use equip yet.
+
+**`code_review.auto_fix` defaults** (repo `.agent-fleet.yaml`):
+
+- Explicit `code_review:` block — defaults `auto_fix: false` unless set
+- `pr_loop.enabled: true` with no `code_review:` section — inherits `auto_fix: true`,
+  `auto_push: true`, `auto_pr_loop: true`
+- See `examples/repo-full.agent-fleet.yaml` and `examples/repo.agent-fleet.yaml`
 
 ### Default skills (pstack)
 

--- a/docs/DISPATCH-COOKBOOK.md
+++ b/docs/DISPATCH-COOKBOOK.md
@@ -2,6 +2,35 @@
 
 How to run agent-fleet on itself without losing work or colliding parallel agents.
 
+## Preflight (run before every batch)
+
+Skips the common failure modes that waste 3–6 minutes per workstream:
+
+```bash
+# Installed CLI matches repo (workstream subcommand, scope fixes)
+pip install -e . --quiet
+
+# Personas resolve (repo dir → package fallback)
+agent-fleet personas validate --workspace .
+
+# Workstreams and scopes are sane
+agent-fleet workstream list --workspace .
+python -m agent_fleet.workstreams run --all --dry-run --workspace .
+
+# Optional: full test baseline
+pytest -q
+```
+
+Checklist:
+
+| Check | Why |
+|-------|-----|
+| `pip install -e .` | Stale `agent-fleet` binary missing `workstream` |
+| `personas validate` | Missing `coder.md` / loadouts under `personas_dir` |
+| `workstream list` + dry-run | Overlapping scopes, bad persona names |
+| Allowlist matches goal | e.g. registry needs `tests/`, `docs/`, `config.py` |
+| Harvest completed worktrees first | Avoid duplicate execute passes |
+
 ## Prefer workstreams over scripts
 
 Declare batches in `.agent-fleet.yaml` under `workstreams:` and run:
@@ -9,13 +38,6 @@ Declare batches in `.agent-fleet.yaml` under `workstreams:` and run:
 ```bash
 agent-fleet workstream run worktree
 agent-fleet workstream run --all
-```
-
-Until `agent-fleet workstream` is wired into the top-level CLI, use the module entry:
-
-```bash
-python -m agent_fleet.workstreams run --all --workspace .
-python -m agent_fleet.workstreams list
 ```
 
 See [WORKSTREAMS.md](WORKSTREAMS.md).
@@ -58,10 +80,9 @@ Enable `auto_fix` in `.agent-fleet.yaml` for self-dispatch buildouts.
 
 ## Integration checklist
 
-Wire workstreams into the installed CLI (outside this module):
+For self-hosted batches on agent-fleet:
 
-1. `agent_fleet/cli.py` — call `register_workstream_commands(sub)`
-2. `agent_fleet/repo.py` — expose `RepoConfig.workstreams` via `load_workstreams_config`
-3. `agent_fleet/__init__.py` — export `run_workstreams`
-
-The module is self-contained until those hooks land; `python -m agent_fleet.workstreams` exercises list/run/harvest end-to-end.
+1. `.agent-fleet.yaml` — `workstreams`, `persona_scope_allowlist`, `capacity.max_dispatches`
+2. `agents/personas/` — fleet dispatch personas referenced by workstream items
+3. Preflight (above) — then `agent-fleet workstream run --all`
+4. Harvest surviving worktrees onto `default_target_branch`

--- a/docs/DISPATCH-COOKBOOK.md
+++ b/docs/DISPATCH-COOKBOOK.md
@@ -1,0 +1,67 @@
+# Dispatch Cookbook
+
+How to run agent-fleet on itself without losing work or colliding parallel agents.
+
+## Prefer workstreams over scripts
+
+Declare batches in `.agent-fleet.yaml` under `workstreams:` and run:
+
+```bash
+agent-fleet workstream run worktree
+agent-fleet workstream run --all
+```
+
+Until `agent-fleet workstream` is wired into the top-level CLI, use the module entry:
+
+```bash
+python -m agent_fleet.workstreams run --all --workspace .
+python -m agent_fleet.workstreams list
+```
+
+See [WORKSTREAMS.md](WORKSTREAMS.md).
+
+## Sequential vs parallel
+
+| Mode | When |
+|------|------|
+| Sequential (`run --all`) | Stacked PRs, shared modules, default |
+| Parallel (`run --all --parallel`) | Disjoint `persona_scope_allowlist` only |
+
+Parallel PR2 + PR3 both touching `agent_fleet/prompts/` is the canonical failure — blocked when `sequential_stack: true`.
+
+Preview a batch before spending agent time:
+
+```bash
+python -m agent_fleet.workstreams run dispatch-tooling --dry-run --workspace .
+```
+
+## Worktree lifecycle
+
+1. Fleet creates `.worktrees/fleet-runs/task-N-*` with `base_branch` from task or repo config.
+2. On `completed`, worktree is kept.
+3. On `review_changes_requested` with changes, worktree is kept (`should_keep_task_worktree`).
+4. Preview harvest: `python -m agent_fleet.workstreams harvest <path> --target feature/my-branch --dry-run`
+5. Harvest: `python -m agent_fleet.workstreams harvest <path> --target feature/my-branch`
+
+Harvest merges the worktree HEAD commit onto the target branch by SHA. Use `--base` when the target branch does not exist yet.
+
+## auto_fix vs redispatch
+
+- **`code_review.auto_fix`**: same task, fix persona, re-run review (soft failure).
+- **`max_redispatches`**: new session on hard failures (`error`, `timeout`, `scope_violation`).
+
+Enable `auto_fix` in `.agent-fleet.yaml` for self-dispatch buildouts.
+
+## Skills buildout (legacy script)
+
+`scripts/dispatch-skills-buildout.py` remains for the 5-PR stack; new cleanup work uses workstreams only.
+
+## Integration checklist
+
+Wire workstreams into the installed CLI (outside this module):
+
+1. `agent_fleet/cli.py` — call `register_workstream_commands(sub)`
+2. `agent_fleet/repo.py` — expose `RepoConfig.workstreams` via `load_workstreams_config`
+3. `agent_fleet/__init__.py` — export `run_workstreams`
+
+The module is self-contained until those hooks land; `python -m agent_fleet.workstreams` exercises list/run/harvest end-to-end.

--- a/docs/FLEET-CONFIG.md
+++ b/docs/FLEET-CONFIG.md
@@ -42,20 +42,6 @@ Bundled personas ship inside the installed package at `agent_fleet/personas/`. *
 | Global `~/.agent-fleet/fleet.yaml` | Omit → bundled package personas. If set, must be absolute; relative paths resolve against the config directory (usually wrong). |
 | Repo `.agent-fleet.yaml` | Optional. Relative paths resolve against the **repo root**. Overrides bundled personas for dispatches in that repo. |
 
-### Resolution order (repo dir, then package fallback)
-
-When a repo sets `personas_dir: agents/personas` (or any custom directory), fleet searches **that directory first**, then falls back to bundled `agent_fleet/personas/` for prompts and loadouts not defined locally.
-
-| Lookup | Order |
-|--------|-------|
-| Prompt markdown (`coder.md`, loadout `stub:`) | repo `personas_dir` → package `agent_fleet/personas/` |
-| Loadout YAML (`*.loadout.yaml`) | repo `personas_dir` → package |
-| `fleet.yaml` `personas:` entries | Must resolve via the same search order; prune stale entries whose prompt `.md` is missing from both dirs |
-
-This lets self-hosted repos keep workstream-specific personas under `agents/personas/` while still dispatching bundled personas like `coder` or `pr-analyzer` without copying them.
-
-Regression coverage: `tests/test_persona_registry.py` resolves every `agents/personas/*.md` and every YAML config that sets `personas_dir: agents/personas`.
-
 Example — repo-local personas (recommended pattern):
 
 ```yaml
@@ -83,6 +69,12 @@ When a persona prompt or loadout is requested, fleet searches in this order:
 2. **Bundled package personas** — `agent_fleet/personas/` inside the installed package (fallback when a file is missing from the repo tree).
 3. **Skill-backed prompt** — if the persona spec sets `skill: …`, fleet searches configured `skill_dirs`.
 4. **Absolute or tilde path** — `prompt: /path/to/foo.md` or `prompt: ~/fleet/foo.md`.
+
+| Lookup | Order |
+|--------|-------|
+| Prompt markdown (`coder.md`, loadout `stub:`) | repo `personas_dir` → package `agent_fleet/personas/` |
+| Loadout YAML (`*.loadout.yaml`) | repo `personas_dir` → package |
+| `fleet.yaml` `personas:` entries | Same search order; use `prune_fleet_yaml_personas()` to drop entries whose prompt `.md` is missing from both dirs |
 
 This lets repos override bundled personas (e.g. `agents/personas/reviewer.md`) while still resolving bundled defaults such as `coder.md` when only repo-specific personas exist locally.
 

--- a/docs/FLEET-CONFIG.md
+++ b/docs/FLEET-CONFIG.md
@@ -1,0 +1,88 @@
+# Fleet configuration
+
+Where global fleet settings live, how `personas_dir` resolves, and how to avoid import shadowing.
+
+## Global config file
+
+| Location | Status |
+|----------|--------|
+| `~/.agent-fleet/fleet.yaml` | **Preferred** — new installs |
+| `~/.hermes/coding_fleet/fleet.yaml` | Legacy Hermes path (still read by older tooling) |
+
+Copy the template:
+
+```bash
+mkdir -p ~/.agent-fleet
+cp fleet.example.yaml ~/.agent-fleet/fleet.yaml
+```
+
+Override path for a single command:
+
+```bash
+agent-fleet run "..." --config /path/to/fleet.yaml
+```
+
+Environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `AGENT_FLEET_CONFIG` | Global fleet.yaml path (issue dispatch watcher) |
+| `CODING_FLEET_CONFIG` | Global fleet.yaml path (Hermes plugin tools) |
+
+Repo-level settings (verify commands, scope, PR loop) always come from `.agent-fleet.yaml` in the target git repo — not from the global file.
+
+See also: [NEW-REPO.md](NEW-REPO.md), [PERSONAS.md](PERSONAS.md), [AGENT-FLEET-DEV.md](AGENT-FLEET-DEV.md).
+
+## personas_dir
+
+Bundled personas ship inside the installed package at `agent_fleet/personas/`. **Leave `personas_dir` unset in global `fleet.yaml`** unless you maintain a separate persona tree with an **absolute** path.
+
+| Config file | `personas_dir` behavior |
+|-------------|-------------------------|
+| Global `~/.agent-fleet/fleet.yaml` | Omit → bundled package personas. If set, must be absolute; relative paths resolve against the config directory (usually wrong). |
+| Repo `.agent-fleet.yaml` | Optional. Relative paths resolve against the **repo root**. Overrides bundled personas for dispatches in that repo. |
+
+Example — repo-local personas (recommended pattern):
+
+```yaml
+# .agent-fleet.yaml
+personas_dir: agents/personas
+persona_scope_allowlist:
+  cleanup-config:
+    - fleet.example.yaml
+```
+
+Example — global override (only when you have a dedicated persona directory):
+
+```yaml
+# ~/.agent-fleet/fleet.yaml
+personas_dir: /home/you/fleet-personas
+```
+
+**Do not** set `personas_dir: personas` or other relative paths in global config — fleet will look under `~/.agent-fleet/personas/`, which is empty, and persona resolution fails.
+
+## Import shadow
+
+Python imports the first `agent_fleet` package it finds on `sys.path`. A checkout at **`~/Documents/agent_fleet`** (underscore) is a frequent mistake: running Python with that directory as cwd or on `PYTHONPATH` loads the wrong tree — stale code, missing CLI commands, or silent behavior drift.
+
+**Safe clone paths:** `~/agent-fleet-dev`, `~/Documents/agent-fleet` (hyphen), or any path **not** named `agent_fleet` that sits on `sys.path` as a package root.
+
+Check your environment:
+
+```bash
+python3 scripts/check-import-shadow.py
+# stricter: also warn when ~/Documents/agent_fleet exists on disk
+python3 scripts/check-import-shadow.py --strict-disk
+```
+
+The script reports the active import path, flags shadow entries on `sys.path`, and **never deletes** user directories. Fix by renaming/moving the checkout, using `pip install -e .` from your dev tree, and keeping `~/Documents/agent_fleet` off `PYTHONPATH`.
+
+## Runs and level-up storage
+
+| Path | Purpose |
+|------|---------|
+| `~/.agent-fleet/runs/` or `~/.hermes/fleet/runs/` | JSONL dispatch logs (legacy dir wins if it already exists) |
+| `~/.agent-fleet/level_up/` | Persona learning journals and overlays |
+| `~/.agent-fleet/skills/` | Optional user skill overrides |
+
+Use `agent-fleet paths` (when available) to print resolved locations for your machine.

--- a/docs/FLEET-CONFIG.md
+++ b/docs/FLEET-CONFIG.md
@@ -61,6 +61,34 @@ personas_dir: /home/you/fleet-personas
 
 **Do not** set `personas_dir: personas` or other relative paths in global config — fleet will look under `~/.agent-fleet/personas/`, which is empty, and persona resolution fails.
 
+## Persona resolution order
+
+When a persona prompt or loadout is requested, fleet searches in this order:
+
+1. **Repo `personas_dir`** — from `.agent-fleet.yaml` when dispatching in a repo (relative paths resolve against the repo root).
+2. **Bundled package personas** — `agent_fleet/personas/` inside the installed package (fallback when a file is missing from the repo tree).
+3. **Skill-backed prompt** — if the persona spec sets `skill: …`, fleet searches configured `skill_dirs`.
+4. **Absolute or tilde path** — `prompt: /path/to/foo.md` or `prompt: ~/fleet/foo.md`.
+
+This lets repos override bundled personas (e.g. `agents/personas/reviewer.md`) while still resolving bundled defaults such as `coder.md` when only repo-specific personas exist locally.
+
+Loadouts (`.loadout.yaml`) and stub markdown referenced by a loadout follow the same repo-then-package search. `YamlPersonaResolver.list_personas()` unions names from both directories plus any explicit `personas:` entries in `fleet.yaml`.
+
+Example — repo-local override with package fallback:
+
+```yaml
+# .agent-fleet.yaml
+personas_dir: agents/personas
+```
+
+| Persona | `agents/personas/` | Package fallback |
+|---------|-------------------|------------------|
+| `fleet-registry` | `fleet-registry.md` | — |
+| `coder` | (missing) | `agent_fleet/personas/coder.md` |
+| `reviewer` | `reviewer.md` (repo wins) | `agent_fleet/personas/reviewer.md` |
+
+Run `pytest tests/test_persona_registry.py` to verify every persona under `agents/personas` and every `fleet.yaml` entry tied to that directory resolves on your checkout.
+
 ## Import shadow
 
 Python imports the first `agent_fleet` package it finds on `sys.path`. A checkout at **`~/Documents/agent_fleet`** (underscore) is a frequent mistake: running Python with that directory as cwd or on `PYTHONPATH` loads the wrong tree — stale code, missing CLI commands, or silent behavior drift.

--- a/docs/FLEET-CONFIG.md
+++ b/docs/FLEET-CONFIG.md
@@ -42,6 +42,20 @@ Bundled personas ship inside the installed package at `agent_fleet/personas/`. *
 | Global `~/.agent-fleet/fleet.yaml` | Omit → bundled package personas. If set, must be absolute; relative paths resolve against the config directory (usually wrong). |
 | Repo `.agent-fleet.yaml` | Optional. Relative paths resolve against the **repo root**. Overrides bundled personas for dispatches in that repo. |
 
+### Resolution order (repo dir, then package fallback)
+
+When a repo sets `personas_dir: agents/personas` (or any custom directory), fleet searches **that directory first**, then falls back to bundled `agent_fleet/personas/` for prompts and loadouts not defined locally.
+
+| Lookup | Order |
+|--------|-------|
+| Prompt markdown (`coder.md`, loadout `stub:`) | repo `personas_dir` → package `agent_fleet/personas/` |
+| Loadout YAML (`*.loadout.yaml`) | repo `personas_dir` → package |
+| `fleet.yaml` `personas:` entries | Must resolve via the same search order; prune stale entries whose prompt `.md` is missing from both dirs |
+
+This lets self-hosted repos keep workstream-specific personas under `agents/personas/` while still dispatching bundled personas like `coder` or `pr-analyzer` without copying them.
+
+Regression coverage: `tests/test_persona_registry.py` resolves every `agents/personas/*.md` and every YAML config that sets `personas_dir: agents/personas`.
+
 Example — repo-local personas (recommended pattern):
 
 ```yaml

--- a/docs/PERSONA-EVOLUTION.md
+++ b/docs/PERSONA-EVOLUTION.md
@@ -26,7 +26,7 @@ agent_fleet/base-kit/
   manifest.yaml                 # pinned upstream SHAs, licenses
   superpowers/                  # vendored skills (sync script)
   pstack/                       # vendored skills
-  cursor-team-kit/deslop/
+  cursor-team-kit/              # vendored PR/CI/verify skills (sync script)
 
 agent_fleet/personas/
   *.loadout.yaml                # human recipes → base-kit skill ids
@@ -102,7 +102,7 @@ persona: coder
 pipeline: code_review
 base_loadout: coder
 skill_slots_execute: [...]      # catalog ids from base-kit
-skill_slots_review: [cursor-team-kit/deslop]
+skill_slots_review: [pstack/unslop, cursor-team-kit/deslop]
 level_up_generation: 2
 parent_run_id: null             # set for decomposed children
 source_weight: 1.0
@@ -146,14 +146,14 @@ Every equip/promote/compact emits structured events to:
 - `~/.agent-fleet/fleet/runs/<run-id>.jsonl` (when `run_id` set)
 - `~/.agent-fleet/level_up/<repo>/<persona>/journal.jsonl`
 
-Event namespaces: `equip.*`, `phase.review.deslop`, `run.complete`, `experience.appended`, `level_up.gate.*`, `level_up.compact.*`.
+Event namespaces: `equip.*`, `phase.review.unslop`, `run.complete`, `experience.appended`, `level_up.gate.*`, `level_up.compact.*`.
 
 ---
 
 ## Pipelines
 
-- **Execute** — persona loadout + overlays; no deslop
-- **Review** — reviewer loadout + **deslop** (`review_skill_slots`)
+- **Execute** — persona loadout (default: **pstack** skills) + overlays; no unslop
+- **Review** — reviewer loadout + **unslop** + **deslop** (`review_skill_slots`)
 
 PR loop, issue dispatch, and CLI all go orchestration equip → dispatcher.
 
@@ -193,7 +193,7 @@ agent-fleet level-up compact --repo NAME --persona coder
 | `agent_fleet/personas.py` | loadout + compose prompt |
 | `agent_fleet/dispatcher.py` | pass equip context |
 | `agent_fleet/dispatcher_task.py` | record experience + journal |
-| `agent_fleet/phases.py` | review deslop skills |
+| `agent_fleet/phases.py` | review unslop + deslop skills |
 | `agent_fleet/tech_lead.py` | skill promotion review (extension) |
 
 No separate “trainer” or “classifier” product terms.

--- a/docs/PERSONAS.md
+++ b/docs/PERSONAS.md
@@ -13,6 +13,21 @@ Both merge at dispatch time. Repo settings override global defaults where noted 
 
 For persona loadouts, overlays, and local level-up journaling, see **[PERSONA-EVOLUTION.md](PERSONA-EVOLUTION.md)**.
 
+## Bundled persona loadouts
+
+Every first-class bundled persona ships with a `*.loadout.yaml` in `agent_fleet/personas/`. Loadouts reference base-kit skill ids; markdown stubs stay thin role/methodology text.
+
+| Persona | Execute skills | Review / notes |
+|---------|----------------|----------------|
+| `coder` | TDD, prove-it-works, boundary discipline, git worktrees, … | — |
+| `reviewer` | interrogate, reflect | `pstack/unslop`, `cursor-team-kit/deslop` on review phase |
+| `pr-analyzer` | `pstack/interrogate`, `pstack/how` | quality pass in `pr_review/prompts.py` (thermo-nuclear) |
+| `explorer` | `pstack/how`, `pstack/why` | read-only; mode `plan` |
+| `tech-scout` | `pstack/how`, `pstack/figure-it-out` | read-only scout pipeline |
+| `product-scout` | `pstack/how`, `pstack/reflect` | read-only scout pipeline |
+
+At dispatch, orchestration composes: loadout skills + stub markdown + fleet/repo overlays. See `agent_fleet/personas/*.loadout.yaml`.
+
 ## Execution backends
 
 Agent Fleet runs the same personas and pipelines through a pluggable execution backend. Set `default_backend` in `fleet.yaml`:

--- a/docs/REDISPATCH.md
+++ b/docs/REDISPATCH.md
@@ -118,3 +118,27 @@ the attempt number and whether a handoff is present:
 The `FleetTaskResult` returned to the caller reflects the final attempt's outcome, so you can
 tell a task succeeded on the second attempt by checking `result.status == "completed"` after
 a run that would otherwise have failed.
+
+## Worktree retention vs auto cleanup
+
+Parallel and `use_worktree: true` runs create an isolated git worktree under
+`worktree_base` (default `/tmp/agent-fleet-worktrees`). When the task finishes,
+`TaskWorkspace.teardown(keep=...)` either removes that directory or leaves it for harvest.
+
+| Mechanism | Behavior |
+|-----------|----------|
+| **`teardown(keep=False)`** (auto cleanup) | Default when the worktree should not survive. Runs `git worktree remove` and deletes the checkout directory. |
+| **`teardown(keep=True)`** | Skips removal; the path stays on disk for `agent-fleet workstream harvest` or manual inspection. |
+| **`should_keep_task_worktree()`** | Central policy used by the dispatcher to choose `keep=`. Keeps on `completed` / `merged`, when `code_review.auto_push` needs an isolated branch, and on recoverable soft failures (`verify_failed`, `review_changes_requested`) **when there are changed files**. |
+
+Recoverable statuses are **not** redispatched (see table above). When they have local
+changes, the dispatcher auto-commits before teardown so WIP is on the fleet branch even if
+the worktree directory is kept:
+
+```python
+maybe_commit_recoverable_worktree(task_workspace, status, goal=task.goal)
+task_workspace.teardown(keep=should_keep_task_worktree(...))
+```
+
+Hard failures (`error`, `timeout`, `scope_violation`, …) always use auto cleanup
+(`keep=False`) so the next redispatch attempt starts from a fresh worktree.

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -29,7 +29,7 @@ Each item becomes one fleet task with:
 
 ## CLI
 
-Primary entry (once wired into `agent-fleet`):
+Primary entry:
 
 ```bash
 # List configured workstreams
@@ -59,7 +59,7 @@ agent-fleet workstream harvest .worktrees/fleet-runs/task-0-abc123 \
   --workspace /path/to/repo
 ```
 
-Module entry (available before top-level CLI wiring):
+Module entry (same handlers, useful when debugging the workstreams package):
 
 ```bash
 python -m agent_fleet.workstreams list --workspace /path/to/repo

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -59,7 +59,7 @@ agent-fleet workstream harvest .worktrees/fleet-runs/task-0-abc123 \
   --workspace /path/to/repo
 ```
 
-Module entry (same handlers, useful when debugging the workstreams package):
+Module entry (also available as a standalone module):
 
 ```bash
 python -m agent_fleet.workstreams list --workspace /path/to/repo

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -1,0 +1,122 @@
+# Workstreams
+
+Workstreams are **first-class repo-defined task batches** in agent-fleet. Declare them in `.agent-fleet.yaml` and dispatch with the CLI — no ad-hoc Python scripts required.
+
+## Configuration
+
+```yaml
+workstreams:
+  plan: docs/superpowers/plans/2026-05-25-repo-cleanup-buildout.md
+  base_branch: feature/skills-pr-loop
+  default_target_branch: feature/repo-cleanup
+  pipeline: code_review
+  sequential_stack: true   # block parallel runs when persona scopes overlap
+  items:
+    - id: worktree
+      persona: cleanup-worktree
+      goal: |
+        Improve worktree retention and commit-before-teardown...
+      target_branch: feature/repo-cleanup
+      base_branch: feature/skills-pr-loop
+```
+
+Each item becomes one fleet task with:
+
+- `goal` / optional per-item `context`
+- `persona` (must exist under `personas_dir`)
+- `base_branch` for isolated worktree checkout (falls back to workstream or repo `default_branch`)
+- `target_branch` communicated in task context for the agent to commit on
+
+## CLI
+
+Primary entry (once wired into `agent-fleet`):
+
+```bash
+# List configured workstreams
+agent-fleet workstream list --workspace /path/to/repo
+
+# Run one workstream (sequential, default)
+agent-fleet workstream run worktree --workspace /path/to/repo
+
+# Preview tasks without dispatching
+agent-fleet workstream run dispatch-tooling --dry-run --workspace /path/to/repo
+
+# Run all workstreams
+agent-fleet workstream run --all --workspace /path/to/repo
+
+# Parallel batch (blocked when scopes overlap and sequential_stack: true)
+agent-fleet workstream run --all --parallel --workspace /path/to/repo
+
+# Merge a fleet-run worktree onto a feature branch
+agent-fleet workstream harvest .worktrees/fleet-runs/task-0-abc123 \
+  --target feature/repo-cleanup \
+  --workspace /path/to/repo
+
+# Preview harvest plan
+agent-fleet workstream harvest .worktrees/fleet-runs/task-0-abc123 \
+  --target feature/repo-cleanup \
+  --dry-run \
+  --workspace /path/to/repo
+```
+
+Module entry (available before top-level CLI wiring):
+
+```bash
+python -m agent_fleet.workstreams list --workspace /path/to/repo
+python -m agent_fleet.workstreams harvest .worktrees/fleet-runs/task-0-abc123 \
+  --target feature/repo-cleanup --dry-run
+```
+
+### Flags
+
+| Command | Flag | Purpose |
+|---------|------|---------|
+| all | `--workspace` | Repo root (walks up for `.agent-fleet.yaml`) |
+| all | `--config` | Optional `fleet.yaml` path for dispatcher |
+| `run` | `--all` | Run every configured item |
+| `run` | `--parallel` | Concurrent dispatch when scopes are disjoint |
+| `run` | `--dry-run` | Print task payloads, do not dispatch |
+| `harvest` | `--target` | Branch to merge worktree commits onto |
+| `harvest` | `--base` | Start ref when creating a missing target branch |
+| `harvest` | `--dry-run` | Show source SHA/branch without merging |
+
+## Scope overlap protection
+
+When `sequential_stack: true` and you pass `--parallel`, agent-fleet compares `persona_scope_allowlist` prefixes across personas in the batch. Overlapping paths raise an error before any agent runs — preventing the PR2/PR3 `prompts/` collision class of bugs.
+
+## Worktree lifecycle
+
+Dispatcher behavior (see `should_keep_task_worktree`):
+
+| Status | Worktree kept when |
+|--------|-------------------|
+| `completed`, `merged` | Always |
+| `review_changes_requested`, `verify_failed` | When there are changed files |
+| `auto_push` enabled | Isolated worktree kept for publish |
+
+Harvest surviving worktrees with `agent-fleet workstream harvest` (or `python -m agent_fleet.workstreams harvest`).
+
+Harvest merges by **commit SHA** (not branch name) and aborts on conflict, leaving the repo checkout unchanged on failure.
+
+## Python API
+
+```python
+from agent_fleet.repo import find_repo_config
+from agent_fleet.workstreams import run_workstreams
+from agent_fleet.workstreams.cli import load_repo_workstreams
+
+repo = find_repo_config("/path/to/repo")
+config = load_repo_workstreams(repo.repo_root)
+results = run_workstreams(
+    repo=repo,
+    config=config,
+    item_ids=["worktree", "config"],
+    parallel=False,
+)
+```
+
+## Related
+
+- [DISPATCH-COOKBOOK.md](DISPATCH-COOKBOOK.md) — sequential vs parallel, harvest workflow
+- [REDISPATCH.md](REDISPATCH.md) — hard-failure retries vs `code_review.auto_fix`
+- [AGENT-FLEET-DEV.md](AGENT-FLEET-DEV.md) — equip and persona loadouts

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -67,6 +67,17 @@ python -m agent_fleet.workstreams harvest .worktrees/fleet-runs/task-0-abc123 \
   --target feature/repo-cleanup --dry-run
 ```
 
+### Preflight
+
+Before `run --all`, run the checklist in [DISPATCH-COOKBOOK.md](DISPATCH-COOKBOOK.md#preflight-run-before-every-batch). Minimum:
+
+```bash
+pip install -e .
+agent-fleet personas validate --workspace .
+agent-fleet workstream list --workspace .
+agent-fleet workstream run --all --dry-run --workspace .
+```
+
 ### Flags
 
 | Command | Flag | Purpose |

--- a/docs/superpowers/plans/2026-05-25-agent-fleet-integration.md
+++ b/docs/superpowers/plans/2026-05-25-agent-fleet-integration.md
@@ -1,0 +1,10 @@
+# Agent-Fleet Integration Plan
+
+Dispatch via workstreams (not ad-hoc scripts):
+
+```bash
+agent-fleet workstream run registry          # sequential: do this first
+agent-fleet workstream run scout-loadouts skills-stack --parallel
+```
+
+See [WORKSTREAMS.md](../../WORKSTREAMS.md).

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -1,0 +1,316 @@
+# Skills Integration Buildout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make agent-fleet use the base-kit skill catalog consistently across every agent dispatch path — dispatcher, PR loop, code_review auto-fix, and secondary personas — with curated defaults and situational dynamic equip.
+
+**Architecture:** Introduce a single prompt builder (`agent_fleet/prompts/agent.py`) that layers `resolve_dispatch_equip()` → `compose_body` → task-specific sections. All `backend.run()` call sites that represent a persona doing work must go through it. Loadouts remain human-curated recipes; `equip.py` owns situational skill injection. Work lands as **5 stacked PRs** in isolated worktrees off `main`.
+
+**Tech Stack:** Python 3.14, pytest, existing FleetTask/DispatchEquip, base-kit sync script, git worktrees under `.worktrees/`.
+
+---
+
+## Problem summary (from audit)
+
+| Gap | Impact |
+|-----|--------|
+| PR loop (`lifecycle.py`) hand-rolls prompts | CI/review fix agents miss fix-ci, verify-this, pstack principles |
+| `code_review/fix.py` hand-rolls prompts | auto-fix loop misses equip |
+| Only `coder` + `reviewer` loadouts | pr-analyzer, explorer, scouts run skill-less |
+| v0.7.0 coder loadout duplicated superpowers + pstack | ~30k chars redundant guidance |
+| Review had deslop OR unslop, not both | code vs prose cleanup split wrong |
+| Dynamic equip only on `verify_failed` | pr_loop, worktree, CI-fix contexts ignored |
+| thermo-nuclear in `agent_fleet/skills/` AND base-kit | two ids, drift risk |
+| Large uncommitted WIP on `main` | blocks clean branch stack |
+
+---
+
+## Branch / worktree stack
+
+Work from **`main` @ v0.7.0** (or current `main` after stashing WIP). Each PR merges into the previous branch tip (stack) or rebase onto merged predecessor.
+
+```
+main
+ └── feature/skills-foundation      PR1  (land WIP + sync + loadout curation)
+      └── feature/skills-prompt-builder   PR2  (shared prompt builder)
+           └── feature/skills-pr-loop      PR3  (wire PR loop + code_review fix)
+                └── feature/skills-personas    PR4  (secondary persona loadouts)
+                     └── feature/skills-canonical PR5  (thermo-nuclear + equip polish)
+```
+
+**Worktree commands** (run from repo root):
+
+```bash
+git stash push -u -m "wip skills foundation"
+git worktree add .worktrees/skills-foundation -b feature/skills-foundation main
+# After PR1 merges:
+git worktree add .worktrees/skills-prompt-builder -b feature/skills-prompt-builder main
+# … repeat per branch
+```
+
+Restore stash into `feature/skills-foundation` worktree, not `main`.
+
+---
+
+## PR1: `feature/skills-foundation` — catalog + curated defaults
+
+**Goal:** Ship vendored cursor-team-kit catalog and sane default loadouts; dynamic equip for pr_loop + verify_failed.
+
+### Files
+
+- Modify: `scripts/sync-base-kit.sh` (full cursor-team-kit rsync — **done in WIP**)
+- Modify: `agent_fleet/base-kit/manifest.yaml`, vendored trees
+- Modify: `agent_fleet/personas/coder.loadout.yaml`, `reviewer.loadout.yaml`
+- Modify: `agent_fleet/skills_lib.py` (`PR_LOOP_EXECUTE_SKILLS`, `SYSTEMATIC_DEBUGGING_SKILL = pstack/why`)
+- Modify: `agent_fleet/orchestration/equip.py` (pr_loop dynamic skills — **done in WIP**)
+- Modify: `docs/AGENT-FLEET-DEV.md`, `docs/PERSONA-EVOLUTION.md`
+- Test: `tests/test_loadouts.py`, `tests/test_equip.py`
+
+### Coder execute (final)
+
+```yaml
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
+```
+
+**Remove** all `superpowers/*` from default coder loadout (keep superpowers in catalog for custom loadouts).
+
+### Reviewer review phase (final)
+
+```yaml
+pipeline_skills:
+  code_review:
+    review:
+      - pstack/unslop
+      - cursor-team-kit/deslop
+```
+
+### Dynamic equip rules (equip.py)
+
+| Condition | Skills appended to execute |
+|-----------|---------------------------|
+| `last_experience_shows_verify_failed` | `pstack/why` |
+| `repo.pr_loop.enabled` | `fix-ci`, `loop-on-ci`, `get-pr-comments` |
+
+### Tasks
+
+- [ ] Stash/commit-split WIP: separate unrelated changes (fleet_paths, pr_loop preflight) if needed
+- [ ] Run `./scripts/sync-base-kit.sh`; commit vendored trees + manifest
+- [ ] Apply loadout yaml + skills_lib + equip changes
+- [ ] `pytest tests/test_loadouts.py tests/test_equip.py tests/test_phases_deslop.py -q`
+- [ ] Update docs default skills section
+- [ ] Open PR1
+
+---
+
+## PR2: `feature/skills-prompt-builder` — single prompt assembly
+
+**Goal:** DRY prompt construction so every path can prepend persona+skills consistently.
+
+### Files
+
+- Create: `agent_fleet/prompts/__init__.py`
+- Create: `agent_fleet/prompts/agent.py`
+- Create: `tests/test_prompts_agent.py`
+
+### API
+
+```python
+@dataclass(frozen=True)
+class AgentPrompt:
+    full: str
+    persona_section: str
+    task_section: str
+
+def build_agent_prompt(
+    *,
+    persona_body: str,
+    task_heading: str,
+    task_body: str,
+    context: str = "",
+    extra_sections: list[tuple[str, str]] | None = None,
+) -> AgentPrompt:
+    """Layer persona (skills+stub+overlays) then structured task sections."""
+```
+
+Rules:
+- `persona_body` is always `equip.compose_body` when equip exists, else `read_persona_body(persona)`
+- Task sections use consistent `##` headings (matches phases.py style)
+- `extra_sections` = `[("Review", review_body), ("PR changed files", ...)]`
+
+### Refactor (minimal in PR2 — just extract + test)
+
+- [ ] Implement `build_agent_prompt` with tests
+- [ ] Refactor `phases._build_execute_prompt` to call it (behavior-preserving)
+- [ ] `pytest tests/test_phases_execute_equip.py tests/test_prompts_agent.py -q`
+- [ ] Open PR2
+
+---
+
+## PR3: `feature/skills-pr-loop` — wire equip into fix agents
+
+**Goal:** PR loop and code_review auto-fix use the same skill stack as dispatcher.
+
+### Files
+
+- Modify: `agent_fleet/pr_loop/lifecycle.py` — `address_review_findings`, `attempt_ci_fix`
+- Modify: `agent_fleet/code_review/fix.py` — `run_fix_phase`
+- Modify: `agent_fleet/prompts/agent.py` — optional `equip_context` tag for journal
+- Create: `tests/test_pr_loop_equip.py`
+- Create: `tests/test_code_review_fix_equip.py`
+
+### Pattern (both PR loop functions)
+
+```python
+from agent_fleet.hooks import FleetTask
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
+from agent_fleet.prompts.agent import build_agent_prompt
+
+task = FleetTask(
+    goal=f"Fix PR #{pr_number} review findings",
+    context=f"branch={branch}",
+    persona=fix_persona_name,
+    workspace=str(worktree),
+)
+equip = resolve_dispatch_equip(task, fleet_config, repo, run_id=f"pr-loop-{pr_number}")
+prompt = build_agent_prompt(
+    persona_body=equip.compose_body,
+    task_heading="Task",
+    task_body=...,  # existing review/CI instructions
+    extra_sections=[("Review", review_body), ...],
+).full
+```
+
+Notes:
+- Pass `repo` into equip so pr_loop dynamic skills apply
+- Keep `persona_obj.model/mode/allowed_tools` from resolver
+- CI fix task goal should mention failed checks so verify-this/fix-ci skills activate contextually
+
+### code_review/fix.py
+
+- Accept optional `task.equip` or call `resolve_dispatch_equip` inside fix phase
+- Prepend `equip.compose_body` to fix prompt (same as execute phase)
+
+### Tasks
+
+- [ ] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
+- [ ] Wire lifecycle.py (review fix + CI fix)
+- [ ] Wire code_review/fix.py
+- [ ] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
+- [ ] Manual smoke: `agent-fleet loop` dry path with mock backend if available
+- [ ] Open PR3
+
+---
+
+## PR4: `feature/skills-personas` — loadouts for all bundled personas
+
+**Goal:** Every first-class persona gets a loadout; markdown stubs stay thin.
+
+### New loadouts
+
+| Persona | execute skills | review / notes |
+|---------|----------------|----------------|
+| `pr-analyzer` | `pstack/interrogate`, `pstack/how` | quality pass stays in `pr_review/prompts.py` (thermo-nuclear) |
+| `explorer` | `pstack/how`, `pstack/why` | read-only; mode plan |
+| `tech-scout` | `pstack/how`, `pstack/figure-it-out` | read-only scout |
+| `product-scout` | `pstack/how`, `pstack/reflect` | read-only scout |
+
+Optional: `planner` persona if full pipeline uses one — add `pstack/architect` + `superpowers/brainstorming` only if planner is a distinct persona name in fleet.yaml.
+
+### Files
+
+- Create: `agent_fleet/personas/pr-analyzer.loadout.yaml`, `explorer.loadout.yaml`, etc.
+- Modify: `tests/test_loadouts.py` — parametrize all loadouts resolve
+- Modify: `docs/PERSONAS.md` — loadout table
+
+### Tasks
+
+- [ ] Add loadout yamls + stub references
+- [ ] Test every skill id resolves under base-kit
+- [ ] Open PR4
+
+---
+
+## PR5: `feature/skills-canonical` — dedupe + extended dynamic equip
+
+**Goal:** One canonical thermo-nuclear id; richer situational equip without bloating every dispatch.
+
+### Thermo-nuclear canonical id
+
+- Prefer: `cursor-team-kit/thermo-nuclear-code-quality-review` in base-kit
+- Change `DEFAULT_QUALITY_REVIEW_SKILL` and `agent_fleet/skills/` to re-export or symlink via `resolve_skill_path` search order (bundled dir → base-kit)
+- Delete duplicate `agent_fleet/skills/thermo-nuclear-code-quality-review/SKILL.md` once base-kit resolves
+- Update Hermes copy or point Hermes at base-kit path in deploy script
+
+### Extended dynamic equip (equip.py)
+
+| Condition | Skills |
+|-----------|--------|
+| `repo.use_worktree` or task on worktree branch | `superpowers/using-git-worktrees` (if not in loadout) |
+| task.context contains `ci_fix` or phase is CI fix | `cursor-team-kit/fix-ci` (even without pr_loop) |
+| task.pipeline == `full` && persona == planner | `pstack/architect` (if planner loadout exists) |
+
+Keep guards: skip if already in loadout; skip if `skill_exists_in_base_kit` false.
+
+### Tasks
+
+- [ ] Unify thermo-nuclear resolution + tests in `test_skills_quality.py`
+- [ ] Add dynamic equip conditions + tests
+- [ ] Run full `pytest -q`
+- [ ] Open PR5
+
+---
+
+## Out of scope (v1) — track as follow-ups
+
+- **`poteto-mode` as coder loadout replacement** — needs A/B; defer
+- **Full pipeline phases** (planner/researcher/synthesizer/implementer) — audit after PR3 pattern proven; many already use sessions via runner
+- **Level-up promoting catalog skill ids** — overlay text only today; separate feature
+- **Hermes skill duplication** — trim in deploy script after PR5
+
+---
+
+## Verification gate (every PR)
+
+```bash
+cd /path/to/worktree
+uv sync --frozen --group dev
+pytest -q
+ruff check agent_fleet tests
+ty check agent_fleet  # if configured in CI
+```
+
+PR merges only when CI green. Stack rebase: each new branch rebases onto merged predecessor before merge to main.
+
+---
+
+## Execution order for agents
+
+1. **PR1** — unblocks catalog; land first (includes current WIP)
+2. **PR2** — required before PR3 (shared builder)
+3. **PR3** — highest user-visible fix (PR loop)
+4. **PR4** — parallelizable after PR1 if PR2/3 in flight
+5. **PR5** — cleanup after PR1–4 merged
+
+Estimated: **PR1 ~2h, PR2 ~1h, PR3 ~3h, PR4 ~1.5h, PR5 ~2h** (agent time, parallelizable PR4).
+
+---
+
+## Success criteria
+
+- [ ] PR loop fix prompts include composed skill text (grep test for skill headings)
+- [ ] Coder loadout has no superpowers/pstack duplication
+- [ ] Reviewer review phase runs unslop + deslop
+- [ ] All bundled personas have loadouts; all ids resolve
+- [ ] thermo-nuclear single canonical path
+- [ ] `pytest -q` green on main after full stack merges

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -235,8 +235,8 @@ Optional: `planner` persona if full pipeline uses one — add `pstack/architect`
 
 ### Tasks
 
-- [ ] Add loadout yamls + stub references
-- [ ] Test every skill id resolves under base-kit
+- [x] Add loadout yamls + stub references
+- [x] Test every skill id resolves under base-kit
 - [ ] Open PR4
 
 ---
@@ -311,6 +311,6 @@ Estimated: **PR1 ~2h, PR2 ~1h, PR3 ~3h, PR4 ~1.5h, PR5 ~2h** (agent time, parall
 - [ ] PR loop fix prompts include composed skill text (grep test for skill headings)
 - [ ] Coder loadout has no superpowers/pstack duplication
 - [ ] Reviewer review phase runs unslop + deslop
-- [ ] All bundled personas have loadouts; all ids resolve
+- [x] All bundled personas have loadouts; all ids resolve
 - [ ] thermo-nuclear single canonical path
 - [ ] `pytest -q` green on main after full stack merges

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -203,10 +203,10 @@ Notes:
 
 ### Tasks
 
-- [ ] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
-- [ ] Wire lifecycle.py (review fix + CI fix)
-- [ ] Wire code_review/fix.py
-- [ ] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
+- [x] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
+- [x] Wire lifecycle.py (review fix + CI fix)
+- [x] Wire code_review/fix.py
+- [x] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
 - [ ] Manual smoke: `agent-fleet loop` dry path with mock backend if available
 - [ ] Open PR3
 

--- a/examples/repo-full.agent-fleet.yaml
+++ b/examples/repo-full.agent-fleet.yaml
@@ -34,12 +34,12 @@ pr_review:
 # --- Automated PR lifecycle (local watcher or Hermes coding_fleet_pr_loop) ---
 # When pr_loop.enabled is true, code_review inherits auto_fix + auto_push + auto_pr_loop.
 # Override explicitly:
-# code_review:
-#   auto_fix: true
-#   max_fix_attempts: 2
-#   fix_persona: coder
-#   auto_push: true
-#   auto_pr_loop: true
+code_review:
+  auto_fix: true
+  max_fix_attempts: 2
+  fix_persona: coder
+  auto_push: true
+  auto_pr_loop: true
 pr_loop:
   enabled: true
   branch_prefixes: [fleet/]

--- a/examples/repo.agent-fleet.yaml
+++ b/examples/repo.agent-fleet.yaml
@@ -82,6 +82,15 @@ critical_path_prefixes:
 #   contribute_to_fleet: true
 #   journal_task_summaries: true
 
+# code_review auto-fix loop (local pipeline: execute → review → fix → re-check)
+# When pr_loop.enabled is true, these defaults inherit automatically.
+# code_review:
+#   auto_fix: true
+#   max_fix_attempts: 2
+#   fix_persona: coder
+#   auto_push: false
+#   auto_pr_loop: false
+
 # Automated PR lifecycle (requires pr-analyzer workflow + local watcher)
 # Full example: examples/repo-full.agent-fleet.yaml — see docs/NEW-REPO.md
 # pr_loop:

--- a/fleet.example.yaml
+++ b/fleet.example.yaml
@@ -85,6 +85,10 @@ personas:
     prompt: tech-scout.md
     mode: plan
 
+# code_review auto_fix is repo-level (.agent-fleet.yaml), not global fleet.yaml.
+# Default: auto_fix=false. When pr_loop.enabled with no code_review section, inherits
+# auto_fix=true, auto_push=true, auto_pr_loop=true. See examples/repo-full.agent-fleet.yaml.
+
 pipelines:
   simple:
     - execute

--- a/fleet.example.yaml
+++ b/fleet.example.yaml
@@ -1,5 +1,7 @@
 # Global agent fleet config
-# Default location: ~/.hermes/coding_fleet/fleet.yaml
+# Preferred location: ~/.agent-fleet/fleet.yaml
+# Legacy (still supported by some tooling): ~/.hermes/coding_fleet/fleet.yaml
+# See docs/FLEET-CONFIG.md for paths, personas_dir rules, and import-shadow checks.
 
 # Default backend: cursor (Cursor SDK) or kimi (Kimi Code CLI)
 default_backend: cursor
@@ -24,9 +26,12 @@ max_redispatches: 1
 # default_model: kimi-for-coding
 # kimi_bin: ~/.local/bin/kimi-cli
 
-# Bundled personas ship inside the agent_fleet package (agent_fleet/personas/).
-# Override only for repo-local or custom persona directories:
-# personas_dir: /path/to/my/personas
+# personas_dir — bundled personas ship in the installed package (agent_fleet/personas/).
+# Leave UNSET in this global file so fleet uses the package defaults.
+# Relative paths here resolve against this config directory (~/.agent-fleet/) — usually wrong.
+# For repo-local personas, set personas_dir in .agent-fleet.yaml (relative to repo root).
+# Global override only with an absolute path to a custom persona tree:
+# personas_dir: /absolute/path/to/my/personas
 
 # --- MCP server catalog (v0.5.0) ---
 # Named MCP servers that personas can opt into via mcp_servers: [name, ...].

--- a/scripts/check-import-shadow.py
+++ b/scripts/check-import-shadow.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Detect agent_fleet namespace shadowing from stray checkout directories.
+
+A checkout at ~/Documents/agent_fleet (underscore) is a common footgun: if that
+directory is on sys.path (cwd, PYTHONPATH, or editable-install confusion), Python
+imports the wrong tree and the CLI behaves unpredictably.
+
+This script reports the active import location, scans sys.path for shadow
+entries, and warns when known risky directories exist on disk. It never deletes
+or modifies user directories.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+PACKAGE = "agent_fleet"
+
+# Checkouts here commonly shadow the installed package when cwd or PYTHONPATH
+# includes the directory. See docs/FLEET-CONFIG.md#import-shadow.
+KNOWN_SHADOW_ROOTS: tuple[Path, ...] = (Path.home() / "Documents" / "agent_fleet",)
+
+
+def _resolve(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _import_root(module_file: str | None) -> Path | None:
+    if not module_file:
+        return None
+    return _resolve(module_file).parent
+
+
+def _repo_root(package_dir: Path) -> Path:
+    return package_dir.parent
+
+
+def _path_entries() -> list[Path]:
+    entries: list[Path] = []
+    for raw in sys.path:
+        if not raw:
+            continue
+        try:
+            entries.append(_resolve(raw))
+        except OSError:
+            continue
+    return entries
+
+
+def _shadow_roots_on_syspath(*, exclude: Path | None) -> list[Path]:
+    shadows: list[Path] = []
+    for entry in _path_entries():
+        pkg = entry / PACKAGE
+        if not pkg.is_dir():
+            continue
+        if exclude is not None and entry == exclude:
+            continue
+        shadows.append(entry)
+    return shadows
+
+
+def _known_shadows_on_disk() -> list[Path]:
+    return [root for root in KNOWN_SHADOW_ROOTS if root.is_dir() and (root / PACKAGE).is_dir()]
+
+
+def _is_under(path: Path, ancestor: Path) -> bool:
+    try:
+        path.relative_to(ancestor)
+    except ValueError:
+        return False
+    return True
+
+
+def check_import_shadow(*, strict_disk: bool = False) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) describing shadow state."""
+    import agent_fleet
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    active_pkg = _import_root(agent_fleet.__file__)
+    active_repo = _repo_root(active_pkg) if active_pkg else None
+
+    if active_pkg is not None:
+        print(f"agent_fleet imported from: {active_pkg}")
+    else:
+        errors.append("Could not resolve agent_fleet.__file__")
+
+    for shadow_root in _known_shadows_on_disk():
+        if active_repo is not None and _is_under(active_repo, shadow_root):
+            errors.append(
+                f"Active import is under known shadow checkout: {shadow_root}\n"
+                "  Use a hyphenated clone path (~/agent-fleet-dev) or pip install -e ."
+            )
+        elif strict_disk:
+            warnings.append(
+                f"Known shadow checkout exists on disk: {shadow_root}\n"
+                "  Avoid running Python with this directory as cwd or on PYTHONPATH."
+            )
+
+    syspath_shadows = _shadow_roots_on_syspath(exclude=active_repo)
+    for entry in syspath_shadows:
+        if any(_is_under(entry, known) or entry == known for known in KNOWN_SHADOW_ROOTS):
+            errors.append(f"sys.path exposes shadow package root: {entry}")
+        elif active_repo is not None and entry != active_repo:
+            warnings.append(f"sys.path contains alternate agent_fleet root: {entry}")
+
+    return errors, warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict-disk",
+        action="store_true",
+        help="Warn when known shadow checkout directories exist even if not active",
+    )
+    args = parser.parse_args(argv)
+
+    errors, warnings = check_import_shadow(strict_disk=args.strict_disk)
+
+    for msg in warnings:
+        print(f"warning: {msg}", file=sys.stderr)
+
+    if errors:
+        for msg in errors:
+            print(f"error: {msg}", file=sys.stderr)
+        print(
+            "\nRemediation: clone to ~/agent-fleet-dev (hyphen), pip install -e ., "
+            "and do not add ~/Documents/agent_fleet to PYTHONPATH.\n"
+            "See docs/FLEET-CONFIG.md#import-shadow",
+            file=sys.stderr,
+        )
+        return 1
+
+    if warnings:
+        return 0
+
+    print("No agent_fleet import shadow detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync-base-kit.sh
+++ b/scripts/sync-base-kit.sh
@@ -39,20 +39,21 @@ sync_pstack() {
   printf '%s' "$sha"
 }
 
-sync_deslop() {
-  log "Syncing cursor-team-kit deslop"
-  local repo_dir="$TMP/plugins-deslop"
+sync_cursor_team_kit() {
+  log "Syncing cursor/plugins cursor-team-kit → base-kit/cursor-team-kit/"
+  local repo_dir="$TMP/plugins-ctk"
   local sha
   sha="$(clone_sha cursor/plugins "$repo_dir")"
-  mkdir -p "$BASE/cursor-team-kit/deslop"
-  cp "$repo_dir/cursor-team-kit/skills/deslop/SKILL.md" "$BASE/cursor-team-kit/deslop/SKILL.md"
+  rm -rf "$BASE/cursor-team-kit"
+  mkdir -p "$BASE/cursor-team-kit"
+  rsync -a --delete "$repo_dir/cursor-team-kit/skills/" "$BASE/cursor-team-kit/"
   printf '%s' "$sha"
 }
 
 write_manifest() {
   local super_sha="$1"
   local pstack_sha="$2"
-  local deslop_sha="$3"
+  local ctk_sha="$3"
   cat >"$MANIFEST" <<EOF
 schema_version: 1
 synced_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -65,9 +66,9 @@ sources:
     upstream: https://github.com/cursor/plugins/tree/main/pstack
     ref: ${pstack_sha}
     license: MIT
-  deslop:
-    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills/deslop
-    ref: ${deslop_sha}
+  cursor-team-kit:
+    upstream: https://github.com/cursor/plugins/tree/main/cursor-team-kit/skills
+    ref: ${ctk_sha}
     license: MIT
 EOF
   log "Wrote $MANIFEST"
@@ -78,9 +79,9 @@ main() {
   command -v rsync >/dev/null
   super_sha="$(sync_superpowers)"
   pstack_sha="$(sync_pstack)"
-  deslop_sha="$(sync_deslop)"
-  write_manifest "$super_sha" "$pstack_sha" "$deslop_sha"
-  log "Done. superpowers=${super_sha:0:12} pstack=${pstack_sha:0:12}"
+  ctk_sha="$(sync_cursor_team_kit)"
+  write_manifest "$super_sha" "$pstack_sha" "$ctk_sha"
+  log "Done. superpowers=${super_sha:0:12} pstack=${pstack_sha:0:12} cursor-team-kit=${ctk_sha:0:12}"
 }
 
 main "$@"

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -9,13 +9,26 @@ import pytest
 from agent_fleet.contracts.review import ReviewResult, ReviewVerdict
 from agent_fleet.phases import resolve_pipeline_outcome, run_scope_phase
 from agent_fleet.reviewer import aggregate_verdict
-from agent_fleet.scope import files_outside_allowed_paths
+from agent_fleet.scope import files_outside_allowed_paths, path_allowed_by_prefix
 from agent_fleet.verify_core import get_working_tree_changes, get_working_tree_diff, is_git_repo
 
 
 def test_files_outside_allowed_paths() -> None:
     assert files_outside_allowed_paths(("src/",), ["src/a.py", "web/b.ts"]) == ("web/b.ts",)
     assert files_outside_allowed_paths((), ["any/file.py"]) == ()
+
+
+def test_path_allowed_by_prefix_parent_directory() -> None:
+    assert path_allowed_by_prefix("agents/personas/foo.md", "agents/personas/")
+    assert path_allowed_by_prefix("agents/", "agents/personas/")
+    assert not path_allowed_by_prefix("agents/other/foo.md", "agents/personas/")
+
+
+def test_files_outside_allowed_paths_directory_entry() -> None:
+    allow = ("agents/personas/",)
+    assert files_outside_allowed_paths(allow, ["agents/"]) == ()
+    assert files_outside_allowed_paths(allow, ["agents/personas/fleet-skills-stack.md"]) == ()
+    assert files_outside_allowed_paths(allow, ["agent_fleet/cli.py"]) == ("agent_fleet/cli.py",)
 
 
 def test_run_scope_phase_passes() -> None:

--- a/tests/test_code_review_fix_equip.py
+++ b/tests/test_code_review_fix_equip.py
@@ -1,0 +1,183 @@
+# ruff: noqa: TC002
+"""Code review auto-fix phase uses dispatch equip compose body."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_fleet.code_review.fix import run_fix_phase
+from agent_fleet.config import load_fleet_config
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.hooks import FleetTask
+from agent_fleet.level_up.models import DispatchEquip
+from agent_fleet.level_up.paths import persona_dir
+from agent_fleet.personas import YamlPersonaResolver
+from agent_fleet.repo import load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        timeout_s: int,
+        memory_limit: str = "4G",
+        allowed_tools: list[str] | None = None,
+        cwd: Path | None = None,
+        model: str | None = None,
+        mode: object | None = None,
+    ) -> CursorLLMResult:
+        del max_tokens, timeout_s, memory_limit, allowed_tools, cwd, model, mode
+        self.prompts.append(prompt)
+        return CursorLLMResult(
+            stdout="fixed",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+            agent_id="fix-agent",
+        )
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+def test_fix_phase_uses_task_equip_fast_path(
+    tmp_path: Path,
+) -> None:
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    equip = DispatchEquip(
+        persona="coder",
+        base_loadout="coder",
+        skill_slots_execute=("pstack/tdd",),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="# Equip compose\n\nTDD Bug Fix",
+    )
+    task = FleetTask(
+        goal="Implement widget",
+        context="",
+        persona="coder",
+        workspace=str(tmp_path),
+        equip=equip,
+    )
+
+    run_fix_phase(
+        backend=backend,
+        resolver=resolver,
+        task=task,
+        workspace=tmp_path,
+        timeout_s=60,
+        phase_results=[{"phase": "review", "verdict": "request_changes"}],
+        repo=None,
+        fix_persona="coder",
+        attempt=1,
+    )
+
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "TDD Bug Fix" in prompt
+    assert "# Review feedback" in prompt
+    assert "# Verify failures\n(none)" in prompt
+
+
+def test_fix_phase_resolves_equip_when_fix_persona_differs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: fix-persona-mismatch\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    execute_equip = DispatchEquip(
+        persona="coder",
+        base_loadout="coder",
+        skill_slots_execute=("pstack/tdd",),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="# Execute equip\n\nExecute-only body",
+        parent_run_id="parent-run-1",
+    )
+    task = FleetTask(
+        goal="Implement widget",
+        context="ctx",
+        persona="coder",
+        workspace=str(tmp_path),
+        equip=execute_equip,
+    )
+
+    run_fix_phase(
+        backend=backend,
+        resolver=resolver,
+        task=task,
+        workspace=tmp_path,
+        timeout_s=60,
+        phase_results=[],
+        repo=repo,
+        fix_persona="reviewer",
+        attempt=2,
+    )
+
+    prompt = backend.prompts[0]
+    assert "Execute-only body" not in prompt
+    assert "# Persona" in prompt
+    assert "# Review feedback\n(none)" in prompt
+    assert "# Verify failures\n(none)" in prompt
+
+    journal_path = persona_dir("fix-persona-mismatch", "reviewer") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "parent-run-1-fix-2" for row in rows)
+
+
+def test_fix_phase_journals_run_id_without_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: fix-run-id\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    task = FleetTask(goal="Fix tests", persona="coder", workspace=str(tmp_path))
+
+    with patch("agent_fleet.code_review.fix.resolve_dispatch_equip") as mock_resolve:
+        mock_resolve.return_value = DispatchEquip(
+            persona="coder",
+            base_loadout="coder",
+            skill_slots_execute=(),
+            skill_slots_review=(),
+            level_up_generation=0,
+            compose_body="Coder body",
+        )
+        run_fix_phase(
+            backend=backend,
+            resolver=resolver,
+            task=task,
+            workspace=tmp_path,
+            timeout_s=60,
+            phase_results=[],
+            repo=repo,
+            fix_persona="reviewer",
+            attempt=3,
+        )
+
+    mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.kwargs["run_id"] == "code-review-fix-3"

--- a/tests/test_code_review_fix_equip.py
+++ b/tests/test_code_review_fix_equip.py
@@ -74,18 +74,20 @@ def test_fix_phase_uses_task_equip_fast_path(
         equip=equip,
     )
 
-    run_fix_phase(
-        backend=backend,
-        resolver=resolver,
-        task=task,
-        workspace=tmp_path,
-        timeout_s=60,
-        phase_results=[{"phase": "review", "verdict": "request_changes"}],
-        repo=None,
-        fix_persona="coder",
-        attempt=1,
-    )
+    with patch("agent_fleet.code_review.fix.resolve_dispatch_equip") as mock_resolve:
+        run_fix_phase(
+            backend=backend,
+            resolver=resolver,
+            task=task,
+            workspace=tmp_path,
+            timeout_s=60,
+            phase_results=[{"phase": "review", "verdict": "request_changes"}],
+            repo=None,
+            fix_persona="coder",
+            attempt=1,
+        )
 
+    mock_resolve.assert_not_called()
     assert len(backend.prompts) == 1
     prompt = backend.prompts[0]
     assert "TDD Bug Fix" in prompt

--- a/tests/test_equip.py
+++ b/tests/test_equip.py
@@ -18,6 +18,7 @@ from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.repo import load_repo_config
 from agent_fleet.skills_lib import (
+    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
     load_loadout,
     loadout_execute_skill_ids,
@@ -33,7 +34,7 @@ def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
 def test_load_coder_loadout() -> None:
     loadout = load_loadout("coder")
     execute = loadout_execute_skill_ids(loadout)
-    assert "superpowers/test-driven-development" in execute
+    assert "pstack/tdd" in execute
 
 
 def test_resolve_dispatch_equip_baseline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -50,9 +51,9 @@ def test_resolve_dispatch_equip_baseline(tmp_path: Path, monkeypatch: pytest.Mon
     assert isinstance(equip, DispatchEquip)
     assert equip.persona == "coder"
     assert equip.base_loadout == "coder"
-    assert "superpowers/test-driven-development" in equip.skill_slots_execute
+    assert "pstack/tdd" in equip.skill_slots_execute
     assert equip.parent_run_id is None
-    assert "Test-Driven Development" in equip.compose_body
+    assert "TDD Bug Fix" in equip.compose_body
 
     journal_path = persona_dir("equip-demo", "coder") / "journal.jsonl"
     assert journal_path.is_file()
@@ -83,7 +84,7 @@ def test_verify_failed_adds_systematic_debugging(
     equip = resolve_dispatch_equip(task, fleet_config, repo)
 
     assert SYSTEMATIC_DEBUGGING_SKILL in equip.skill_slots_execute
-    assert "Systematic Debugging" in equip.compose_body
+    assert "# Why" in equip.compose_body
 
 
 def test_verify_failed_skips_missing_base_kit_skill(
@@ -109,6 +110,23 @@ def test_verify_failed_skips_missing_base_kit_skill(
     equip = resolve_dispatch_equip(task, fleet_config, repo)
 
     assert SYSTEMATIC_DEBUGGING_SKILL not in equip.skill_slots_execute
+
+
+def test_pr_loop_adds_ci_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        "name: pr-loop-repo\npr_loop:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task = FleetTask(goal="Fix CI", persona="coder", workspace=str(tmp_path))
+    equip = resolve_dispatch_equip(task, fleet_config, repo)
+
+    for skill_id in PR_LOOP_EXECUTE_SKILLS:
+        assert skill_id in equip.skill_slots_execute
 
 
 def test_child_tasks_carry_parent_run_id() -> None:

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -18,6 +18,7 @@ from agent_fleet.contracts.task_spec import validate_task_spec
 from agent_fleet.contracts.tech_lead_review import TechLeadReview, TechLeadVerdict
 from agent_fleet.cursor_backend import CursorBackend
 from agent_fleet.dispatcher import FleetDispatcher, _normalize_tasks
+from agent_fleet.hooks import FleetTask, FleetTaskResult
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.phase_graph import default_phase_graph
 from agent_fleet.repo import RepoConfig, load_repo_config
@@ -293,14 +294,12 @@ def test_dispatcher_keeps_worktree_on_recoverable_status(
     def fake_pipeline(**kwargs: object) -> tuple[list[dict[str, object]], str, int, list[str]]:
         del kwargs
         (shared.path / "changed.txt").write_text("edited\n", encoding="utf-8")
-        phase_results = [
-            {
-                "phase": "verify",
-                "passed": False,
-                "command": "pytest -q",
-            }
-        ]
-        return phase_results, "verify failed", 1, ["changed.txt"]
+        verify_phase: dict[str, object] = {
+            "phase": "verify",
+            "passed": False,
+            "command": "pytest -q",
+        }
+        return [verify_phase], "verify failed", 1, ["changed.txt"]
 
     monkeypatch.setattr(
         "agent_fleet.dispatcher.run_configured_pipeline",
@@ -332,6 +331,7 @@ def test_dispatcher_keeps_worktree_on_recoverable_status(
 def test_parallel_dispatch_warns_on_scope_overlap(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo_yaml = tmp_path / ".agent-fleet.yaml"
     repo_yaml.write_text(
@@ -359,11 +359,9 @@ def test_parallel_dispatch_warns_on_scope_overlap(
     def fake_execute(
         _self: FleetDispatcher,
         task_index: int,
-        task: object,
+        task: FleetTask,
         **kwargs: object,
-    ) -> object:
-        from agent_fleet.hooks import FleetTaskResult
-
+    ) -> FleetTaskResult:
         del kwargs
         return FleetTaskResult(
             task_index=task_index,
@@ -375,7 +373,7 @@ def test_parallel_dispatch_warns_on_scope_overlap(
             duration_seconds=0.1,
         )
 
-    dispatcher._execute_task = fake_execute.__get__(dispatcher, FleetDispatcher)  # type: ignore[method-assign]
+    monkeypatch.setattr(dispatcher, "_execute_task", fake_execute)
 
     with caplog.at_level("WARNING"):
         results = dispatcher.dispatch(

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
 import textwrap
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,10 +17,10 @@ from agent_fleet.contracts.review import ReviewResult, ReviewVerdict
 from agent_fleet.contracts.task_spec import validate_task_spec
 from agent_fleet.contracts.tech_lead_review import TechLeadReview, TechLeadVerdict
 from agent_fleet.cursor_backend import CursorBackend
-from agent_fleet.dispatcher import _normalize_tasks
+from agent_fleet.dispatcher import FleetDispatcher, _normalize_tasks
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.phase_graph import default_phase_graph
-from agent_fleet.repo import load_repo_config
+from agent_fleet.repo import RepoConfig, load_repo_config
 from agent_fleet.runner import _run_outcome, _spine_from_repo
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -50,7 +52,7 @@ def test_load_persona_prompt(fleet_config: FleetConfig) -> None:
 
 
 def test_normalize_single_task() -> None:
-    tasks = _normalize_tasks(
+    tasks, base_branches = _normalize_tasks(
         goal="Fix the bug",
         context="see auth.py",
         persona="coder",
@@ -60,19 +62,24 @@ def test_normalize_single_task() -> None:
     )
     assert len(tasks) == 1
     assert tasks[0].goal == "Fix the bug"
+    assert base_branches == [None]
 
 
 def test_normalize_batch() -> None:
-    tasks = _normalize_tasks(
+    tasks, base_branches = _normalize_tasks(
         goal=None,
         context=None,
         persona=None,
         workspace=None,
         pipeline=None,
-        tasks=[{"goal": "A"}, {"goal": "B", "persona": "explorer"}],
+        tasks=[
+            {"goal": "A"},
+            {"goal": "B", "persona": "explorer", "base_branch": "feature/x"},
+        ],
     )
     assert len(tasks) == 2
     assert tasks[1].persona == "explorer"
+    assert base_branches == [None, "feature/x"]
 
 
 def test_normalize_requires_input() -> None:
@@ -244,3 +251,141 @@ def test_make_backend_kimi(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert isinstance(backend, KimiBackend)
     assert backend.model == "kimi-for-coding"
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True)
+
+
+def test_dispatcher_keeps_worktree_on_recoverable_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recoverable soft failures with changes should retain the isolated worktree."""
+    from agent_fleet.worktree import prepare_task_workspace
+
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)
+    worktree_base = tmp_path / "worktrees"
+    repo_config = RepoConfig(
+        repo_root=repo_path,
+        use_worktree=True,
+        worktree_base=worktree_base,
+    )
+    shared = prepare_task_workspace(repo_config, task_index=0, force_isolation=True)
+
+    fc = load_fleet_config(ROOT / "fleet.example.yaml")
+    fc.default_workspace = str(repo_path)
+    dispatcher = FleetDispatcher(config=fc)
+    dispatcher.backend = MagicMock()
+
+    monkeypatch.setattr(
+        "agent_fleet.dispatcher.find_repo_config",
+        lambda _workspace: repo_config,
+    )
+
+    def fake_pipeline(**kwargs: object) -> tuple[list[dict[str, object]], str, int, list[str]]:
+        del kwargs
+        (shared.path / "changed.txt").write_text("edited\n", encoding="utf-8")
+        phase_results = [
+            {
+                "phase": "verify",
+                "passed": False,
+                "command": "pytest -q",
+            }
+        ]
+        return phase_results, "verify failed", 1, ["changed.txt"]
+
+    monkeypatch.setattr(
+        "agent_fleet.dispatcher.run_configured_pipeline",
+        fake_pipeline,
+    )
+
+    def prepare_once(**kwargs: object) -> tuple[Path, object, None]:
+        del kwargs
+        return shared.path, shared, None
+
+    monkeypatch.setattr(
+        "agent_fleet.dispatcher.prepare_task_workspace_if_needed",
+        prepare_once,
+    )
+
+    results = dispatcher.dispatch(
+        goal="verify failure retention",
+        persona="coder",
+        workspace=str(repo_path),
+        pipeline="simple",
+    )
+    assert len(results) == 1
+    assert results[0].status == "verify_failed"
+    assert results[0].worktree == str(shared.path)
+    assert shared.path.exists()
+    shared.teardown(keep=False)
+
+
+def test_parallel_dispatch_warns_on_scope_overlap(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        textwrap.dedent(
+            """
+            name: demo
+            persona_scope_allowlist:
+              coder:
+                - src/
+              reviewer:
+                - src/
+            """
+        ),
+        encoding="utf-8",
+    )
+    repo = load_repo_config(repo_yaml)
+    fc = load_fleet_config(ROOT / "fleet.example.yaml")
+    fc.default_workspace = str(tmp_path)
+    fc.max_parallel = 4
+    fc.repo_config = repo
+
+    dispatcher = FleetDispatcher(config=fc)
+    dispatcher.backend = MagicMock()
+
+    def fake_execute(
+        _self: FleetDispatcher,
+        task_index: int,
+        task: object,
+        **kwargs: object,
+    ) -> object:
+        from agent_fleet.hooks import FleetTaskResult
+
+        del kwargs
+        return FleetTaskResult(
+            task_index=task_index,
+            persona=task.persona,
+            goal=task.goal,
+            status="completed",
+            summary=None,
+            error=None,
+            duration_seconds=0.1,
+        )
+
+    dispatcher._execute_task = fake_execute.__get__(dispatcher, FleetDispatcher)  # type: ignore[method-assign]
+
+    with caplog.at_level("WARNING"):
+        results = dispatcher.dispatch(
+            tasks=[
+                {"goal": "task A", "persona": "coder"},
+                {"goal": "task B", "persona": "reviewer"},
+            ],
+            workspace=str(tmp_path),
+            pipeline="simple",
+        )
+
+    assert len(results) == 2
+    assert any("Parallel batch may collide" in record.message for record in caplog.records)

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -389,3 +389,12 @@ def test_parallel_dispatch_warns_on_scope_overlap(
 
     assert len(results) == 2
     assert any("Parallel batch may collide" in record.message for record in caplog.records)
+
+
+def test_workstream_subcommand_registered() -> None:
+    """agent-fleet workstream must be wired into the top-level CLI."""
+    from agent_fleet.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["workstream", "--help"])
+    assert exc.value.code == 0

--- a/tests/test_loadouts.py
+++ b/tests/test_loadouts.py
@@ -15,21 +15,21 @@ from agent_fleet.skills_lib import (
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def test_deslop_loads_from_base_kit() -> None:
+def test_unslop_loads_from_base_kit() -> None:
     dirs = base_kit_skill_dirs()
     assert dirs
-    path = resolve_skill_path("cursor-team-kit/deslop", dirs)
+    path = resolve_skill_path("pstack/unslop", dirs)
     assert path is not None
     assert path.name == "SKILL.md"
-    text = load_skill_text("cursor-team-kit/deslop", dirs)
-    assert "Remove AI code slop" in text
+    text = load_skill_text("pstack/unslop", dirs)
+    assert "slop" in text.lower()
 
 
-def test_reviewer_loadout_lists_deslop_for_review() -> None:
+def test_reviewer_loadout_lists_unslop_for_review() -> None:
     loadout = load_loadout("reviewer")
     assert loadout is not None
     review_skills = loadout["pipeline_skills"]["code_review"]["review"]
-    assert review_skills == ["cursor-team-kit/deslop"]
+    assert review_skills == ["pstack/unslop", "cursor-team-kit/deslop"]
 
 
 def test_compose_persona_body_includes_sections() -> None:

--- a/tests/test_loadouts.py
+++ b/tests/test_loadouts.py
@@ -4,15 +4,40 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from agent_fleet.personas import load_loadout
 from agent_fleet.skills_lib import (
     base_kit_skill_dirs,
     compose_persona_body,
     load_skill_text,
+    loadout_execute_skill_ids,
+    loadout_review_skill_ids,
     resolve_skill_path,
 )
 
 ROOT = Path(__file__).resolve().parent.parent
+PERSONAS_DIR = ROOT / "agent_fleet" / "personas"
+
+
+def bundled_loadout_names() -> list[str]:
+    return sorted(path.stem.replace(".loadout", "") for path in PERSONAS_DIR.glob("*.loadout.yaml"))
+
+
+@pytest.mark.parametrize("persona", bundled_loadout_names())
+def test_loadout_skill_ids_resolve_in_base_kit(persona: str) -> None:
+    loadout = load_loadout(persona)
+    assert loadout is not None
+    dirs = base_kit_skill_dirs()
+    skill_ids = [
+        *loadout_execute_skill_ids(loadout),
+        *loadout_review_skill_ids(loadout),
+    ]
+    assert skill_ids, persona
+    for skill_id in skill_ids:
+        path = resolve_skill_path(skill_id, dirs)
+        assert path is not None, f"{persona}: {skill_id}"
+        assert path.name == "SKILL.md"
 
 
 def test_unslop_loads_from_base_kit() -> None:
@@ -35,7 +60,7 @@ def test_reviewer_loadout_lists_unslop_for_review() -> None:
 def test_compose_persona_body_includes_sections() -> None:
     loadout = load_loadout("coder")
     assert loadout is not None
-    stub = (ROOT / "agent_fleet" / "personas" / "coder.md").read_text(encoding="utf-8")
+    stub = (PERSONAS_DIR / "coder.md").read_text(encoding="utf-8")
     body = compose_persona_body(
         loadout,
         fleet_overlay="- Prefer ruff before finishing.",

--- a/tests/test_persona_registry.py
+++ b/tests/test_persona_registry.py
@@ -1,0 +1,137 @@
+"""Regression: every declared persona resolves via YamlPersonaResolver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_fleet.config import FleetConfig, load_fleet_config
+from agent_fleet.personas import YamlPersonaResolver, read_persona_body
+
+ROOT = Path(__file__).resolve().parent.parent
+AGENTS_PERSONAS = ROOT / "agents" / "personas"
+FLEET_EXAMPLE = ROOT / "fleet.example.yaml"
+_AGENTS_PERSONAS_DIR = "agents/personas"
+
+
+def _persona_names_from_dir(personas_dir: Path) -> set[str]:
+    if not personas_dir.is_dir():
+        return set()
+    names: set[str] = set()
+    for path in personas_dir.glob("*.md"):
+        names.add(path.stem)
+    for path in personas_dir.glob("*.loadout.yaml"):
+        names.add(path.stem.replace(".loadout", ""))
+    return names
+
+
+def _yaml_uses_agents_personas(raw: dict[str, object]) -> bool:
+    personas_dir = raw.get("personas_dir")
+    if personas_dir is None:
+        return False
+    normalized = str(personas_dir).rstrip("/")
+    return normalized == _AGENTS_PERSONAS_DIR
+
+
+def _persona_refs_from_yaml(raw: dict[str, object]) -> set[str]:
+    names: set[str] = set()
+    personas = raw.get("personas")
+    if isinstance(personas, dict):
+        names.update(str(name) for name in personas)
+    workstreams = raw.get("workstreams")
+    if isinstance(workstreams, dict):
+        for item in workstreams.get("items") or []:
+            if isinstance(item, dict) and item.get("persona"):
+                names.add(str(item["persona"]))
+    return names
+
+
+def _yaml_files_pointing_at_agents_personas() -> list[tuple[Path, set[str]]]:
+    candidates = sorted(ROOT.rglob("*.yaml"))
+    dot_config = ROOT / ".agent-fleet.yaml"
+    if dot_config.is_file() and dot_config not in candidates:
+        candidates.append(dot_config)
+    matches: list[tuple[Path, set[str]]] = []
+    for path in candidates:
+        if any(part.startswith(".") for part in path.relative_to(ROOT).parts[:-1]):
+            continue
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict) or not _yaml_uses_agents_personas(raw):
+            continue
+        refs = _persona_refs_from_yaml(raw)
+        if refs:
+            matches.append((path, refs))
+    return matches
+
+
+def _agents_personas_config() -> FleetConfig:
+    assert AGENTS_PERSONAS.is_dir(), f"missing repo personas dir: {AGENTS_PERSONAS}"
+    return load_fleet_config(FLEET_EXAMPLE, personas_dir=AGENTS_PERSONAS)
+
+
+@pytest.fixture
+def fleet_config() -> FleetConfig:
+    return load_fleet_config(FLEET_EXAMPLE)
+
+
+def _assert_persona_resolves(resolver: YamlPersonaResolver, name: str) -> None:
+    persona = resolver.load(name)
+    if persona.body:
+        assert persona.body.strip()
+    else:
+        assert persona.prompt_path.is_file(), f"{name}: prompt missing at {persona.prompt_path}"
+        assert read_persona_body(persona).strip()
+
+
+@pytest.fixture(scope="module")
+def agents_personas_config() -> FleetConfig:
+    if not AGENTS_PERSONAS.is_dir():
+        pytest.skip(f"{AGENTS_PERSONAS} not present in this checkout")
+    return _agents_personas_config()
+
+
+def test_every_agents_personas_file_resolves(agents_personas_config: FleetConfig) -> None:
+    resolver = YamlPersonaResolver(agents_personas_config)
+    names = _persona_names_from_dir(AGENTS_PERSONAS)
+    assert names, f"expected persona files under {AGENTS_PERSONAS}"
+    for name in sorted(names):
+        _assert_persona_resolves(resolver, name)
+
+
+def test_fleet_yaml_entries_for_agents_personas_resolve(
+    agents_personas_config: FleetConfig,
+) -> None:
+    resolver = YamlPersonaResolver(agents_personas_config)
+    yaml_matches = [
+        (path, names) for path, names in _yaml_files_pointing_at_agents_personas() if names
+    ]
+    if not yaml_matches:
+        pytest.skip("no yaml in repo declares personas under personas_dir: agents/personas")
+    for _path, persona_names in yaml_matches:
+        for name in sorted(persona_names):
+            _assert_persona_resolves(resolver, name)
+
+
+def test_fleet_example_personas_resolve_with_package_dir(fleet_config: FleetConfig) -> None:
+    resolver = YamlPersonaResolver(fleet_config)
+    for name in sorted(fleet_config.personas):
+        _assert_persona_resolves(resolver, name)
+
+
+def test_repo_persona_overrides_package_fallback(agents_personas_config: FleetConfig) -> None:
+    resolver = YamlPersonaResolver(agents_personas_config)
+    reviewer = resolver.load("reviewer")
+    assert reviewer.prompt_path.resolve() == (AGENTS_PERSONAS / "reviewer.md").resolve()
+    coder = resolver.load("coder")
+    assert "agent_fleet" in str(coder.prompt_path)
+    assert coder.prompt_path.name == "coder.md"
+
+
+def test_workstream_subcommand_registered() -> None:
+    from agent_fleet.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["workstream", "--help"])
+    assert exc.value.code == 0

--- a/tests/test_persona_registry.py
+++ b/tests/test_persona_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -11,14 +12,39 @@ from agent_fleet.config import FleetConfig, load_fleet_config
 from agent_fleet.personas import YamlPersonaResolver, read_persona_body
 
 ROOT = Path(__file__).resolve().parent.parent
-AGENTS_PERSONAS = ROOT / "agents" / "personas"
 FLEET_EXAMPLE = ROOT / "fleet.example.yaml"
 _AGENTS_PERSONAS_DIR = "agents/personas"
 
 
+def _git_common_root() -> Path | None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    git_common = Path(result.stdout.strip())
+    if not git_common.is_absolute():
+        git_common = (ROOT / git_common).resolve()
+    if git_common.name == ".git":
+        return git_common.parent
+    return git_common.parent.parent
+
+
+def _agents_personas_dir() -> Path | None:
+    for base in (ROOT, _git_common_root()):
+        if base is None:
+            continue
+        candidate = base / "agents" / "personas"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 def _persona_names_from_dir(personas_dir: Path) -> set[str]:
-    if not personas_dir.is_dir():
-        return set()
     names: set[str] = set()
     for path in personas_dir.glob("*.md"):
         names.add(path.stem)
@@ -49,26 +75,39 @@ def _persona_refs_from_yaml(raw: dict[str, object]) -> set[str]:
 
 
 def _yaml_files_pointing_at_agents_personas() -> list[tuple[Path, set[str]]]:
-    candidates = sorted(ROOT.rglob("*.yaml"))
-    dot_config = ROOT / ".agent-fleet.yaml"
-    if dot_config.is_file() and dot_config not in candidates:
-        candidates.append(dot_config)
+    search_roots = [ROOT]
+    main_root = _git_common_root()
+    if main_root is not None and main_root not in search_roots:
+        search_roots.append(main_root)
+
     matches: list[tuple[Path, set[str]]] = []
-    for path in candidates:
-        if any(part.startswith(".") for part in path.relative_to(ROOT).parts[:-1]):
-            continue
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-        if not isinstance(raw, dict) or not _yaml_uses_agents_personas(raw):
-            continue
-        refs = _persona_refs_from_yaml(raw)
-        if refs:
-            matches.append((path, refs))
+    seen_paths: set[Path] = set()
+    for base in search_roots:
+        candidates = sorted(base.rglob("*.yaml"))
+        dot_config = base / ".agent-fleet.yaml"
+        if dot_config.is_file() and dot_config not in candidates:
+            candidates.append(dot_config)
+        for path in candidates:
+            if "node_modules" in path.parts or ".worktrees" in path.parts:
+                continue
+            resolved = path.resolve()
+            if resolved in seen_paths:
+                continue
+            seen_paths.add(resolved)
+            try:
+                raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+            except yaml.YAMLError:
+                continue
+            if not isinstance(raw, dict) or not _yaml_uses_agents_personas(raw):
+                continue
+            refs = _persona_refs_from_yaml(raw)
+            if refs:
+                matches.append((path, refs))
     return matches
 
 
-def _agents_personas_config() -> FleetConfig:
-    assert AGENTS_PERSONAS.is_dir(), f"missing repo personas dir: {AGENTS_PERSONAS}"
-    return load_fleet_config(FLEET_EXAMPLE, personas_dir=AGENTS_PERSONAS)
+def _agents_personas_config(personas_dir: Path) -> FleetConfig:
+    return load_fleet_config(FLEET_EXAMPLE, personas_dir=personas_dir)
 
 
 @pytest.fixture
@@ -86,16 +125,25 @@ def _assert_persona_resolves(resolver: YamlPersonaResolver, name: str) -> None:
 
 
 @pytest.fixture(scope="module")
-def agents_personas_config() -> FleetConfig:
-    if not AGENTS_PERSONAS.is_dir():
-        pytest.skip(f"{AGENTS_PERSONAS} not present in this checkout")
-    return _agents_personas_config()
+def agents_personas_dir() -> Path:
+    personas_dir = _agents_personas_dir()
+    if personas_dir is None:
+        pytest.skip("agents/personas not present in this checkout")
+    return personas_dir
 
 
-def test_every_agents_personas_file_resolves(agents_personas_config: FleetConfig) -> None:
+@pytest.fixture(scope="module")
+def agents_personas_config(agents_personas_dir: Path) -> FleetConfig:
+    return _agents_personas_config(agents_personas_dir)
+
+
+def test_every_agents_personas_file_resolves(
+    agents_personas_dir: Path,
+    agents_personas_config: FleetConfig,
+) -> None:
     resolver = YamlPersonaResolver(agents_personas_config)
-    names = _persona_names_from_dir(AGENTS_PERSONAS)
-    assert names, f"expected persona files under {AGENTS_PERSONAS}"
+    names = _persona_names_from_dir(agents_personas_dir)
+    assert names, f"expected persona files under {agents_personas_dir}"
     for name in sorted(names):
         _assert_persona_resolves(resolver, name)
 
@@ -104,9 +152,7 @@ def test_fleet_yaml_entries_for_agents_personas_resolve(
     agents_personas_config: FleetConfig,
 ) -> None:
     resolver = YamlPersonaResolver(agents_personas_config)
-    yaml_matches = [
-        (path, names) for path, names in _yaml_files_pointing_at_agents_personas() if names
-    ]
+    yaml_matches = _yaml_files_pointing_at_agents_personas()
     if not yaml_matches:
         pytest.skip("no yaml in repo declares personas under personas_dir: agents/personas")
     for _path, persona_names in yaml_matches:
@@ -120,18 +166,13 @@ def test_fleet_example_personas_resolve_with_package_dir(fleet_config: FleetConf
         _assert_persona_resolves(resolver, name)
 
 
-def test_repo_persona_overrides_package_fallback(agents_personas_config: FleetConfig) -> None:
+def test_repo_persona_overrides_package_fallback(
+    agents_personas_dir: Path,
+    agents_personas_config: FleetConfig,
+) -> None:
     resolver = YamlPersonaResolver(agents_personas_config)
     reviewer = resolver.load("reviewer")
-    assert reviewer.prompt_path.resolve() == (AGENTS_PERSONAS / "reviewer.md").resolve()
+    assert reviewer.prompt_path.resolve() == (agents_personas_dir / "reviewer.md").resolve()
     coder = resolver.load("coder")
     assert "agent_fleet" in str(coder.prompt_path)
     assert coder.prompt_path.name == "coder.md"
-
-
-def test_workstream_subcommand_registered() -> None:
-    from agent_fleet.cli import main
-
-    with pytest.raises(SystemExit) as exc:
-        main(["workstream", "--help"])
-    assert exc.value.code == 0

--- a/tests/test_persona_registry.py
+++ b/tests/test_persona_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -61,16 +62,18 @@ def _yaml_uses_agents_personas(raw: dict[str, object]) -> bool:
     return normalized == _AGENTS_PERSONAS_DIR
 
 
-def _persona_refs_from_yaml(raw: dict[str, object]) -> set[str]:
+def _persona_refs_from_yaml(raw: dict[str, Any]) -> set[str]:
     names: set[str] = set()
     personas = raw.get("personas")
     if isinstance(personas, dict):
         names.update(str(name) for name in personas)
-    workstreams = raw.get("workstreams")
+    workstreams: Any = raw.get("workstreams")
     if isinstance(workstreams, dict):
-        for item in workstreams.get("items") or []:
-            if isinstance(item, dict) and item.get("persona"):
-                names.add(str(item["persona"]))
+        items: Any = workstreams.get("items")
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and item.get("persona"):
+                    names.add(str(item["persona"]))
     return names
 
 

--- a/tests/test_phases_deslop.py
+++ b/tests/test_phases_deslop.py
@@ -68,7 +68,7 @@ def test_structured_review_appends_deslop_skill_from_equip(
         persona="reviewer",
         base_loadout="reviewer",
         skill_slots_execute=(),
-        skill_slots_review=("cursor-team-kit/deslop",),
+        skill_slots_review=("pstack/unslop", "cursor-team-kit/deslop"),
         level_up_generation=0,
     )
     task = FleetTask(
@@ -91,7 +91,7 @@ def test_structured_review_appends_deslop_skill_from_equip(
     assert len(backend.prompts) == 1
     prompt = backend.prompts[0]
     assert "# Review Skills" in prompt
-    assert "Remove AI code slop" in prompt
+    assert "Unslop" in prompt
 
 
 def test_legacy_review_appends_deslop_skill_from_equip(
@@ -105,7 +105,7 @@ def test_legacy_review_appends_deslop_skill_from_equip(
         persona="reviewer",
         base_loadout="reviewer",
         skill_slots_execute=(),
-        skill_slots_review=("cursor-team-kit/deslop",),
+        skill_slots_review=("pstack/unslop", "cursor-team-kit/deslop"),
         level_up_generation=0,
     )
     task = FleetTask(goal="Review slop", persona="coder", equip=equip)
@@ -129,4 +129,4 @@ def test_legacy_review_appends_deslop_skill_from_equip(
     assert len(backend.prompts) == 1
     prompt = backend.prompts[0]
     assert "# Review Skills" in prompt
-    assert "Remove AI code slop" in prompt
+    assert "Unslop" in prompt

--- a/tests/test_phases_execute_equip.py
+++ b/tests/test_phases_execute_equip.py
@@ -32,3 +32,31 @@ def test_execute_prompt_prefers_equip_compose_body() -> None:
     assert "Static persona body from resolver." not in prompt
     assert "Systematic Debugging" in prompt
     assert "Fix failing test" in prompt
+
+
+def test_execute_prompt_includes_persona_modifiers_and_closing() -> None:
+    persona = Persona(
+        name="coder",
+        prompt_path=Path("coder.md"),
+        allowed_tools=[],
+        capabilities={},
+        body="Coder body.",
+        allowed_paths=("src/",),
+        extra_instructions="Prefer small diffs.",
+    )
+    task = FleetTask(
+        goal="Implement feature",
+        context="See design doc.",
+        persona="coder",
+    )
+
+    prompt = _build_execute_prompt(persona, task)
+
+    assert prompt.index("# Persona") < prompt.index("# Additional Instructions")
+    assert prompt.index("# Additional Instructions") < prompt.index("# Scope:")
+    assert prompt.index("# Scope:") < prompt.index("# Task")
+    assert prompt.index("# Task") < prompt.index("# Context")
+    assert prompt.index("# Context") < prompt.index("Execute this task in the workspace")
+    assert "Prefer small diffs." in prompt
+    assert "only modify paths matching: src/" in prompt
+    assert "See design doc." in prompt

--- a/tests/test_pr_loop_equip.py
+++ b/tests/test_pr_loop_equip.py
@@ -151,6 +151,42 @@ def test_ci_fix_prompt_includes_fix_ci_skill(
     assert "- (none)" in prompt
 
 
+def test_ci_fix_journals_equip_with_run_id(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_fleet.level_up.paths import persona_dir
+
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        attempt_ci_fix(
+            pr_number=7,
+            branch="fleet/coder/7-def",
+            failed_checks=["pytest"],
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+            persona="coder",
+        )
+
+    journal_path = persona_dir("pr-loop-equip", "coder") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "pr-loop-7" for row in rows)
+
+
 def test_review_fix_journals_equip_with_run_id(
     tmp_path: Path,
     worktree: Path,

--- a/tests/test_pr_loop_equip.py
+++ b/tests/test_pr_loop_equip.py
@@ -1,0 +1,198 @@
+"""PR loop fix agents include dispatch equip compose body."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.pr_loop.config import PrLoopConfig
+from agent_fleet.pr_loop.lifecycle import address_review_findings, attempt_ci_fix
+from agent_fleet.repo import RepoConfig, load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        timeout_s: int,
+        memory_limit: str = "4G",
+        allowed_tools: list[str] | None = None,
+        cwd: Path | None = None,
+        model: str | None = None,
+        mode: object | None = None,
+    ) -> CursorLLMResult:
+        del max_tokens, timeout_s, memory_limit, allowed_tools, cwd, model, mode
+        self.prompts.append(prompt)
+        return CursorLLMResult(
+            stdout="done",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+            agent_id="fix-agent",
+        )
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+def _pr_loop_repo(tmp_path: Path) -> RepoConfig:
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        "name: pr-loop-equip\npr_loop:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    return load_repo_config(repo_yaml)
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    return wt
+
+
+def test_review_fix_prompt_includes_fix_ci_skill(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+    review_body = "**Risk Level:** MEDIUM\n<details><summary>MEDIUM</summary>"
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.has_blocking_findings",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_diff",
+            return_value="+added",
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_changed_files",
+            return_value=["src/a.py"],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        result = address_review_findings(
+            pr_number=42,
+            branch="fleet/coder/42-abc",
+            review_body=review_body,
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+        )
+
+    assert result.status == "no_changes"
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "# Persona" in prompt
+    assert "# Fix CI" in prompt
+    assert "# Review" in prompt
+    assert review_body in prompt
+    assert "- (none)" in prompt
+
+
+def test_ci_fix_prompt_includes_fix_ci_skill(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        result = attempt_ci_fix(
+            pr_number=7,
+            branch="fleet/coder/7-def",
+            failed_checks=["pytest"],
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+            persona="coder",
+        )
+
+    assert not result.ok
+    assert result.phase == "no_changes"
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "# Fix CI" in prompt
+    assert "Failed checks: pytest" in prompt
+    assert "- (none)" in prompt
+
+
+def test_review_fix_journals_equip_with_run_id(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_fleet.level_up.paths import persona_dir
+
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.has_blocking_findings",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_diff",
+            return_value="+added",
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_changed_files",
+            return_value=["src/a.py"],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        address_review_findings(
+            pr_number=99,
+            branch="fleet/coder/99-xyz",
+            review_body="blocking finding",
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+        )
+
+    journal_path = persona_dir("pr-loop-equip", "coder") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "pr-loop-99" for row in rows)

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -1,0 +1,51 @@
+"""Tests for shared agent prompt assembly."""
+
+from __future__ import annotations
+
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+
+
+def test_build_agent_prompt_minimal() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+    )
+
+    assert isinstance(result, AgentPrompt)
+    assert result.persona_section == "# Persona\nYou are a coder."
+    assert "# Task\nFix the bug." in result.full
+    assert result.full == result.persona_section + result.task_section
+    assert "# Context" not in result.full
+
+
+def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
+    result = build_agent_prompt(
+        persona_body="Reviewer persona.",
+        task_heading="Original Task",
+        task_body="Ship the feature.",
+        context="branch=main",
+        extra_sections=[
+            ("Additional Instructions", "Be thorough."),
+            ("Scope: only modify paths matching: src/", ""),
+        ],
+    )
+
+    assert "# Additional Instructions\nBe thorough." in result.full
+    assert "# Scope: only modify paths matching: src/" in result.full
+    assert "# Context\nbranch=main" in result.full
+    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
+    assert result.full.index("# Original Task") < result.full.index("# Context")
+
+
+def test_build_agent_prompt_strips_whitespace() -> None:
+    result = build_agent_prompt(
+        persona_body="  persona  ",
+        task_heading="Task",
+        task_body="  goal  ",
+        context="  ctx  ",
+    )
+
+    assert result.persona_section == "# Persona\npersona"
+    assert "# Task\ngoal" in result.full
+    assert "# Context\nctx" in result.full

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+from agent_fleet.prompts.agent import build_agent_prompt
 
 
 def test_build_agent_prompt_minimal() -> None:
@@ -12,40 +12,64 @@ def test_build_agent_prompt_minimal() -> None:
         task_body="Fix the bug.",
     )
 
-    assert isinstance(result, AgentPrompt)
     assert result.persona_section == "# Persona\nYou are a coder."
-    assert "# Task\nFix the bug." in result.full
-    assert result.full == result.persona_section + result.task_section
-    assert "# Context" not in result.full
+    assert result.task_section == "\n# Task\nFix the bug."
+    assert result.full == "# Persona\nYou are a coder.\n# Task\nFix the bug."
 
 
-def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
+def test_build_agent_prompt_includes_context_and_closing() -> None:
+    closing = (
+        "Execute this task in the workspace. Return a concise summary of what you "
+        "did, files changed, and any follow-up needed."
+    )
     result = build_agent_prompt(
-        persona_body="Reviewer persona.",
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        context="See auth.py",
+        closing_instruction=closing,
+    )
+
+    assert "# Context\nSee auth.py" in result.full
+    assert result.full.endswith(closing)
+    assert "# Task\nFix the bug." in result.task_section
+
+
+def test_build_agent_prompt_includes_persona_extras() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        extra_instructions="Prefer small diffs.",
+        allowed_paths=("src/**", "tests/**"),
+    )
+
+    assert "# Additional Instructions\nPrefer small diffs." in result.persona_section
+    assert "# Scope: only modify paths matching: src/**, tests/**" in result.persona_section
+
+
+def test_build_agent_prompt_supports_extra_sections() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a reviewer.",
         task_heading="Original Task",
-        task_body="Ship the feature.",
-        context="branch=main",
+        task_body="Add logging.",
         extra_sections=[
-            ("Additional Instructions", "Be thorough."),
-            ("Scope: only modify paths matching: src/", ""),
+            ("Implementation Summary", "Added structured logs."),
+            ("Review", "Check for PII in logs."),
         ],
     )
 
-    assert "# Additional Instructions\nBe thorough." in result.full
-    assert "# Scope: only modify paths matching: src/" in result.full
-    assert "# Context\nbranch=main" in result.full
-    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
-    assert result.full.index("# Original Task") < result.full.index("# Context")
+    assert "# Implementation Summary\nAdded structured logs." in result.full
+    assert "# Review\nCheck for PII in logs." in result.full
 
 
-def test_build_agent_prompt_strips_whitespace() -> None:
+def test_build_agent_prompt_skips_blank_extra_sections() -> None:
     result = build_agent_prompt(
-        persona_body="  persona  ",
+        persona_body="You are a reviewer.",
         task_heading="Task",
-        task_body="  goal  ",
-        context="  ctx  ",
+        task_body="Review changes.",
+        extra_sections=[("Review", "   "), ("Notes", "Keep it concise.")],
     )
 
-    assert result.persona_section == "# Persona\npersona"
-    assert "# Task\ngoal" in result.full
-    assert "# Context\nctx" in result.full
+    assert "# Review" not in result.full
+    assert "# Notes\nKeep it concise." in result.full

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -6,12 +6,17 @@ import subprocess
 from pathlib import Path
 
 from agent_fleet.repo import RepoConfig
-from agent_fleet.worktree import prepare_task_workspace, should_isolate_worktree
+from agent_fleet.worktree import (
+    maybe_commit_recoverable_worktree,
+    prepare_task_workspace,
+    should_isolate_worktree,
+    should_keep_task_worktree,
+)
 
 
 def _init_git_repo(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
     (path / "README.md").write_text("hello\n", encoding="utf-8")
@@ -28,6 +33,67 @@ def test_should_isolate_parallel_batch() -> None:
 def test_should_isolate_when_repo_flag_set() -> None:
     repo = RepoConfig(repo_root=Path("/tmp/repo"), use_worktree=True)
     assert should_isolate_worktree(repo, batch_size=1, same_workspace_tasks=1) is True
+
+
+def test_should_keep_task_worktree() -> None:
+    assert should_keep_task_worktree("completed") is True
+    assert should_keep_task_worktree("review_changes_requested") is False
+    assert should_keep_task_worktree("review_changes_requested", has_changes=True) is True
+    assert should_keep_task_worktree("verify_failed", has_changes=True) is True
+    assert should_keep_task_worktree("error", has_changes=True) is False
+
+
+def test_prepare_task_workspace_uses_base_branch(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)
+    subprocess.run(["git", "checkout", "-b", "feature/base"], cwd=repo_path, check=True)
+    (repo_path / "base.txt").write_text("on base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "base.txt"], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "base branch"], cwd=repo_path, check=True)
+    subprocess.run(["git", "checkout", "main"], cwd=repo_path, check=True)
+
+    repo = RepoConfig(
+        repo_root=repo_path,
+        use_worktree=True,
+        worktree_base=tmp_path / "worktrees",
+        default_branch="main",
+    )
+    task = prepare_task_workspace(
+        repo,
+        task_index=0,
+        force_isolation=True,
+        base_branch="feature/base",
+    )
+    assert (task.path / "base.txt").read_text() == "on base\n"
+    task.teardown(keep=False)
+
+
+def test_maybe_commit_recoverable_worktree(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)
+    repo = RepoConfig(
+        repo_root=repo_path,
+        use_worktree=True,
+        worktree_base=tmp_path / "worktrees",
+    )
+    task = prepare_task_workspace(repo, task_index=0, force_isolation=True)
+    (task.path / "wip.txt").write_text("wip\n", encoding="utf-8")
+
+    sha = maybe_commit_recoverable_worktree(
+        task,
+        "verify_failed",
+        goal="fix tests",
+    )
+    assert sha is not None
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=task.path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert not status.stdout.strip()
+    task.teardown(keep=False)
 
 
 def test_prepare_task_workspace_creates_isolated_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **Persona registry**: repo-then-package resolution in `personas.py`, equip wiring, `tests/test_persona_registry.py`, FLEET-CONFIG docs, workstream CLI registered in `cli.py`
- **Scout loadouts**: `pr-analyzer`, `explorer`, `tech-scout`, `product-scout` loadouts in `agent_fleet/personas/` with extended `test_loadouts.py`
- **Fleet dispatch personas**: `agents/personas/` for registry, scout-loadouts, skills-stack, and skills buildout personas (from `feature/skills-personas`)
- **Scope fix**: parent directory paths (e.g. `agents/`) match nested allowlist prefixes (`agents/personas/`)
- **Self-host config**: `.agent-fleet.yaml` workstreams + preflight documented in DISPATCH-COOKBOOK.md

Dispatched via `agent-fleet workstream run`; registry and scout-loadouts completed on this branch; skills-stack re-run completed after scope fix.

## Test plan

- [x] `pytest tests/test_persona_registry.py tests/test_loadouts.py tests/test_code_review.py -q`
- [x] `agent-fleet workstream run skills-stack` → completed (scope gate passes)
- [ ] Review `.agent-fleet.yaml` capacity and workstream goals for your fleet host

**Note:** Intended stack base is `feature/flywheel-less-is-more` (not on remote); this PR targets `main` which currently matches that tip (`7967c41`).


Made with [Cursor](https://cursor.com)