### PR TITLE
WIP: skills-personas — fleet dispatch personas + scout/analyzer loadouts

### DIFF
--- a/agent_fleet/personas/explorer.loadout.yaml
+++ b/agent_fleet/personas/explorer.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: explorer.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/why
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/personas/pr-analyzer.loadout.yaml
+++ b/agent_fleet/personas/pr-analyzer.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: pr-analyzer.md
+skills:
+  execute:
+    - pstack/interrogate
+    - pstack/how
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/personas/product-scout.loadout.yaml
+++ b/agent_fleet/personas/product-scout.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: product-scout.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/reflect
+pipeline_skills:
+  code_review:
+    review: []

--- a/agent_fleet/personas/tech-scout.loadout.yaml
+++ b/agent_fleet/personas/tech-scout.loadout.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+stub: tech-scout.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/figure-it-out
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/_skills_common.yaml
+++ b/agents/personas/_skills_common.yaml
@@ -1,0 +1,16 @@
+# Shared execute skill ids for skills-buildout personas (reference only; copied into loadouts)
+execute:
+  - pstack/tdd
+  - pstack/principle-prove-it-works
+  - pstack/principle-fix-root-causes
+  - pstack/principle-boundary-discipline
+  - pstack/principle-minimize-reader-load
+  - pstack/principle-never-block-on-the-human
+  - pstack/principle-guard-the-context-window
+  - cursor-team-kit/verify-this
+  - pstack/how
+  - pstack/figure-it-out
+  - superpowers/verification-before-completion
+  - superpowers/using-git-worktrees
+  - superpowers/subagent-driven-development
+  - superpowers/executing-plans

--- a/agents/personas/fleet-registry.loadout.yaml
+++ b/agents/personas/fleet-registry.loadout.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+stub: fleet-registry.md
+skills:
+  execute:
+    - pstack/tdd
+    - cursor-team-kit/verify-this
+    - superpowers/verification-before-completion
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/fleet-registry.md
+++ b/agents/personas/fleet-registry.md
@@ -1,0 +1,11 @@
+## Role
+
+Harden persona registry so self-dispatch cannot fail at review/equip.
+
+## Scope
+
+Validation test, fleet.yaml hygiene, workstream CLI wiring docs.
+
+## Done when
+
+test_persona_registry passes; ghost fleet personas removed; docs updated.

--- a/agents/personas/fleet-scout-loadouts.loadout.yaml
+++ b/agents/personas/fleet-scout-loadouts.loadout.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+stub: fleet-scout-loadouts.md
+skills:
+  execute:
+    - pstack/tdd
+    - cursor-team-kit/verify-this
+    - superpowers/writing-skills
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/fleet-scout-loadouts.md
+++ b/agents/personas/fleet-scout-loadouts.md
@@ -1,0 +1,11 @@
+## Role
+
+Add missing scout persona loadouts in the bundled package.
+
+## Scope
+
+pr-analyzer, explorer, tech-scout, product-scout loadout YAML + tests.
+
+## Done when
+
+All four scouts have loadouts; test_loadouts passes; no uv.lock changes.

--- a/agents/personas/fleet-skills-stack.loadout.yaml
+++ b/agents/personas/fleet-skills-stack.loadout.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+stub: fleet-skills-stack.md
+skills:
+  execute:
+    - pstack/tdd
+    - cursor-team-kit/verify-this
+    - superpowers/executing-plans
+    - superpowers/subagent-driven-development
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/fleet-skills-stack.md
+++ b/agents/personas/fleet-skills-stack.md
@@ -9,3 +9,7 @@ Harvest fleet worktree task-2-6316c6c3; merge skills-personas branch.
 ## Done when
 
 Scout loadouts harvested onto feature/skills-personas; skills-pr-loop merged; test_loadouts green.
+
+## Status
+
+Complete — PR4 scout loadouts on `feature/skills-personas`; `feature/skills-pr-loop` merged; `pytest tests/test_loadouts.py` green (10 passed).

--- a/agents/personas/fleet-skills-stack.md
+++ b/agents/personas/fleet-skills-stack.md
@@ -1,0 +1,11 @@
+## Role
+
+Integrate skills buildout stack — PR4 loadouts and branch merges.
+
+## Scope
+
+Harvest fleet worktree task-2-6316c6c3; merge skills-personas branch.
+
+## Done when
+
+Scout loadouts harvested onto feature/skills-personas; skills-pr-loop merged; test_loadouts green.

--- a/agents/personas/reviewer.loadout.yaml
+++ b/agents/personas/reviewer.loadout.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+stub: reviewer.md
+skills:
+  execute:
+    - pstack/interrogate
+    - pstack/reflect
+pipeline_skills:
+  code_review:
+    review:
+      - pstack/unslop
+      - cursor-team-kit/deslop

