### PR TITLE
WIP: skills-pr-loop — wire equip.compose into PR loop & code_review fixes

### DIFF
--- a/agent_fleet/code_review/fix.py
+++ b/agent_fleet/code_review/fix.py
@@ -6,11 +6,17 @@ import textwrap
 from typing import TYPE_CHECKING, Any
 
 from agent_fleet.agent_mode import parse_agent_mode
+from agent_fleet.config import load_fleet_config
+from agent_fleet.hooks import FleetTask
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
+from agent_fleet.prompts.agent import build_agent_prompt
+from agent_fleet.repo import merge_repo_into_fleet_config
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from agent_fleet.hooks import FleetTask, LLMBackend
+    from agent_fleet.hooks import LLMBackend
+    from agent_fleet.level_up.models import DispatchEquip
     from agent_fleet.personas import YamlPersonaResolver
     from agent_fleet.repo import RepoConfig
 
@@ -60,6 +66,38 @@ def _verify_feedback(phase_results: list[dict[str, Any]]) -> str:
     return "\n\n".join(lines)
 
 
+def _resolve_fix_equip(
+    *,
+    task: FleetTask,
+    fix_persona: str,
+    repo: RepoConfig | None,
+    attempt: int,
+) -> DispatchEquip:
+    if fix_persona == task.persona and task.equip is not None:
+        return task.equip
+
+    fleet_config = load_fleet_config()
+    if repo is not None:
+        fleet_config = merge_repo_into_fleet_config(fleet_config, repo)
+
+    parent_run_id = task.equip.parent_run_id if task.equip else None
+    fix_task = FleetTask(
+        goal=task.goal,
+        context=task.context,
+        persona=fix_persona,
+        workspace=task.workspace,
+        pipeline=task.pipeline,
+        title=task.title,
+        equip=task.equip,
+    )
+    run_id = (
+        f"{parent_run_id}-fix-{attempt}"
+        if parent_run_id
+        else f"code-review-fix-{attempt}"
+    )
+    return resolve_dispatch_equip(fix_task, fleet_config, repo, run_id=run_id)
+
+
 def run_fix_phase(
     *,
     backend: LLMBackend,
@@ -76,33 +114,37 @@ def run_fix_phase(
     persona = resolver.load(fix_persona)
     review_block = _review_feedback(phase_results)
     verify_block = _verify_feedback(phase_results)
+    equip = _resolve_fix_equip(
+        task=task,
+        fix_persona=fix_persona,
+        repo=repo,
+        attempt=attempt,
+    )
 
     verify_commands = ""
     if repo and repo.verify_commands:
         verify_commands = "\n".join(f"- `{cmd}`" for cmd in repo.verify_commands)
 
-    prompt = textwrap.dedent(f"""\
-        You are fixing issues found during an automated code review pipeline.
-
-        ## Original task
-        {task.goal.strip()}
-
-        ## Context
-        {task.context.strip() or "(none)"}
-
-        ## Review feedback
-        {review_block or "(none — focus on verify failures below)"}
-
-        ## Verify failures
-        {verify_block or "(none)"}
-
-        ## Instructions
+    instructions = textwrap.dedent(f"""\
         1. Fix every valid blocking issue above with minimal diffs.
         2. Do NOT commit or push — the orchestrator handles git.
         3. Run these verify commands before finishing:
-        {verify_commands or "- (none configured)"}
+        {verify_commands or "- (none)"}
         4. Fix attempt {attempt} — address root causes, not symptoms.
     """)
+
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body="You are fixing issues found during an automated code review pipeline.",
+        context=task.context.strip() or "(none)",
+        extra_sections=[
+            ("Original task", task.goal.strip()),
+            ("Review feedback", review_block or "(none)"),
+            ("Verify failures", verify_block or "(none)"),
+            ("Instructions", instructions),
+        ],
+    ).full
 
     result = backend.run(
         prompt,

--- a/agent_fleet/code_review/fix.py
+++ b/agent_fleet/code_review/fix.py
@@ -6,7 +6,7 @@ import textwrap
 from typing import TYPE_CHECKING, Any
 
 from agent_fleet.agent_mode import parse_agent_mode
-from agent_fleet.config import load_fleet_config
+from agent_fleet.config import FleetConfig, load_fleet_config
 from agent_fleet.hooks import FleetTask
 from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.prompts.agent import build_agent_prompt
@@ -72,11 +72,12 @@ def _resolve_fix_equip(
     fix_persona: str,
     repo: RepoConfig | None,
     attempt: int,
+    fleet_config: FleetConfig | None = None,
 ) -> DispatchEquip:
     if fix_persona == task.persona and task.equip is not None:
         return task.equip
 
-    fleet_config = load_fleet_config()
+    fleet_config = fleet_config or load_fleet_config()
     if repo is not None:
         fleet_config = merge_repo_into_fleet_config(fleet_config, repo)
 
@@ -109,6 +110,7 @@ def run_fix_phase(
     repo: RepoConfig | None,
     fix_persona: str,
     attempt: int,
+    fleet_config: FleetConfig | None = None,
 ) -> dict[str, Any]:
     """Dispatch fix persona to address review or verify failures."""
     persona = resolver.load(fix_persona)
@@ -119,6 +121,7 @@ def run_fix_phase(
         fix_persona=fix_persona,
         repo=repo,
         attempt=attempt,
+        fleet_config=fleet_config,
     )
 
     verify_commands = ""

--- a/agent_fleet/code_review/loop.py
+++ b/agent_fleet/code_review/loop.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from agent_fleet.code_review.config import CodeReviewConfig
+    from agent_fleet.config import FleetConfig
     from agent_fleet.hooks import FleetTask, LLMBackend
     from agent_fleet.personas import YamlPersonaResolver
     from agent_fleet.repo import RepoConfig
@@ -78,6 +79,7 @@ def run_code_review_with_auto_fix(
     repo: RepoConfig | None,
     config: CodeReviewConfig,
     reviewer_persona: str = "reviewer",
+    fleet_config: FleetConfig | None = None,
 ) -> tuple[list[dict[str, Any]], str, int, list[str]]:
     """Run code_review pipeline with optional fix → re-check loops."""
     if not config.auto_fix or phases != ["execute", "review"]:
@@ -121,6 +123,7 @@ def run_code_review_with_auto_fix(
             repo=repo,
             fix_persona=fix_persona,
             attempt=attempt,
+            fleet_config=fleet_config,
         )
         phase_results.append(fix_result)
         if fix_result["exit_code"] != 0:

--- a/agent_fleet/dispatcher_task.py
+++ b/agent_fleet/dispatcher_task.py
@@ -120,6 +120,7 @@ def run_configured_pipeline(
                 phases=phases,
                 repo=repo_config or git_repo,
                 config=code_review_cfg,
+                fleet_config=task_config,
             )
         return run_pipeline(
             backend=backend,

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING
 from agent_fleet.agent_mode import parse_agent_mode
 from agent_fleet.backends import make_backend
 from agent_fleet.config import FleetConfig, load_fleet_config
+from agent_fleet.hooks import FleetTask
 from agent_fleet.observability.fleet_logger import FleetLogger
+from agent_fleet.orchestration.equip import resolve_dispatch_equip
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.pr_loop import github_ops
 from agent_fleet.pr_loop.github_ops import CommitPushResult
@@ -22,6 +24,7 @@ from agent_fleet.pr_loop.review_parse import (
     has_blocking_findings,
     parse_review_risk,
 )
+from agent_fleet.prompts.agent import build_agent_prompt
 from agent_fleet.repo import RepoConfig, merge_repo_into_fleet_config
 from agent_fleet.scope import files_outside_allowed_paths
 from agent_fleet.state import (
@@ -322,26 +325,53 @@ def address_review_findings(
 
     pr_files_block = "\n".join(f"- `{path}`" for path in pr_files) or "- (unknown)"
 
-    prompt = textwrap.dedent(f"""\
-        The PR analyzer posted review findings on PR #{pr_number}. Address every
-        blocking finding in the review comment below.
+    fix_task = FleetTask(
+        goal=f"Fix PR #{pr_number} review findings",
+        context=f"branch={branch}",
+        persona=fix_persona_name,
+        workspace=str(worktree),
+    )
+    equip = resolve_dispatch_equip(
+        fix_task,
+        fleet_config,
+        repo,
+        run_id=f"pr-loop-{pr_number}",
+    )
 
-        ## Review
-        {review_body}
+    extra_sections: list[tuple[str, str]] = [
+        ("Review", review_body),
+        ("PR changed files (only edit these or subpaths)", pr_files_block),
+    ]
+    if commit_failure_block.strip():
+        extra_sections.append(
+            (
+                "Previous commit/push failure (must fix before finishing)",
+                commit_failure_block.strip(),
+            )
+        )
 
-        ## PR changed files (only edit these or subpaths)
-        {pr_files_block}
-        {commit_failure_block}
-        ## Instructions
+    instructions_body = textwrap.dedent(f"""\
         1. Read each finding and fix valid issues in the relevant files above.
         2. Do NOT edit files outside this PR's changed paths.
         3. Run verify commands before finishing:
-        {verify_block or "- (none configured)"}
+        {verify_block or "- (none)"}
         4. Pre-commit and commit preflight must pass (same gates as git commit):
-        {preflight_block or verify_block or "- pre-commit hooks on changed files (automatic)"}
+        {preflight_block or verify_block or "- (none)"}
         5. Do NOT commit or push — the orchestrator commits after this phase.
         6. If a finding is a false positive, note it but do not change code for it.
     """)
+    extra_sections.append(("Instructions", instructions_body))
+
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body=(
+            f"The PR analyzer posted review findings on PR #{pr_number}. "
+            "Address every blocking finding in the review comment below."
+        ),
+        context=f"branch={branch}",
+        extra_sections=extra_sections,
+    ).full
 
     logger.info(
         "Review fix PR #%s persona=%s worktree=%s pr_files=%d",
@@ -440,24 +470,49 @@ def attempt_ci_fix(
     verify_block = "\n".join(f"- `{cmd}`" for cmd in repo.verify_commands) or "- (none)"
     failure_block = ""
     if commit_error_context:
-        failure_block = textwrap.dedent(f"""
-
-        ## Previous commit/push failure
-        ```
-        {commit_error_context[:6000]}
-        ```
+        failure_block = textwrap.dedent(f"""\
+            ```
+            {commit_error_context[:6000]}
+            ```
         """)
-    prompt = textwrap.dedent(f"""\
+
+    fix_task = FleetTask(
+        goal=f"Fix CI failures on PR #{pr_number}",
+        context=(
+            f"branch={branch}; failed_checks={', '.join(failed_checks)}; ci_fix"
+        ),
+        persona=fix_persona_name,
+        workspace=str(worktree),
+    )
+    equip = resolve_dispatch_equip(
+        fix_task,
+        fleet_config,
+        repo,
+        run_id=f"pr-loop-{pr_number}",
+    )
+
+    extra_sections: list[tuple[str, str]] = []
+    if failure_block.strip():
+        extra_sections.append(("Previous commit/push failure", failure_block.strip()))
+
+    task_body = textwrap.dedent(f"""\
         CI failed on PR #{pr_number}. Fix the failures caused by this branch.
 
         Failed checks: {", ".join(failed_checks)}
-        {failure_block}
+
         Verify commands:
         {verify_block}
 
         Do NOT commit or push — the orchestrator commits after this phase.
         Do NOT weaken CI workflows to make checks pass.
     """)
+    prompt = build_agent_prompt(
+        persona_body=equip.compose_body,
+        task_heading="Task",
+        task_body=task_body,
+        context=f"branch={branch}; ci_fix",
+        extra_sections=extra_sections,
+    ).full
     logger.info(
         "CI fix PR #%s persona=%s worktree=%s checks=%s",
         pr_number,

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -335,7 +335,7 @@ def address_review_findings(
         fix_task,
         fleet_config,
         repo,
-        run_id=f"pr-loop-{pr_number}",
+        run_id=f"pr-loop-{pr_number}-{int(time.time())}",
     )
 
     extra_sections: list[tuple[str, str]] = [
@@ -488,7 +488,7 @@ def attempt_ci_fix(
         fix_task,
         fleet_config,
         repo,
-        run_id=f"pr-loop-{pr_number}",
+        run_id=f"pr-loop-{pr_number}-{int(time.time())}",
     )
 
     extra_sections: list[tuple[str, str]] = []

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -203,10 +203,10 @@ Notes:
 
 ### Tasks
 
-- [ ] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
-- [ ] Wire lifecycle.py (review fix + CI fix)
-- [ ] Wire code_review/fix.py
-- [ ] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
+- [x] Write failing tests: PR loop prompt contains `# Fix CI` or skill marker from fix-ci
+- [x] Wire lifecycle.py (review fix + CI fix)
+- [x] Wire code_review/fix.py
+- [x] `pytest tests/test_pr_loop_equip.py tests/test_code_review_fix_equip.py -q`
 - [ ] Manual smoke: `agent-fleet loop` dry path with mock backend if available
 - [ ] Open PR3
 

--- a/tests/test_code_review_fix_equip.py
+++ b/tests/test_code_review_fix_equip.py
@@ -1,0 +1,183 @@
+# ruff: noqa: TC002
+"""Code review auto-fix phase uses dispatch equip compose body."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_fleet.code_review.fix import run_fix_phase
+from agent_fleet.config import load_fleet_config
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.hooks import FleetTask
+from agent_fleet.level_up.models import DispatchEquip
+from agent_fleet.level_up.paths import persona_dir
+from agent_fleet.personas import YamlPersonaResolver
+from agent_fleet.repo import load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        timeout_s: int,
+        memory_limit: str = "4G",
+        allowed_tools: list[str] | None = None,
+        cwd: Path | None = None,
+        model: str | None = None,
+        mode: object | None = None,
+    ) -> CursorLLMResult:
+        del max_tokens, timeout_s, memory_limit, allowed_tools, cwd, model, mode
+        self.prompts.append(prompt)
+        return CursorLLMResult(
+            stdout="fixed",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+            agent_id="fix-agent",
+        )
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+def test_fix_phase_uses_task_equip_fast_path(
+    tmp_path: Path,
+) -> None:
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    equip = DispatchEquip(
+        persona="coder",
+        base_loadout="coder",
+        skill_slots_execute=("pstack/tdd",),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="# Equip compose\n\nTDD Bug Fix",
+    )
+    task = FleetTask(
+        goal="Implement widget",
+        context="",
+        persona="coder",
+        workspace=str(tmp_path),
+        equip=equip,
+    )
+
+    run_fix_phase(
+        backend=backend,
+        resolver=resolver,
+        task=task,
+        workspace=tmp_path,
+        timeout_s=60,
+        phase_results=[{"phase": "review", "verdict": "request_changes"}],
+        repo=None,
+        fix_persona="coder",
+        attempt=1,
+    )
+
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "TDD Bug Fix" in prompt
+    assert "# Review feedback" in prompt
+    assert "# Verify failures\n(none)" in prompt
+
+
+def test_fix_phase_resolves_equip_when_fix_persona_differs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: fix-persona-mismatch\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    execute_equip = DispatchEquip(
+        persona="coder",
+        base_loadout="coder",
+        skill_slots_execute=("pstack/tdd",),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="# Execute equip\n\nExecute-only body",
+        parent_run_id="parent-run-1",
+    )
+    task = FleetTask(
+        goal="Implement widget",
+        context="ctx",
+        persona="coder",
+        workspace=str(tmp_path),
+        equip=execute_equip,
+    )
+
+    run_fix_phase(
+        backend=backend,
+        resolver=resolver,
+        task=task,
+        workspace=tmp_path,
+        timeout_s=60,
+        phase_results=[],
+        repo=repo,
+        fix_persona="reviewer",
+        attempt=2,
+    )
+
+    prompt = backend.prompts[0]
+    assert "Execute-only body" not in prompt
+    assert "# Persona" in prompt
+    assert "# Review feedback\n(none)" in prompt
+    assert "# Verify failures\n(none)" in prompt
+
+    journal_path = persona_dir("fix-persona-mismatch", "reviewer") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "parent-run-1-fix-2" for row in rows)
+
+
+def test_fix_phase_journals_run_id_without_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text("name: fix-run-id\n", encoding="utf-8")
+    repo = load_repo_config(repo_yaml)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    backend = _CapturingBackend()
+    task = FleetTask(goal="Fix tests", persona="coder", workspace=str(tmp_path))
+
+    with patch("agent_fleet.code_review.fix.resolve_dispatch_equip") as mock_resolve:
+        mock_resolve.return_value = DispatchEquip(
+            persona="coder",
+            base_loadout="coder",
+            skill_slots_execute=(),
+            skill_slots_review=(),
+            level_up_generation=0,
+            compose_body="Coder body",
+        )
+        run_fix_phase(
+            backend=backend,
+            resolver=resolver,
+            task=task,
+            workspace=tmp_path,
+            timeout_s=60,
+            phase_results=[],
+            repo=repo,
+            fix_persona="reviewer",
+            attempt=3,
+        )
+
+    mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.kwargs["run_id"] == "code-review-fix-3"

--- a/tests/test_pr_loop_equip.py
+++ b/tests/test_pr_loop_equip.py
@@ -195,4 +195,6 @@ def test_review_fix_journals_equip_with_run_id(
     journal_path = persona_dir("pr-loop-equip", "coder") / "journal.jsonl"
     assert journal_path.is_file()
     rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
-    assert any(row.get("run_id") == "pr-loop-99" for row in rows)
+    assert any(
+        str(row.get("run_id", "")).startswith("pr-loop-99-") for row in rows
+    )

--- a/tests/test_pr_loop_equip.py
+++ b/tests/test_pr_loop_equip.py
@@ -1,0 +1,198 @@
+"""PR loop fix agents include dispatch equip compose body."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.pr_loop.config import PrLoopConfig
+from agent_fleet.pr_loop.lifecycle import address_review_findings, attempt_ci_fix
+from agent_fleet.repo import RepoConfig, load_repo_config
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class _CapturingBackend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        timeout_s: int,
+        memory_limit: str = "4G",
+        allowed_tools: list[str] | None = None,
+        cwd: Path | None = None,
+        model: str | None = None,
+        mode: object | None = None,
+    ) -> CursorLLMResult:
+        del max_tokens, timeout_s, memory_limit, allowed_tools, cwd, model, mode
+        self.prompts.append(prompt)
+        return CursorLLMResult(
+            stdout="done",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+            agent_id="fix-agent",
+        )
+
+
+def _patch_level_up_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr("agent_fleet.level_up.paths.LEVEL_UP_ROOT", root)
+
+
+def _pr_loop_repo(tmp_path: Path) -> RepoConfig:
+    repo_yaml = tmp_path / ".agent-fleet.yaml"
+    repo_yaml.write_text(
+        "name: pr-loop-equip\npr_loop:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    return load_repo_config(repo_yaml)
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    return wt
+
+
+def test_review_fix_prompt_includes_fix_ci_skill(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+    review_body = "**Risk Level:** MEDIUM\n<details><summary>MEDIUM</summary>"
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.has_blocking_findings",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_diff",
+            return_value="+added",
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_changed_files",
+            return_value=["src/a.py"],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        result = address_review_findings(
+            pr_number=42,
+            branch="fleet/coder/42-abc",
+            review_body=review_body,
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+        )
+
+    assert result.status == "no_changes"
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "# Persona" in prompt
+    assert "# Fix CI" in prompt
+    assert "# Review" in prompt
+    assert review_body in prompt
+    assert "- (none)" in prompt
+
+
+def test_ci_fix_prompt_includes_fix_ci_skill(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        result = attempt_ci_fix(
+            pr_number=7,
+            branch="fleet/coder/7-def",
+            failed_checks=["pytest"],
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+            persona="coder",
+        )
+
+    assert not result.ok
+    assert result.phase == "no_changes"
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "# Fix CI" in prompt
+    assert "Failed checks: pytest" in prompt
+    assert "- (none)" in prompt
+
+
+def test_review_fix_journals_equip_with_run_id(
+    tmp_path: Path,
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_fleet.level_up.paths import persona_dir
+
+    _patch_level_up_root(monkeypatch, tmp_path / "level_up")
+    repo = _pr_loop_repo(tmp_path)
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    backend = _CapturingBackend()
+
+    with (
+        patch("agent_fleet.pr_loop.lifecycle.make_backend", return_value=backend),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.has_blocking_findings",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_diff",
+            return_value="+added",
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_changed_files",
+            return_value=["src/a.py"],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle._git_changed_files",
+            return_value=[],
+        ),
+    ):
+        address_review_findings(
+            pr_number=99,
+            branch="fleet/coder/99-xyz",
+            review_body="blocking finding",
+            repo=repo,
+            loop_config=PrLoopConfig(enabled=True),
+            fleet_config=fleet_config,
+            worktree=worktree,
+        )
+
+    journal_path = persona_dir("pr-loop-equip", "coder") / "journal.jsonl"
+    assert journal_path.is_file()
+    rows = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines()]
+    assert any(row.get("run_id") == "pr-loop-99" for row in rows)


### PR DESCRIPTION
## Summary
Stacks on `feature/skills-prompt-builder` (#12), which stacks on `feature/skills-foundation` (#13).

Adds `85ed9ac`: wires `equip.compose` into the PR loop watcher and code_review fix-agent dispatch so persona loadouts apply on redispatches, not just initial runs.

## Status
**Draft for review only.** Part of the stacked skills buildout. Do not merge before #13 → #12.

## Test plan
- [ ] `pytest tests/test_pr_loop_equip.py`
- [ ] Manual: trigger a `request_changes` verdict; confirm the redispatched fix agent gets the persona loadout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)