### PR TITLE
WIP: skills prompt-builder — consolidate build_agent_prompt

### DIFF
--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -44,18 +44,23 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    return build_agent_prompt(
+    extra_sections: list[tuple[str, str]] = []
+    if persona.extra_instructions.strip():
+        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
+    if persona.allowed_paths:
+        paths = ", ".join(persona.allowed_paths)
+        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
+    prompt = build_agent_prompt(
         persona_body=body,
         task_heading="Task",
         task_body=task.goal,
         context=task.context,
-        extra_instructions=persona.extra_instructions,
-        allowed_paths=persona.allowed_paths,
-        closing_instruction=(
-            "Execute this task in the workspace. Return a concise summary of what you "
-            "did, files changed, and any follow-up needed."
-        ),
-    ).full
+        extra_sections=extra_sections or None,
+    )
+    return prompt.full + (
+        "\n\nExecute this task in the workspace. Return a concise summary of what you "
+        "did, files changed, and any follow-up needed."
+    )
 
 
 def run_execute_phase(

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -8,6 +8,7 @@ from agent_fleet.agent_mode import parse_agent_mode
 from agent_fleet.contracts.review import ReviewVerdict
 from agent_fleet.personas import read_persona_body
 from agent_fleet.pr_review.runner import run_pr_review
+from agent_fleet.prompts.agent import build_agent_prompt
 from agent_fleet.reviewer import aggregate_verdict
 from agent_fleet.reviewer import review as structured_review
 from agent_fleet.scope import files_outside_allowed_paths
@@ -43,24 +44,23 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    parts = [
-        "# Persona",
-        body.strip(),
-    ]
+    extra_sections: list[tuple[str, str]] = []
     if persona.extra_instructions.strip():
-        parts.extend(["", "# Additional Instructions", persona.extra_instructions.strip()])
+        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
     if persona.allowed_paths:
         paths = ", ".join(persona.allowed_paths)
-        parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
-    parts.extend(["", "# Task", task.goal.strip()])
-    if task.context.strip():
-        parts.extend(["", "# Context", task.context.strip()])
-    parts.append("")
-    parts.append(
-        "Execute this task in the workspace. Return a concise summary of what you "
+        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
+    prompt = build_agent_prompt(
+        persona_body=body,
+        task_heading="Task",
+        task_body=task.goal,
+        context=task.context,
+        extra_sections=extra_sections or None,
+    )
+    return prompt.full + (
+        "\n\nExecute this task in the workspace. Return a concise summary of what you "
         "did, files changed, and any follow-up needed."
     )
-    return "\n".join(parts)
 
 
 def run_execute_phase(

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -44,23 +44,18 @@ def _build_execute_prompt(persona: Persona, task: FleetTask) -> str:
         body = task.equip.compose_body.strip()
     else:
         body = read_persona_body(persona)
-    extra_sections: list[tuple[str, str]] = []
-    if persona.extra_instructions.strip():
-        extra_sections.append(("Additional Instructions", persona.extra_instructions.strip()))
-    if persona.allowed_paths:
-        paths = ", ".join(persona.allowed_paths)
-        extra_sections.append((f"Scope: only modify paths matching: {paths}", ""))
-    prompt = build_agent_prompt(
+    return build_agent_prompt(
         persona_body=body,
         task_heading="Task",
         task_body=task.goal,
         context=task.context,
-        extra_sections=extra_sections or None,
-    )
-    return prompt.full + (
-        "\n\nExecute this task in the workspace. Return a concise summary of what you "
-        "did, files changed, and any follow-up needed."
-    )
+        extra_instructions=persona.extra_instructions,
+        allowed_paths=persona.allowed_paths,
+        closing_instruction=(
+            "Execute this task in the workspace. Return a concise summary of what you "
+            "did, files changed, and any follow-up needed."
+        ),
+    ).full
 
 
 def run_execute_phase(

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt builders for fleet agent dispatch."""
+
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+
+__all__ = ["AgentPrompt", "build_agent_prompt"]

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,4 +1,4 @@
-"""Prompt builders for fleet agent dispatch."""
+"""Shared prompt builders for agent dispatch paths."""
 
 from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
 

--- a/agent_fleet/prompts/__init__.py
+++ b/agent_fleet/prompts/__init__.py
@@ -1,4 +1,4 @@
-"""Shared prompt builders for agent dispatch paths."""
+"""Prompt builders for fleet agent dispatch."""
 
 from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
 

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,0 +1,40 @@
+"""Shared prompt assembly for persona-backed agent dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentPrompt:
+    full: str
+    persona_section: str
+    task_section: str
+
+
+def build_agent_prompt(
+    *,
+    persona_body: str,
+    task_heading: str,
+    task_body: str,
+    context: str = "",
+    extra_sections: list[tuple[str, str]] | None = None,
+) -> AgentPrompt:
+    """Layer persona (skills+stub+overlays) then structured task sections."""
+    persona_section = "\n".join(["# Persona", persona_body.strip()])
+
+    parts: list[str] = []
+    for heading, body in extra_sections or []:
+        if body.strip():
+            parts.extend(["", f"# {heading}", body.strip()])
+        else:
+            parts.extend(["", f"# {heading}"])
+
+    parts.extend(["", f"# {task_heading}", task_body.strip()])
+
+    if context.strip():
+        parts.extend(["", "# Context", context.strip()])
+
+    task_section = "\n".join(parts)
+    full = persona_section + task_section
+    return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,4 +1,4 @@
-"""Shared prompt assembly for persona-backed agent dispatch."""
+"""Shared agent prompt assembly for execute and fix dispatch paths."""
 
 from __future__ import annotations
 
@@ -18,23 +18,32 @@ def build_agent_prompt(
     task_heading: str,
     task_body: str,
     context: str = "",
+    extra_instructions: str = "",
+    allowed_paths: tuple[str, ...] | list[str] = (),
+    closing_instruction: str = "",
     extra_sections: list[tuple[str, str]] | None = None,
 ) -> AgentPrompt:
     """Layer persona (skills+stub+overlays) then structured task sections."""
-    persona_section = "\n".join(["# Persona", persona_body.strip()])
+    persona_parts = [
+        "# Persona",
+        persona_body.strip(),
+    ]
+    if extra_instructions.strip():
+        persona_parts.extend(["", "# Additional Instructions", extra_instructions.strip()])
+    if allowed_paths:
+        paths = ", ".join(allowed_paths)
+        persona_parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
+    persona_section = "\n".join(persona_parts)
 
-    parts: list[str] = []
+    task_parts: list[str] = ["", f"# {task_heading}", task_body.strip()]
+    if context.strip():
+        task_parts.extend(["", "# Context", context.strip()])
     for heading, body in extra_sections or []:
         if body.strip():
-            parts.extend(["", f"# {heading}", body.strip()])
-        else:
-            parts.extend(["", f"# {heading}"])
+            task_parts.extend(["", f"# {heading}", body.strip()])
+    if closing_instruction.strip():
+        task_parts.extend(["", closing_instruction.strip()])
+    task_section = "\n".join(task_parts)
 
-    parts.extend(["", f"# {task_heading}", task_body.strip()])
-
-    if context.strip():
-        parts.extend(["", "# Context", context.strip()])
-
-    task_section = "\n".join(parts)
-    full = persona_section + task_section
+    full = f"{persona_section}{task_section}"
     return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/agent_fleet/prompts/agent.py
+++ b/agent_fleet/prompts/agent.py
@@ -1,4 +1,4 @@
-"""Shared agent prompt assembly for execute and fix dispatch paths."""
+"""Shared prompt assembly for persona-backed agent dispatch."""
 
 from __future__ import annotations
 
@@ -18,32 +18,23 @@ def build_agent_prompt(
     task_heading: str,
     task_body: str,
     context: str = "",
-    extra_instructions: str = "",
-    allowed_paths: tuple[str, ...] | list[str] = (),
-    closing_instruction: str = "",
     extra_sections: list[tuple[str, str]] | None = None,
 ) -> AgentPrompt:
     """Layer persona (skills+stub+overlays) then structured task sections."""
-    persona_parts = [
-        "# Persona",
-        persona_body.strip(),
-    ]
-    if extra_instructions.strip():
-        persona_parts.extend(["", "# Additional Instructions", extra_instructions.strip()])
-    if allowed_paths:
-        paths = ", ".join(allowed_paths)
-        persona_parts.extend(["", f"# Scope: only modify paths matching: {paths}"])
-    persona_section = "\n".join(persona_parts)
+    persona_section = "\n".join(["# Persona", persona_body.strip()])
 
-    task_parts: list[str] = ["", f"# {task_heading}", task_body.strip()]
-    if context.strip():
-        task_parts.extend(["", "# Context", context.strip()])
+    parts: list[str] = []
     for heading, body in extra_sections or []:
         if body.strip():
-            task_parts.extend(["", f"# {heading}", body.strip()])
-    if closing_instruction.strip():
-        task_parts.extend(["", closing_instruction.strip()])
-    task_section = "\n".join(task_parts)
+            parts.extend(["", f"# {heading}", body.strip()])
+        else:
+            parts.extend(["", f"# {heading}"])
 
-    full = f"{persona_section}{task_section}"
+    parts.extend(["", f"# {task_heading}", task_body.strip()])
+
+    if context.strip():
+        parts.extend(["", "# Context", context.strip()])
+
+    task_section = "\n".join(parts)
+    full = persona_section + task_section
     return AgentPrompt(full=full, persona_section=persona_section, task_section=task_section)

--- a/tests/test_phases_execute_equip.py
+++ b/tests/test_phases_execute_equip.py
@@ -32,3 +32,31 @@ def test_execute_prompt_prefers_equip_compose_body() -> None:
     assert "Static persona body from resolver." not in prompt
     assert "Systematic Debugging" in prompt
     assert "Fix failing test" in prompt
+
+
+def test_execute_prompt_includes_persona_modifiers_and_closing() -> None:
+    persona = Persona(
+        name="coder",
+        prompt_path=Path("coder.md"),
+        allowed_tools=[],
+        capabilities={},
+        body="Coder body.",
+        allowed_paths=("src/",),
+        extra_instructions="Prefer small diffs.",
+    )
+    task = FleetTask(
+        goal="Implement feature",
+        context="See design doc.",
+        persona="coder",
+    )
+
+    prompt = _build_execute_prompt(persona, task)
+
+    assert prompt.index("# Persona") < prompt.index("# Additional Instructions")
+    assert prompt.index("# Additional Instructions") < prompt.index("# Scope:")
+    assert prompt.index("# Scope:") < prompt.index("# Task")
+    assert prompt.index("# Task") < prompt.index("# Context")
+    assert prompt.index("# Context") < prompt.index("Execute this task in the workspace")
+    assert "Prefer small diffs." in prompt
+    assert "only modify paths matching: src/" in prompt
+    assert "See design doc." in prompt

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -1,0 +1,51 @@
+"""Tests for shared agent prompt assembly."""
+
+from __future__ import annotations
+
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+
+
+def test_build_agent_prompt_minimal() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+    )
+
+    assert isinstance(result, AgentPrompt)
+    assert result.persona_section == "# Persona\nYou are a coder."
+    assert "# Task\nFix the bug." in result.full
+    assert result.full == result.persona_section + result.task_section
+    assert "# Context" not in result.full
+
+
+def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
+    result = build_agent_prompt(
+        persona_body="Reviewer persona.",
+        task_heading="Original Task",
+        task_body="Ship the feature.",
+        context="branch=main",
+        extra_sections=[
+            ("Additional Instructions", "Be thorough."),
+            ("Scope: only modify paths matching: src/", ""),
+        ],
+    )
+
+    assert "# Additional Instructions\nBe thorough." in result.full
+    assert "# Scope: only modify paths matching: src/" in result.full
+    assert "# Context\nbranch=main" in result.full
+    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
+    assert result.full.index("# Original Task") < result.full.index("# Context")
+
+
+def test_build_agent_prompt_strips_whitespace() -> None:
+    result = build_agent_prompt(
+        persona_body="  persona  ",
+        task_heading="Task",
+        task_body="  goal  ",
+        context="  ctx  ",
+    )
+
+    assert result.persona_section == "# Persona\npersona"
+    assert "# Task\ngoal" in result.full
+    assert "# Context\nctx" in result.full

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from agent_fleet.prompts.agent import build_agent_prompt
+from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
 
 
 def test_build_agent_prompt_minimal() -> None:
@@ -12,64 +12,40 @@ def test_build_agent_prompt_minimal() -> None:
         task_body="Fix the bug.",
     )
 
+    assert isinstance(result, AgentPrompt)
     assert result.persona_section == "# Persona\nYou are a coder."
-    assert result.task_section == "\n# Task\nFix the bug."
-    assert result.full == "# Persona\nYou are a coder.\n# Task\nFix the bug."
+    assert "# Task\nFix the bug." in result.full
+    assert result.full == result.persona_section + result.task_section
+    assert "# Context" not in result.full
 
 
-def test_build_agent_prompt_includes_context_and_closing() -> None:
-    closing = (
-        "Execute this task in the workspace. Return a concise summary of what you "
-        "did, files changed, and any follow-up needed."
-    )
+def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
     result = build_agent_prompt(
-        persona_body="You are a coder.",
-        task_heading="Task",
-        task_body="Fix the bug.",
-        context="See auth.py",
-        closing_instruction=closing,
-    )
-
-    assert "# Context\nSee auth.py" in result.full
-    assert result.full.endswith(closing)
-    assert "# Task\nFix the bug." in result.task_section
-
-
-def test_build_agent_prompt_includes_persona_extras() -> None:
-    result = build_agent_prompt(
-        persona_body="You are a coder.",
-        task_heading="Task",
-        task_body="Fix the bug.",
-        extra_instructions="Prefer small diffs.",
-        allowed_paths=("src/**", "tests/**"),
-    )
-
-    assert "# Additional Instructions\nPrefer small diffs." in result.persona_section
-    assert "# Scope: only modify paths matching: src/**, tests/**" in result.persona_section
-
-
-def test_build_agent_prompt_supports_extra_sections() -> None:
-    result = build_agent_prompt(
-        persona_body="You are a reviewer.",
+        persona_body="Reviewer persona.",
         task_heading="Original Task",
-        task_body="Add logging.",
+        task_body="Ship the feature.",
+        context="branch=main",
         extra_sections=[
-            ("Implementation Summary", "Added structured logs."),
-            ("Review", "Check for PII in logs."),
+            ("Additional Instructions", "Be thorough."),
+            ("Scope: only modify paths matching: src/", ""),
         ],
     )
 
-    assert "# Implementation Summary\nAdded structured logs." in result.full
-    assert "# Review\nCheck for PII in logs." in result.full
+    assert "# Additional Instructions\nBe thorough." in result.full
+    assert "# Scope: only modify paths matching: src/" in result.full
+    assert "# Context\nbranch=main" in result.full
+    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
+    assert result.full.index("# Original Task") < result.full.index("# Context")
 
 
-def test_build_agent_prompt_skips_blank_extra_sections() -> None:
+def test_build_agent_prompt_strips_whitespace() -> None:
     result = build_agent_prompt(
-        persona_body="You are a reviewer.",
+        persona_body="  persona  ",
         task_heading="Task",
-        task_body="Review changes.",
-        extra_sections=[("Review", "   "), ("Notes", "Keep it concise.")],
+        task_body="  goal  ",
+        context="  ctx  ",
     )
 
-    assert "# Review" not in result.full
-    assert "# Notes\nKeep it concise." in result.full
+    assert result.persona_section == "# Persona\npersona"
+    assert "# Task\ngoal" in result.full
+    assert "# Context\nctx" in result.full

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -38,6 +38,17 @@ def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
     assert result.full.index("# Original Task") < result.full.index("# Context")
 
 
+def test_build_agent_prompt_emits_heading_for_empty_body_section() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        extra_sections=[("Scope:", "")],
+    )
+
+    assert "# Scope:" in result.task_section
+
+
 def test_build_agent_prompt_strips_whitespace() -> None:
     result = build_agent_prompt(
         persona_body="  persona  ",

--- a/tests/test_prompts_agent.py
+++ b/tests/test_prompts_agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from agent_fleet.prompts.agent import AgentPrompt, build_agent_prompt
+from agent_fleet.prompts.agent import build_agent_prompt
 
 
 def test_build_agent_prompt_minimal() -> None:
@@ -12,40 +12,64 @@ def test_build_agent_prompt_minimal() -> None:
         task_body="Fix the bug.",
     )
 
-    assert isinstance(result, AgentPrompt)
     assert result.persona_section == "# Persona\nYou are a coder."
-    assert "# Task\nFix the bug." in result.full
-    assert result.full == result.persona_section + result.task_section
-    assert "# Context" not in result.full
+    assert result.task_section == "\n# Task\nFix the bug."
+    assert result.full == "# Persona\nYou are a coder.\n# Task\nFix the bug."
 
 
-def test_build_agent_prompt_includes_context_and_extra_sections() -> None:
+def test_build_agent_prompt_includes_context_and_closing() -> None:
+    closing = (
+        "Execute this task in the workspace. Return a concise summary of what you "
+        "did, files changed, and any follow-up needed."
+    )
     result = build_agent_prompt(
-        persona_body="Reviewer persona.",
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        context="See auth.py",
+        closing_instruction=closing,
+    )
+
+    assert "# Context\nSee auth.py" in result.full
+    assert result.full.endswith(closing)
+    assert "# Task\nFix the bug." in result.task_section
+
+
+def test_build_agent_prompt_includes_persona_extras() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a coder.",
+        task_heading="Task",
+        task_body="Fix the bug.",
+        extra_instructions="Prefer small diffs.",
+        allowed_paths=("src/**", "tests/**"),
+    )
+
+    assert "# Additional Instructions\nPrefer small diffs." in result.persona_section
+    assert "# Scope: only modify paths matching: src/**, tests/**" in result.persona_section
+
+
+def test_build_agent_prompt_supports_extra_sections() -> None:
+    result = build_agent_prompt(
+        persona_body="You are a reviewer.",
         task_heading="Original Task",
-        task_body="Ship the feature.",
-        context="branch=main",
+        task_body="Add logging.",
         extra_sections=[
-            ("Additional Instructions", "Be thorough."),
-            ("Scope: only modify paths matching: src/", ""),
+            ("Implementation Summary", "Added structured logs."),
+            ("Review", "Check for PII in logs."),
         ],
     )
 