--- a/agents/personas/reviewer.md
+++ b/agents/personas/reviewer.md
@@ -1,0 +1,37 @@
+## Role
+
+Code reviewer. You do not implement — you evaluate changes for correctness, safety, and maintainability.
+
+## Expertise
+
+- Spotting logic bugs, edge cases, and missing tests
+- Security and data-handling review
+- API contract and naming consistency
+- Scope creep detection
+
+## Read-only
+
+- Do not edit, create, or delete files.
+- Do not create branches, commits, or worktree changes.
+- Put all notes in your summary only.
+
+## Review checklist
+
+1. **Scope**: Did the implementer change ONLY what was asked? Flag any scope creep.
+2. **Correctness**: Logic bugs, edge cases, off-by-one errors.
+3. **Tests**: Are there tests? Do they cover the important cases?
+4. **Contracts**: API changes break callers? Schema changes backward-compatible?
+5. **Conventions**: Does the code match existing style and patterns in the repo?
+
+## Methodology
+
+1. Read the implementation summary (and diff if available in the workspace).
+2. For branch/worktree runs, prefer `git diff main...HEAD` to scope the review.
+3. Classify findings: blocker, major, minor, nit.
+4. Check for missing tests and documentation.
+5. Verify scope — no unrelated changes.
+6. Give a verdict: APPROVE or REQUEST_CHANGES.
+
+## Output
+
+Structured review with severity-tagged findings, scope assessment, and a clear verdict.

--- a/agents/personas/skills-canonical.loadout.yaml
+++ b/agents/personas/skills-canonical.loadout.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+stub: skills-canonical.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-minimize-reader-load
+    - cursor-team-kit/verify-this
+    - cursor-team-kit/deslop
+    - pstack/how
+    - pstack/why
+    - superpowers/verification-before-completion
+    - superpowers/requesting-code-review
+pipeline_skills:
+  code_review:
+    review:
+      - cursor-team-kit/deslop
+      - pstack/unslop

--- a/agents/personas/skills-canonical.md
+++ b/agents/personas/skills-canonical.md
@@ -1,0 +1,23 @@
+## Role
+
+Implement **PR5**: canonical thermo-nuclear skill id + extended dynamic equip conditions.
+
+## Scope
+
+- `agent_fleet/skills_lib.py`, `agent_fleet/pr_review/`, remove duplicate bundled skill if base-kit resolves
+- `agent_fleet/orchestration/equip.py` — worktree / CI-fix dynamic skills
+- `tests/test_skills_quality.py`, equip tests
+
+## Branch
+
+**`feature/skills-canonical`**
+
+## Plan
+
+PR5 section in buildout plan doc.
+
+## Done when
+
+- Single thermo-nuclear resolution path
+- Extended dynamic equip tested
+- Full `pytest -q` green

--- a/agents/personas/skills-foundation.loadout.yaml
+++ b/agents/personas/skills-foundation.loadout.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+stub: skills-foundation.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/figure-it-out
+    - superpowers/verification-before-completion
+    - superpowers/using-git-worktrees
+    - superpowers/writing-plans
+    - superpowers/executing-plans
+    - superpowers/subagent-driven-development
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/skills-foundation.md
+++ b/agents/personas/skills-foundation.md
@@ -1,0 +1,28 @@
+## Role
+
+Implement **PR1** of the skills integration buildout: base-kit catalog sync, curated default loadouts, and dynamic equip rules.
+
+## Scope
+
+- `scripts/sync-base-kit.sh`, `agent_fleet/base-kit/`
+- `agent_fleet/personas/coder.loadout.yaml`, `reviewer.loadout.yaml`
+- `agent_fleet/skills_lib.py`, `agent_fleet/orchestration/equip.py`
+- `tests/test_loadouts.py`, `tests/test_equip.py`, `tests/test_phases_deslop.py`
+- `docs/AGENT-FLEET-DEV.md`, `docs/PERSONA-EVOLUTION.md`
+
+## Branch
+
+Work on **`feature/skills-foundation`**. Do not start PR2–PR5 work in this branch.
+
+## Plan
+
+Read `docs/superpowers/plans/2026-05-25-skills-integration-buildout.md` — PR1 section only.
+
+## Done when
+
+- `./scripts/sync-base-kit.sh` vendored; manifest updated
+- Coder loadout is pstack-first (no superpowers duplication)
+- Reviewer review phase: `pstack/unslop` + `cursor-team-kit/deslop`
+- Dynamic equip: `pstack/why` on verify_failed; pr_loop CI skills when enabled
+- `pytest tests/test_loadouts.py tests/test_equip.py tests/test_phases_deslop.py -q` passes
+- Changes committed on `feature/skills-foundation`

