### PR TITLE
refactor: adopt fleet_paths helpers across config + level_up + pr_review

### DIFF
--- a/agent_fleet/config.py
+++ b/agent_fleet/config.py
@@ -12,24 +12,22 @@ import yaml
 
 from agent_fleet.agent_mode import coerce_agent_mode
 from agent_fleet.contracts.mcp import McpServerSpec, parse_mcp_server_spec
+from agent_fleet.fleet_paths import default_fleet_config_path, default_runs_dir
 from agent_fleet.skills_lib import bundled_skill_dirs, merge_skill_dirs
 
 if TYPE_CHECKING:
     from agent_fleet.agent_mode import AgentMode
     from agent_fleet.repo import RepoConfig
 
-_DEFAULT_CONFIG_PATH = Path.home() / ".hermes" / "coding_fleet" / "fleet.yaml"
 _PACKAGE_PERSONAS = Path(__file__).resolve().parent / "personas"
-_NEW_DEFAULT_RUNS_DIR = Path.home() / ".agent-fleet" / "fleet" / "runs"
-# Keep writing to ~/.hermes/fleet/runs when that directory already exists.
-_LEGACY_RUNS_DIR = Path.home() / ".hermes" / "fleet" / "runs"
 
-
-def default_runs_dir() -> Path:
-    """Default JSONL run log directory for fleet dispatches."""
-    if _LEGACY_RUNS_DIR.exists():
-        return _LEGACY_RUNS_DIR
-    return _NEW_DEFAULT_RUNS_DIR
+__all__ = [
+    "FleetConfig",
+    "PersonaSpec",
+    "default_fleet_config_path",
+    "default_runs_dir",
+    "load_fleet_config",
+]
 
 
 _DEFAULT_PIPELINES: dict[str, list[str]] = {
@@ -152,7 +150,7 @@ def load_fleet_config(
     default_persona: str | None = None,
     default_workspace: str | None = None,
 ) -> FleetConfig:
-    config_path = _expand_path(str(path)) if path else _DEFAULT_CONFIG_PATH
+    config_path = _expand_path(str(path)) if path else default_fleet_config_path()
     data: dict[str, Any] = {}
     if config_path.exists():
         loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}

--- a/agent_fleet/fleet_paths.py
+++ b/agent_fleet/fleet_paths.py
@@ -46,15 +46,15 @@ def default_runs_dir() -> Path:
     raw = os.environ.get("AGENT_FLEET_RUNS_DIR")
     if raw:
         return Path(raw).expanduser().resolve()
-    preferred = agent_fleet_home() / "runs"
-    if preferred.is_dir() or not _LEGACY_HERMES_RUNS.is_dir():
-        return preferred
-    logger.warning(
-        "Using deprecated runs dir %s — run `agent-fleet migrate-home` to move logs to %s",
-        _LEGACY_HERMES_RUNS,
-        preferred,
-    )
-    return _LEGACY_HERMES_RUNS
+    preferred = agent_fleet_home() / "fleet" / "runs"
+    if _LEGACY_HERMES_RUNS.is_dir():
+        logger.warning(
+            "Using deprecated runs dir %s — run `agent-fleet migrate-home` to move logs to %s",
+            _LEGACY_HERMES_RUNS,
+            preferred,
+        )
+        return _LEGACY_HERMES_RUNS
+    return preferred
 
 
 def user_skill_dir() -> Path:
@@ -65,7 +65,7 @@ def user_skill_dir() -> Path:
 def ensure_agent_fleet_home() -> Path:
     """Create ~/.agent-fleet layout if missing."""
     home = agent_fleet_home()
-    for sub in ("runs", "level_up", "journal", "skills", "pr-review", "scripts"):
+    for sub in ("fleet/runs", "level_up", "journal", "skills", "pr-review-logs", "scripts"):
         (home / sub).mkdir(parents=True, exist_ok=True)
     return home
 
@@ -83,7 +83,7 @@ def migrate_from_hermes(*, dry_run: bool = False) -> dict[str, str]:
             shutil.copy2(_LEGACY_HERMES_CONFIG, target_config)
             actions["fleet.yaml"] = f"copied to {target_config}"
 
-    target_runs = home / "runs"
+    target_runs = home / "fleet" / "runs"
     if _LEGACY_HERMES_RUNS.is_dir():
         target_runs.mkdir(parents=True, exist_ok=True)
         copied = 0

--- a/agent_fleet/level_up/paths.py
+++ b/agent_fleet/level_up/paths.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-LEVEL_UP_ROOT = Path.home() / ".agent-fleet" / "level_up"
-JOURNAL_INDEX_PATH = Path.home() / ".agent-fleet" / "journal" / "index.jsonl"
+from agent_fleet.fleet_paths import agent_fleet_home
+
+LEVEL_UP_ROOT = agent_fleet_home() / "level_up"
+JOURNAL_INDEX_PATH = agent_fleet_home() / "journal" / "index.jsonl"
 FLEET_TIER = "_fleet"
 
 COMPACTION_IDLE_DAYS = 7

--- a/agent_fleet/pr_review/analyzer.py
+++ b/agent_fleet/pr_review/analyzer.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import json
 import re
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agent_fleet.fleet_paths import agent_fleet_home
 from agent_fleet.pr_review.git import classify_files, is_deletion_only_pr
 from agent_fleet.pr_review.prompts import build_prompt
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from agent_fleet.hooks import LLMBackend
     from agent_fleet.pr_review.config import PrReviewConfig
 
@@ -46,7 +48,7 @@ def _log_analysis(
     parsed: dict[str, Any] | None,
     error: str | None = None,
 ) -> None:
-    log_dir = config.log_dir or Path.home() / ".agent-fleet" / "pr-review-logs"
+    log_dir = config.log_dir or agent_fleet_home() / "pr-review-logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
     payload = {


### PR DESCRIPTION
## Summary

Follow-up to #17. Three call sites now go through `agent_fleet.fleet_paths` instead of constructing `Path.home() / \".agent-fleet\"` inline:

- **`agent_fleet/config.py`** — `_DEFAULT_CONFIG_PATH` and the local `default_runs_dir()` are replaced by re-exports from `fleet_paths`. Hermes legacy fallback is preserved (it's inside the helper).
- **`agent_fleet/level_up/paths.py`** — `LEVEL_UP_ROOT` and `JOURNAL_INDEX_PATH` now derive from `agent_fleet_home()`, so `AGENT_FLEET_HOME` env override actually applies here.
- **`agent_fleet/pr_review/analyzer.py:49`** — `log_dir` fallback uses `agent_fleet_home()`.

Also fixes a latent inconsistency in #17: `fleet_paths.default_runs_dir()` returned `~/.agent-fleet/runs`, but the real on-disk layout (per `config.default_runs_dir()` and the README) is `~/.agent-fleet/fleet/runs`. The helper now matches reality.

Not refactored (intentionally):

- `agent_fleet/config.py:173` — `Path.home() / \".hermes\" / \"skills\"` is a *Hermes* skills fallback, not an agent-fleet path.
- The dozens of references to repo-local `.agent-fleet.yaml` filenames — those are repo config, not user-home paths.

## Test plan

- [x] `uv run ruff check agent_fleet tests integrations` — clean
- [x] `uv run pytest` — 294 passed, 3 skipped (unchanged from main)
- [x] `uv run pyright` on the four touched files — 0 errors
- [ ] CI green

## Follow-up

- `agent-fleet migrate-home` CLI subcommand (last item from the PR #17 plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)