-    assert "# Additional Instructions\nBe thorough." in result.full
-    assert "# Scope: only modify paths matching: src/" in result.full
-    assert "# Context\nbranch=main" in result.full
-    assert result.full.index("# Additional Instructions") < result.full.index("# Original Task")
-    assert result.full.index("# Original Task") < result.full.index("# Context")
+    assert "# Implementation Summary\nAdded structured logs." in result.full
+    assert "# Review\nCheck for PII in logs." in result.full
 
 
-def test_build_agent_prompt_strips_whitespace() -> None:
+def test_build_agent_prompt_skips_blank_extra_sections() -> None:
     result = build_agent_prompt(
-        persona_body="  persona  ",
+        persona_body="You are a reviewer.",
         task_heading="Task",
-        task_body="  goal  ",
-        context="  ctx  ",
+        task_body="Review changes.",
+        extra_sections=[("Review", "   "), ("Notes", "Keep it concise.")],
     )
 
-    assert result.persona_section == "# Persona\npersona"
-    assert "# Task\ngoal" in result.full
-    assert "# Context\nctx" in result.full
+    assert "# Review" not in result.full
+    assert "# Notes\nKeep it concise." in result.full


### PR DESCRIPTION
## Summary
- Shared \`build_agent_prompt\` builder for execute-phase prompts (introduced earlier in this branch).
- This branch carries WIP follow-ups: prompts/__init__ re-export pruning, prompts/agent.py simplifications, phases.py extras removal, and slimmed test_prompts_agent.py.

## Status
Draft for review only — not ready to merge. Sibling branches \`feature/skills-foundation\`, \`feature/skills-personas\`, \`feature/skills-pr-loop\` are part of the same buildout.

## Test plan
- [ ] \`pytest tests/test_prompts_agent.py\`
- [ ] Manual: \`agent-fleet run\` with a coder persona, confirm prompt assembly unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)