### PR TITLE
feat(bridge): shared supervised cursor-sdk-bridge for concurrent runs

### DIFF
--- a/agent_fleet/bridge_daemon.py
+++ b/agent_fleet/bridge_daemon.py
@@ -1,0 +1,425 @@
+"""Shared cursor-sdk-bridge daemon for concurrent agent-fleet runs.
+
+The cursor-sdk Python client, by default, spawns a private bridge subprocess
+the first time it needs one. That makes it impossible to run several
+`agent-fleet run` processes side-by-side: each tries to spin up its own
+bridge and they race on shared resources.
+
+cursor-sdk already supports connecting to an externally-managed bridge via
+the env vars `CURSOR_SDK_BRIDGE_URL` and `CURSOR_SDK_BRIDGE_TOKEN`. This
+module launches one long-lived bridge (optionally under a supervisor that
+respawns it on crash), persists its discovery info to
+`~/.agent-fleet/bridge.json`, and exposes helpers so the cursor backend
+can transparently attach to it.
+
+Run as a module to enter supervisor mode:
+    python -m agent_fleet.bridge_daemon --supervisor --workspace ~/.agent-fleet
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import errno
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from agent_fleet.fleet_paths import agent_fleet_home, ensure_agent_fleet_home
+
+logger = logging.getLogger(__name__)
+
+_READY_PREFIX = "cursor-sdk-bridge ready "
+_DEFAULT_TIMEOUT_S = 30.0
+_SUPERVISOR_BACKOFF_MAX_S = 30.0
+
+
+def bridge_state_path() -> Path:
+    return agent_fleet_home() / "bridge.json"
+
+
+def bridge_log_path() -> Path:
+    return agent_fleet_home() / "bridge.log"
+
+
+def supervisor_pid_path() -> Path:
+    return agent_fleet_home() / "bridge-supervisor.pid"
+
+
+def supervisor_log_path() -> Path:
+    return agent_fleet_home() / "bridge-supervisor.log"
+
+
+def _resolve_bridge_binary() -> str:
+    from cursor_sdk._vendor import resolve_bridge_path
+
+    return str(resolve_bridge_path())
+
+
+def load_bridge_state() -> dict[str, Any] | None:
+    path = bridge_state_path()
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError, json.JSONDecodeError:
+        return None
+
+
+def _load_supervisor_pid() -> int | None:
+    path = supervisor_pid_path()
+    if not path.is_file():
+        return None
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except OSError, ValueError:
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        return exc.errno != errno.ESRCH
+    return True
+
+
+def _read_discovery_from_log(log_path: Path, deadline: float) -> dict[str, Any]:
+    """Tail the bridge stderr log until the ready discovery line appears."""
+    while time.monotonic() < deadline:
+        if log_path.is_file():
+            with log_path.open("r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    if line.startswith(_READY_PREFIX):
+                        payload = line[len(_READY_PREFIX) :].strip()
+                        return json.loads(payload)
+        time.sleep(0.1)
+    raise TimeoutError(f"Bridge did not emit discovery within deadline ({log_path})")
+
+
+def _discovery_to_state(discovery: dict[str, Any], pid: int) -> dict[str, Any]:
+    url = discovery.get("url")
+    if not url:
+        host = discovery.get("host", "")
+        port = discovery.get("port")
+        if host and port is not None:
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+            url = f"http://{host}:{port}"
+    auth_token = (discovery.get("authToken") or "").strip()
+    if not auth_token:
+        token_file = discovery.get("authTokenFile")
+        if token_file:
+            try:
+                auth_token = Path(str(token_file)).read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                raise ValueError(f"Could not read authTokenFile {token_file}: {exc}") from exc
+    if not url or not auth_token:
+        raise ValueError("Bridge discovery missing url or authToken")
+    return {
+        "url": url,
+        "auth_token": auth_token,
+        "pid": pid,
+        "workspace_ref": discovery.get("workspaceRef", ""),
+        "server_version": discovery.get("serverVersion", ""),
+        "schema_version": discovery.get("schemaVersion", 1),
+        "started_at": time.time(),
+    }
+
+
+def _spawn_bridge_subprocess(workspace: str, log_path: Path) -> subprocess.Popen:
+    # cursor-sdk-bridge has a documented opt-in env var that installs
+    # process-level uncaughtException/unhandledRejection survivors. Without
+    # it, an EPIPE on a peer-disconnect socket bubbles up as an unhandled
+    # stream 'error' event and kills the node process, which is fatal when
+    # multiple concurrent agent-fleet runs share one bridge.
+    env = {**os.environ, "CURSOR_SDK_BRIDGE_SURVIVE_UNCAUGHT": "1"}
+    log_fh = log_path.open("ab", buffering=0)
+    try:
+        return subprocess.Popen(
+            [_resolve_bridge_binary(), "--workspace", workspace],
+            stdout=subprocess.DEVNULL,
+            stderr=log_fh,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+            env=env,
+        )
+    finally:
+        log_fh.close()
+
+
+def _publish_bridge_state(discovery: dict[str, Any], pid: int) -> dict[str, Any]:
+    state = _discovery_to_state(discovery, pid)
+    bridge_state_path().write_text(json.dumps(state, indent=2), encoding="utf-8")
+    return state
+
+
+def _rotate_bridge_log(log_path: Path) -> None:
+    """Preserve a crashed bridge's stderr for post-mortem diagnosis."""
+    if not log_path.is_file() or log_path.stat().st_size == 0:
+        log_path.unlink(missing_ok=True)
+        return
+    ts = time.strftime("%Y%m%dT%H%M%S")
+    rotated = log_path.with_name(f"{log_path.name}.crashed-{ts}")
+    with contextlib.suppress(OSError):
+        log_path.rename(rotated)
+    log_path.unlink(missing_ok=True)
+
+
+def _launch_one_bridge(workspace: str, timeout_s: float) -> tuple[subprocess.Popen, dict[str, Any]]:
+    log_path = bridge_log_path()
+    _rotate_bridge_log(log_path)
+    proc = _spawn_bridge_subprocess(workspace, log_path)
+    deadline = time.monotonic() + timeout_s
+    try:
+        discovery = _read_discovery_from_log(log_path, deadline)
+    except Exception:
+        with contextlib.suppress(Exception):
+            proc.terminate()
+        raise
+    state = _publish_bridge_state(discovery, proc.pid)
+    return proc, state
+
+
+def _supervisor_loop(workspace: str, timeout_s: float) -> int:
+    """Long-running loop: respawn the bridge whenever it exits."""
+    pid_path = supervisor_pid_path()
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    child: dict[str, subprocess.Popen | None] = {"proc": None}
+    stopping = {"flag": False}
+
+    def _on_signal(_signum: int, _frame: object) -> None:
+        stopping["flag"] = True
+        proc = child["proc"]
+        if proc is not None and proc.poll() is None:
+            with contextlib.suppress(Exception):
+                proc.terminate()
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    backoff = 1.0
+    try:
+        while not stopping["flag"]:
+            try:
+                proc, _ = _launch_one_bridge(workspace, timeout_s)
+                child["proc"] = proc
+                backoff = 1.0
+                exit_code = proc.wait()
+                logger.warning("bridge exited (status=%s); will respawn", exit_code)
+            except Exception as exc:
+                logger.exception("bridge launch failed: %s", exc)
+            finally:
+                child["proc"] = None
+                bridge_state_path().unlink(missing_ok=True)
+            if stopping["flag"]:
+                break
+            time.sleep(backoff)
+            backoff = min(backoff * 2.0, _SUPERVISOR_BACKOFF_MAX_S)
+    finally:
+        pid_path.unlink(missing_ok=True)
+        bridge_state_path().unlink(missing_ok=True)
+    return 0
+
+
+def start_bridge(
+    *,
+    workspace: Path | str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    supervise: bool = True,
+) -> dict[str, Any]:
+    """Start a detached bridge daemon and persist its discovery info.
+
+    If a healthy daemon is already recorded in `~/.agent-fleet/bridge.json`,
+    return its state unchanged (idempotent). When `supervise=True` (default)
+    the bridge runs under a parent supervisor that respawns it on crash.
+    """
+    ensure_agent_fleet_home()
+    existing = load_bridge_state()
+    if existing and _pid_alive(int(existing.get("pid", 0))):
+        return existing
+
+    workspace_arg = str(workspace) if workspace else str(agent_fleet_home())
+
+    if not supervise:
+        _, state = _launch_one_bridge(workspace_arg, timeout_s)
+        return state
+
+    # Tear down any stale supervisor before launching a new one.
+    _terminate_supervisor()
+
+    supervisor_log = supervisor_log_path().open("ab", buffering=0)
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "agent_fleet.bridge_daemon",
+                "--supervisor",
+                "--workspace",
+                workspace_arg,
+                "--timeout",
+                str(timeout_s),
+            ],
+            stdout=supervisor_log,
+            stderr=supervisor_log,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    finally:
+        supervisor_log.close()
+
+    deadline = time.monotonic() + timeout_s + 5.0
+    while time.monotonic() < deadline:
+        state = load_bridge_state()
+        if state and _pid_alive(int(state.get("pid", 0))):
+            return state
+        time.sleep(0.2)
+    raise TimeoutError("Supervisor did not publish bridge state in time")
+
+
+def _terminate_supervisor() -> bool:
+    pid = _load_supervisor_pid()
+    if pid is None or not _pid_alive(pid):
+        supervisor_pid_path().unlink(missing_ok=True)
+        return False
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _pid_alive(pid):
+        time.sleep(0.1)
+    if _pid_alive(pid):
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+    supervisor_pid_path().unlink(missing_ok=True)
+    return True
+
+
+def stop_bridge() -> dict[str, Any]:
+    """Terminate the supervisor (if any) and the bridge, remove state."""
+    result: dict[str, Any] = {"stopped": False}
+    supervisor_pid = _load_supervisor_pid()
+    if supervisor_pid is not None:
+        result["supervisor_pid"] = supervisor_pid
+        if _terminate_supervisor():
+            result["supervisor_stopped"] = True
+
+    state = load_bridge_state()
+    if state is None:
+        result.setdefault("reason", "no bridge.json found")
+        result["stopped"] = bool(result.get("supervisor_stopped"))
+        return result
+    pid = int(state.get("pid", 0) or 0)
+    result["pid"] = pid
+    if pid > 0 and _pid_alive(pid):
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGTERM)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and _pid_alive(pid):
+            time.sleep(0.1)
+        if _pid_alive(pid):
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
+    bridge_state_path().unlink(missing_ok=True)
+    result["stopped"] = True
+    return result
+
+
+def status_bridge() -> dict[str, Any]:
+    state = load_bridge_state()
+    supervisor_pid = _load_supervisor_pid()
+    supervised = supervisor_pid is not None and _pid_alive(supervisor_pid)
+    if state is None:
+        return {
+            "running": False,
+            "supervised": supervised,
+            "supervisor_pid": supervisor_pid,
+            "reason": "no bridge.json",
+        }
+    pid = int(state.get("pid", 0) or 0)
+    alive = _pid_alive(pid)
+    return {
+        "running": alive,
+        "supervised": supervised,
+        "supervisor_pid": supervisor_pid,
+        "pid": pid,
+        "url": state.get("url"),
+        "workspace_ref": state.get("workspace_ref"),
+        "server_version": state.get("server_version"),
+        "started_at": state.get("started_at"),
+    }
+
+
+def apply_bridge_env(*, force: bool = False, wait_s: float = 0.0) -> bool:
+    """If a healthy bridge daemon is recorded, export its endpoint to env.
+
+    Returns True when env was populated (caller can rely on shared bridge),
+    False otherwise. When ``force`` is False, existing env vars take
+    precedence; pass ``force=True`` on reconnect after a supervisor respawn
+    so the new (different) URL/token replace the stale ones. ``wait_s``
+    polls for bridge.json to (re)appear, which happens after a respawn.
+    """
+    if (
+        not force
+        and os.environ.get("CURSOR_SDK_BRIDGE_URL")
+        and (
+            os.environ.get("CURSOR_SDK_BRIDGE_TOKEN")
+            or os.environ.get("CURSOR_SDK_BRIDGE_AUTH_TOKEN")
+        )
+    ):
+        return True
+    deadline = time.monotonic() + max(0.0, wait_s)
+    state = load_bridge_state()
+    while state is None and time.monotonic() < deadline:
+        time.sleep(0.2)
+        state = load_bridge_state()
+    if state is None:
+        return False
+    pid = int(state.get("pid", 0) or 0)
+    if not _pid_alive(pid):
+        return False
+    url = str(state.get("url", "")).strip()
+    token = str(state.get("auth_token", "")).strip()
+    if not url or not token:
+        return False
+    os.environ["CURSOR_SDK_BRIDGE_URL"] = url
+    os.environ["CURSOR_SDK_BRIDGE_TOKEN"] = token
+    os.environ["CURSOR_SDK_BRIDGE_AUTH_TOKEN"] = token
+    return True
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="agent_fleet.bridge_daemon")
+    parser.add_argument("--supervisor", action="store_true", help="Run the supervisor loop")
+    parser.add_argument("--workspace", default=None)
+    parser.add_argument("--timeout", type=float, default=_DEFAULT_TIMEOUT_S)
+    args = parser.parse_args(argv)
+    if not args.supervisor:
+        parser.print_help()
+        return 2
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s bridge-supervisor %(message)s",
+    )
+    workspace = args.workspace or str(agent_fleet_home())
+    ensure_agent_fleet_home()
+    return _supervisor_loop(workspace, args.timeout)
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -215,6 +215,42 @@ def cmd_migrate_home(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_bridge(args: argparse.Namespace) -> int:
+    from agent_fleet.bridge_daemon import (
+        start_bridge,
+        status_bridge,
+        stop_bridge,
+    )
+
+    action = args.bridge_action
+    if action == "start":
+        try:
+            state = start_bridge(workspace=args.workspace, timeout_s=args.timeout)
+        except Exception as exc:
+            print(f"bridge start failed: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(_redact_state(state), indent=2))
+        return 0
+    if action == "stop":
+        result = stop_bridge()
+        print(json.dumps(result, indent=2))
+        return 0 if result.get("stopped") or result.get("reason") else 1
+    if action == "status":
+        result = status_bridge()
+        print(json.dumps(result, indent=2))
+        return 0 if result.get("running") else 1
+    print(f"unknown bridge action: {action}", file=sys.stderr)
+    return 2
+
+
+def _redact_state(state: dict) -> dict:
+    redacted = dict(state)
+    token = redacted.get("auth_token")
+    if isinstance(token, str) and token:
+        redacted["auth_token"] = f"<{len(token)} chars>"
+    return redacted
+
+
 def _resolve_repo_from_path(repo_path: Path) -> RepoConfig:
     from agent_fleet.repo import find_repo_config, load_repo_config
 
@@ -548,6 +584,31 @@ def main(argv: list[str] | None = None) -> int:
         help="Print what would be copied without modifying the filesystem",
     )
     migrate_home_p.set_defaults(func=cmd_migrate_home)
+
+    bridge_p = sub.add_parser(
+        "bridge",
+        help="Manage a shared cursor-sdk bridge daemon (enables concurrent agent-fleet runs)",
+    )
+    bridge_sub = bridge_p.add_subparsers(dest="bridge_action", required=True)
+    bridge_start_p = bridge_sub.add_parser(
+        "start", help="Start a shared bridge daemon (idempotent)"
+    )
+    bridge_start_p.add_argument(
+        "--workspace",
+        default=None,
+        help="Workspace path passed to cursor-sdk-bridge (defaults to ~/.agent-fleet)",
+    )
+    bridge_start_p.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Seconds to wait for the bridge discovery line",
+    )
+    bridge_start_p.set_defaults(func=cmd_bridge)
+    bridge_stop_p = bridge_sub.add_parser("stop", help="Stop the shared bridge daemon")
+    bridge_stop_p.set_defaults(func=cmd_bridge)
+    bridge_status_p = bridge_sub.add_parser("status", help="Show shared bridge daemon status")
+    bridge_status_p.set_defaults(func=cmd_bridge)
 
     level_up_p = sub.add_parser("level-up", help="Persona level-up status and journal")
     level_up_sub = level_up_p.add_subparsers(dest="level_up_command", required=True)

