### PR TITLE
feat(cli): agent-fleet migrate-home subcommand

### DIFF
--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -202,6 +202,19 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_migrate_home(args: argparse.Namespace) -> int:
+    from agent_fleet.fleet_paths import agent_fleet_home, migrate_from_hermes
+
+    actions = migrate_from_hermes(dry_run=bool(args.dry_run))
+    if not actions:
+        print(f"nothing to migrate; ~/.agent-fleet already at {agent_fleet_home()}")
+        return 0
+    label = "[dry-run] " if args.dry_run else ""
+    for key, value in actions.items():
+        print(f"{label}{key}: {value}")
+    return 0
+
+
 def _resolve_repo_from_path(repo_path: Path) -> RepoConfig:
     from agent_fleet.repo import find_repo_config, load_repo_config
 
@@ -524,6 +537,17 @@ def main(argv: list[str] | None = None) -> int:
     init_p.add_argument("path", nargs="?", help="Repo path")
     init_p.add_argument("--force", action="store_true")
     init_p.set_defaults(func=cmd_init)
+
+    migrate_home_p = sub.add_parser(
+        "migrate-home",
+        help="Copy legacy ~/.hermes/coding_fleet config + run logs into ~/.agent-fleet/",
+    )
+    migrate_home_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be copied without modifying the filesystem",
+    )
+    migrate_home_p.set_defaults(func=cmd_migrate_home)
 
     level_up_p = sub.add_parser("level-up", help="Persona level-up status and journal")
     level_up_sub = level_up_p.add_subparsers(dest="level_up_command", required=True)

--- a/tests/test_migrate_home_cli.py
+++ b/tests/test_migrate_home_cli.py
@@ -45,9 +45,7 @@ def test_migrate_home_no_legacy_reports_noop(
     monkeypatch.setenv("AGENT_FLEET_HOME", str(af_home))
     import agent_fleet.fleet_paths as fleet_paths
 
-    monkeypatch.setattr(
-        fleet_paths, "_LEGACY_HERMES_CONFIG", tmp_path / "missing" / "fleet.yaml"
-    )
+    monkeypatch.setattr(fleet_paths, "_LEGACY_HERMES_CONFIG", tmp_path / "missing" / "fleet.yaml")
     monkeypatch.setattr(fleet_paths, "_LEGACY_HERMES_RUNS", tmp_path / "missing" / "runs")
 
     rc = main(["migrate-home"])

--- a/tests/test_migrate_home_cli.py
+++ b/tests/test_migrate_home_cli.py
@@ -1,0 +1,57 @@
+"""Tests for the agent-fleet migrate-home CLI subcommand."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agent_fleet.cli import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_migrate_home_dry_run_lists_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    hermes = tmp_path / ".hermes" / "coding_fleet"
+    hermes.mkdir(parents=True)
+    (hermes / "fleet.yaml").write_text("max_parallel: 2\n", encoding="utf-8")
+    af_home = tmp_path / ".agent-fleet"
+    monkeypatch.setenv("AGENT_FLEET_HOME", str(af_home))
+    import agent_fleet.fleet_paths as fleet_paths
+
+    monkeypatch.setattr(fleet_paths, "_LEGACY_HERMES_CONFIG", hermes / "fleet.yaml")
+    monkeypatch.setattr(fleet_paths, "_LEGACY_HERMES_RUNS", tmp_path / ".hermes" / "fleet" / "runs")
+
+    rc = main(["migrate-home", "--dry-run"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[dry-run]" in out
+    assert "fleet.yaml" in out
+    assert not (af_home / "fleet.yaml").exists()
+
+
+def test_migrate_home_no_legacy_reports_noop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    af_home = tmp_path / ".agent-fleet"
+    monkeypatch.setenv("AGENT_FLEET_HOME", str(af_home))
+    import agent_fleet.fleet_paths as fleet_paths
+
+    monkeypatch.setattr(
+        fleet_paths, "_LEGACY_HERMES_CONFIG", tmp_path / "missing" / "fleet.yaml"
+    )
+    monkeypatch.setattr(fleet_paths, "_LEGACY_HERMES_RUNS", tmp_path / "missing" / "runs")
+
+    rc = main(["migrate-home"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "nothing to migrate" in out


### PR DESCRIPTION
## Summary

Adds `agent-fleet migrate-home [--dry-run]` — the user-facing entry point for `fleet_paths.migrate_from_hermes()` introduced in #17.

Closes out the follow-up list from PR #17 / #18.

```
$ agent-fleet migrate-home --help
usage: agent-fleet migrate-home [-h] [--dry-run]

options:
  -h, --help  show this help message and exit
  --dry-run   Print what would be copied without modifying the filesystem
```

## Test plan

- [x] `uv run pytest tests/test_migrate_home_cli.py` — 2/2 pass (dry-run + no-op paths)
- [x] `uv run pytest` — 296 passed, 3 skipped (+2 vs main)
- [x] `uv run ruff check` clean
- [x] `uv run pyright agent_fleet/cli.py tests/test_migrate_home_cli.py` — 0 errors
- [x] `uv run agent-fleet migrate-home --help` resolves
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)