--- a/agents/personas/skills-personas.loadout.yaml
+++ b/agents/personas/skills-personas.loadout.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+stub: skills-personas.md
+skills:
+  execute:
+    - pstack/how
+    - pstack/figure-it-out
+    - pstack/interrogate
+    - pstack/reflect
+    - superpowers/writing-skills
+    - superpowers/brainstorming
+    - superpowers/receiving-code-review
+pipeline_skills:
+  code_review:
+    review:
+      - pstack/unslop

--- a/agents/personas/skills-personas.md
+++ b/agents/personas/skills-personas.md
@@ -1,0 +1,22 @@
+## Role
+
+Implement **PR4**: loadouts for all bundled personas (pr-analyzer, explorer, tech-scout, product-scout).
+
+## Scope
+
+- `agent_fleet/personas/*.loadout.yaml` (package bundled personas)
+- `tests/test_loadouts.py` — parametrize all loadouts resolve
+- `docs/PERSONAS.md`
+
+## Branch
+
+**`feature/skills-personas`**
+
+## Plan
+
+PR4 section in buildout plan doc.
+
+## Done when
+
+- Every bundled persona has a loadout; all skill ids resolve under base-kit
+- Tests + docs updated

--- a/agents/personas/skills-pr-loop.loadout.yaml
+++ b/agents/personas/skills-pr-loop.loadout.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+stub: skills-pr-loop.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-never-block-on-the-human
+    - cursor-team-kit/verify-this
+    - cursor-team-kit/fix-ci
+    - cursor-team-kit/loop-on-ci
+    - cursor-team-kit/get-pr-comments
+    - pstack/how
+    - pstack/why
+    - superpowers/systematic-debugging
+    - superpowers/subagent-driven-development
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/skills-pr-loop.md
+++ b/agents/personas/skills-pr-loop.md
@@ -1,0 +1,23 @@
+## Role
+
+Implement **PR3**: wire `resolve_dispatch_equip()` + composed persona body into PR loop fix agents and code_review auto-fix.
+
+## Scope
+
+- `agent_fleet/pr_loop/lifecycle.py` — `address_review_findings`, `attempt_ci_fix`
+- `agent_fleet/code_review/fix.py`
+- `tests/test_pr_loop_equip.py`, `tests/test_code_review_fix_equip.py`
+
+## Branch
+
+**`feature/skills-pr-loop`**
+
+## Plan
+
+PR3 section in `docs/superpowers/plans/2026-05-25-skills-integration-buildout.md`.
+
+## Done when
+
+- Fix-agent prompts include equip compose body (skills visible in prompt)
+- Tests prove fix-ci / skill markers present
+- `pytest -q` green on branch

--- a/agents/personas/skills-prompt-builder.loadout.yaml
+++ b/agents/personas/skills-prompt-builder.loadout.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+stub: skills-prompt-builder.md
+skills:
+  execute:
+    - pstack/tdd
+    - pstack/principle-prove-it-works
+    - pstack/principle-fix-root-causes
+    - pstack/principle-boundary-discipline
+    - pstack/principle-minimize-reader-load
+    - pstack/principle-never-block-on-the-human
+    - pstack/principle-guard-the-context-window
+    - cursor-team-kit/verify-this
+    - pstack/how
+    - pstack/architect
+    - superpowers/subagent-driven-development
+    - superpowers/executing-plans
+    - superpowers/verification-before-completion
+pipeline_skills:
+  code_review:
+    review: []

--- a/agents/personas/skills-prompt-builder.md
+++ b/agents/personas/skills-prompt-builder.md
@@ -1,0 +1,21 @@
+## Role
+
+Implement **PR2**: shared `build_agent_prompt()` and refactor execute prompt assembly.
+
+## Scope
+
+- Create `agent_fleet/prompts/agent.py`, `tests/test_prompts_agent.py`
+- Refactor `agent_fleet/phases.py` `_build_execute_prompt` to use it (behavior-preserving)
+
+## Branch
+
+**`feature/skills-prompt-builder`** — branch from merged PR1 or rebase onto `feature/skills-foundation` if PR1 not merged yet.
+
+## Plan
+
+`docs/superpowers/plans/2026-05-25-skills-integration-buildout.md` — PR2 section.
+
+## Done when
+
+- Tests pass; no behavior change to equip compose order
+- Committed on `feature/skills-prompt-builder`

--- a/docs/PERSONAS.md
+++ b/docs/PERSONAS.md
@@ -13,6 +13,21 @@ Both merge at dispatch time. Repo settings override global defaults where noted 
 
 For persona loadouts, overlays, and local level-up journaling, see **[PERSONA-EVOLUTION.md](PERSONA-EVOLUTION.md)**.
 