--- a/agent_fleet/cursor_backend.py
+++ b/agent_fleet/cursor_backend.py
@@ -393,6 +393,35 @@ class CursorBackend:
     # bridge and produce "internal: internal error".  Serialize access.
     _prompt_lock = threading.Lock()
 
+    _BRIDGE_RETRY_SIGNALS = (
+        "Connection refused",
+        "ConnectError",
+        "Connection reset",
+        "Bridge request failed",
+    )
+    _BRIDGE_RETRY_MAX = 3
+    _BRIDGE_RETRY_SLEEP_S = 2.0
+
+    @classmethod
+    def _is_bridge_disconnect(cls, exc: BaseException) -> bool:
+        msg = str(exc)
+        return any(sig in msg for sig in cls._BRIDGE_RETRY_SIGNALS)
+
+    @classmethod
+    def _reconnect_bridge(cls) -> None:
+        try:
+            from cursor_sdk._client import close_default_client
+
+            close_default_client()
+        except Exception:
+            logger.debug("close_default_client failed", exc_info=True)
+        try:
+            from agent_fleet.bridge_daemon import apply_bridge_env
+
+            apply_bridge_env(force=True, wait_s=15.0)
+        except Exception:
+            logger.debug("apply_bridge_env failed during reconnect", exc_info=True)
+
     def __init__(
         self,
         *,
@@ -403,6 +432,14 @@ class CursorBackend:
         self.default_model = default_model
         self.default_mode = default_mode
         self.api_key = api_key or os.environ.get("CURSOR_API_KEY", "")
+        # Attach to a shared bridge daemon if one is running so multiple
+        # concurrent agent-fleet processes don't each spawn their own bridge.
+        try:
+            from agent_fleet.bridge_daemon import apply_bridge_env
+
+            apply_bridge_env()
+        except Exception:
+            logger.debug("apply_bridge_env failed; falling back to per-process bridge")
 
     def create_session(
         self,
@@ -490,17 +527,42 @@ class CursorBackend:
         t0 = time.monotonic()
 
         def _execute() -> CursorLLMResult:
-            try:
-                with CursorBackend._prompt_lock:
-                    result = Agent.prompt(
-                        prompt_with_scope,
-                        AgentOptions(
-                            model=selected_model,
-                            mode=selected_mode,
-                            api_key=self.api_key,
-                            local=LocalAgentOptions(cwd=work_dir),
-                        ),
+            attempt = 0
+            while True:
+                try:
+                    with CursorBackend._prompt_lock:
+                        result = Agent.prompt(
+                            prompt_with_scope,
+                            AgentOptions(
+                                model=selected_model,
+                                mode=selected_mode,
+                                api_key=self.api_key,
+                                local=LocalAgentOptions(cwd=work_dir),
+                            ),
+                        )
+                    break
+                except Exception as exc:
+                    if (
+                        CursorBackend._is_bridge_disconnect(exc)
+                        and attempt < CursorBackend._BRIDGE_RETRY_MAX
+                    ):
+                        attempt += 1
+                        logger.warning(
+                            "bridge disconnect (attempt %d/%d): %s",
+                            attempt,
+                            CursorBackend._BRIDGE_RETRY_MAX,
+                            exc,
+                        )
+                        time.sleep(CursorBackend._BRIDGE_RETRY_SLEEP_S * attempt)
+                        CursorBackend._reconnect_bridge()
+                        continue
+                    return CursorLLMResult(
+                        stdout="",
+                        stderr=str(exc),
+                        exit_code=1,
+                        duration_s=time.monotonic() - t0,
                     )
+            try:
                 duration_s = time.monotonic() - t0
                 text = getattr(result, "result", None) or str(result)
                 agent_id = getattr(result, "agent_id", None)

--- a/agent_fleet/verify_core.py
+++ b/agent_fleet/verify_core.py
@@ -99,13 +99,18 @@ def get_changed_files(worktree_path: Path) -> list[str]:
 
 
 def is_git_repo(workspace: Path) -> bool:
-    result = subprocess.run(
-        ["git", "rev-parse", "--is-inside-work-tree"],
-        cwd=workspace,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    if not Path(workspace).is_dir():
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
@@ -161,15 +166,34 @@ def get_working_tree_diff(workspace: Path, *, max_chars: int = 120_000) -> str:
 
 def run_shell_verify(workspace: Path, command: str, *, timeout_s: int = 600) -> dict[str, object]:
     """Run a repo verify command and return a phase-shaped result dict."""
-    result = subprocess.run(
-        command,
-        shell=True,
-        cwd=workspace,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=timeout_s,
-    )
+    if not Path(workspace).is_dir():
+        return {
+            "command": command,
+            "exit_code": 127,
+            "stdout": "",
+            "stderr": f"workspace does not exist: {workspace}",
+            "passed": False,
+            "detail": f"workspace does not exist: {workspace}",
+        }
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except (OSError, FileNotFoundError) as exc:
+        return {
+            "command": command,
+            "exit_code": 127,
+            "stdout": "",
+            "stderr": f"subprocess.run failed: {exc}",
+            "passed": False,
+            "detail": str(exc),
+        }
     combined = (result.stdout or "") + (result.stderr or "")
     return {
         "command": command,


### PR DESCRIPTION
## Summary

- Adds a long-lived **shared cursor-sdk-bridge daemon** under a Python supervisor so multiple `agent-fleet run` processes attach to one bridge via `CURSOR_SDK_BRIDGE_URL` / `CURSOR_SDK_BRIDGE_TOKEN` instead of each spawning its own.
- Hardens against the upstream EPIPE-on-peer-disconnect crash: passes `CURSOR_SDK_BRIDGE_SURVIVE_UNCAUGHT=1` to engage the bridge's built-in process-level error survivors, supervisor respawns with exponential backoff, and `CursorBackend` retries `Agent.prompt` up to 3× on `ConnectError` while force-reloading `bridge.json` so a new respawn URL replaces the stale one.
- Hardens `verify_core` against the worktree teardown race: `is_git_repo` and `run_shell_verify` return a failed phase result instead of crashing the pipeline with `FileNotFoundError` when the workspace has vanished.

## New surface

- `agent_fleet.bridge_daemon` module (supervisor + spawn + discovery).
- `agent-fleet bridge {start,stop,status}` CLI subcommand.
- Crashed bridge stderr is rotated to `~/.agent-fleet/bridge.log.crashed-<ts>` for post-mortem rather than overwritten.

## Why

Without this, concurrent `agent-fleet run` invocations against a single repo would all race their private bridge subprocesses on shared workspace state, and one EPIPE on a disconnecting client socket would kill the bridge mid-run, taking the others down with it. The fix lets us run 3+ concurrent code_review pipelines reliably.

## Test plan

- [x] `uv run ruff format` + `uv run ruff check` clean on touched files
- [x] `uv run python -c "import agent_fleet.bridge_daemon, agent_fleet.cursor_backend"` succeeds
- [x] `agent-fleet bridge start/status/stop` round-trips and shows `supervised: true`
- [x] Manually killing the bridge node process triggers supervisor respawn with a new URL
- [x] End-to-end: 3 concurrent silphco code_review runs (data #1702, backend #1736, frontend #1769) against the supervised bridge — all completed without bridge crashes
- [x] Crashed-bridge stderr rotation captured an EPIPE traceback that surfaced the root cause and the survive-uncaught env var
- [ ] Reviewer to sanity-check the env-var precedence in `apply_bridge_env(force=...)` for any non-concurrent callers that rely on operator-set `CURSOR_SDK_BRIDGE_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)