+## Bundled persona loadouts
+
+Every first-class bundled persona ships with a `*.loadout.yaml` in `agent_fleet/personas/`. Loadouts reference base-kit skill ids; markdown stubs stay thin role/methodology text.
+
+| Persona | Execute skills | Review / notes |
+|---------|----------------|----------------|
+| `coder` | TDD, prove-it-works, boundary discipline, git worktrees, … | — |
+| `reviewer` | interrogate, reflect | `pstack/unslop`, `cursor-team-kit/deslop` on review phase |
+| `pr-analyzer` | `pstack/interrogate`, `pstack/how` | quality pass in `pr_review/prompts.py` (thermo-nuclear) |
+| `explorer` | `pstack/how`, `pstack/why` | read-only; mode `plan` |
+| `tech-scout` | `pstack/how`, `pstack/figure-it-out` | read-only scout pipeline |
+| `product-scout` | `pstack/how`, `pstack/reflect` | read-only scout pipeline |
+
+At dispatch, orchestration composes: loadout skills + stub markdown + fleet/repo overlays. See `agent_fleet/personas/*.loadout.yaml`.
+
 ## Execution backends
 
 Agent Fleet runs the same personas and pipelines through a pluggable execution backend. Set `default_backend` in `fleet.yaml`:

--- a/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
+++ b/docs/superpowers/plans/2026-05-25-skills-integration-buildout.md
@@ -235,8 +235,8 @@ Optional: `planner` persona if full pipeline uses one — add `pstack/architect`
 
 ### Tasks
 
-- [ ] Add loadout yamls + stub references
-- [ ] Test every skill id resolves under base-kit
+- [x] Add loadout yamls + stub references
+- [x] Test every skill id resolves under base-kit
 - [ ] Open PR4
 
 ---
@@ -311,6 +311,6 @@ Estimated: **PR1 ~2h, PR2 ~1h, PR3 ~3h, PR4 ~1.5h, PR5 ~2h** (agent time, parall
 - [ ] PR loop fix prompts include composed skill text (grep test for skill headings)
 - [ ] Coder loadout has no superpowers/pstack duplication
 - [ ] Reviewer review phase runs unslop + deslop
-- [ ] All bundled personas have loadouts; all ids resolve
+- [x] All bundled personas have loadouts; all ids resolve
 - [ ] thermo-nuclear single canonical path
 - [ ] `pytest -q` green on main after full stack merges

--- a/tests/test_loadouts.py
+++ b/tests/test_loadouts.py
@@ -4,15 +4,40 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from agent_fleet.personas import load_loadout
 from agent_fleet.skills_lib import (
     base_kit_skill_dirs,
     compose_persona_body,
     load_skill_text,
+    loadout_execute_skill_ids,
+    loadout_review_skill_ids,
     resolve_skill_path,
 )
 
 ROOT = Path(__file__).resolve().parent.parent
+PERSONAS_DIR = ROOT / "agent_fleet" / "personas"
+
+
+def bundled_loadout_names() -> list[str]:
+    return sorted(path.stem.replace(".loadout", "") for path in PERSONAS_DIR.glob("*.loadout.yaml"))
+
+
+@pytest.mark.parametrize("persona", bundled_loadout_names())
+def test_loadout_skill_ids_resolve_in_base_kit(persona: str) -> None:
+    loadout = load_loadout(persona)
+    assert loadout is not None
+    dirs = base_kit_skill_dirs()
+    skill_ids = [
+        *loadout_execute_skill_ids(loadout),
+        *loadout_review_skill_ids(loadout),
+    ]
+    assert skill_ids, persona
+    for skill_id in skill_ids:
+        path = resolve_skill_path(skill_id, dirs)
+        assert path is not None, f"{persona}: {skill_id}"
+        assert path.name == "SKILL.md"
 
 
 def test_unslop_loads_from_base_kit() -> None:
@@ -35,7 +60,7 @@ def test_reviewer_loadout_lists_unslop_for_review() -> None:
 def test_compose_persona_body_includes_sections() -> None:
     loadout = load_loadout("coder")
     assert loadout is not None
-    stub = (ROOT / "agent_fleet" / "personas" / "coder.md").read_text(encoding="utf-8")
+    stub = (PERSONAS_DIR / "coder.md").read_text(encoding="utf-8")
     body = compose_persona_body(
         loadout,
         fleet_overlay="- Prefer ruff before finishing.",


### PR DESCRIPTION
## Summary
Stacks on `feature/skills-pr-loop`. Sibling of `feature/skills-canonical`.

Three commits on top of pr-loop:
- `2770084` Integrate PR4 scout and analyzer loadouts.
- `6c91ca6` Add fleet dispatch personas; mark PR4 complete.
- `b8e349d` Docs: mark fleet-skills-stack integration complete.

## Status
**Draft.** Part of the stacked skills buildout.

## Test plan
- [ ] `pytest tests/test_pr_loop_equip.py tests/test_prompts_agent.py`
- [ ] `agent-fleet personas` lists the new fleet dispatch personas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)