### PR TITLE
fix(cursor): default composer-2.5 to non-fast (slow) variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Built on **[Cursor SDK](https://github.com/cursor/cursor-sdk)** (`cursor-sdk`). 
 | [Schedules](docs/SCHEDULES.md) | Cron-based daily/weekly fleet jobs |
 
 **Requires:** Python 3.14 · [Cursor API key](https://cursor.com/dashboard/integrations) · git workspace  
-**Default model:** `composer-2.5`
+**Default model:** `composer-2.5` (slow / non-fast tier — agent-fleet pins `fast=false` explicitly so you aren't silently routed to the fast variant that Cursor returns as its default for the bare model id).
 
-> **Switch to `composer-2.5-fast`** for higher throughput at lower quality. Edit `~/.agent-fleet/fleet.yaml` — set `default_model: composer-2.5-fast` to apply fleet-wide, or set `model: composer-2.5-fast` under a single persona (under `personas:`) to scope the override.
+> **Switch to `composer-2.5-fast`** for higher throughput at lower quality (agent-fleet pins `fast=true`). Edit `~/.agent-fleet/fleet.yaml` — set `default_model: composer-2.5-fast` to apply fleet-wide, or set `model: composer-2.5-fast` under a single persona (under `personas:`) to scope the override.
 
 ---
 

--- a/agent_fleet/cursor_backend.py
+++ b/agent_fleet/cursor_backend.py
@@ -34,6 +34,28 @@ class CursorLLMResult:
     mcp_tool_calls: tuple[str, ...] = field(default_factory=tuple)
 
 
+def _resolve_model_selection(model: str) -> str | dict[str, Any]:
+    """Translate a user-facing model name to a cursor-sdk model selection.
+
+    Cursor's composer models have a ``fast`` parameter whose default
+    variant is ``fast='true'`` (the cheaper-quality, more-throughput tier
+    that is also billed differently). Passing the bare string
+    ``"composer-2.5"`` therefore silently routes to the fast variant.
+
+    We treat the bare names as the *slow* (non-fast) tier per the
+    long-standing fleet convention (see README) and require the explicit
+    ``-fast`` suffix to opt in.
+    """
+    if model in {"composer-2.5", "composer-2"}:
+        return {"id": model, "params": [{"id": "fast", "value": "false"}]}
+    if model in {"composer-2.5-fast", "composer-2-fast"}:
+        return {
+            "id": model.removesuffix("-fast"),
+            "params": [{"id": "fast", "value": "true"}],
+        }
+    return model
+
+
 def _format_mcp_tool_label(args: Mapping[str, Any] | None) -> str | None:
     if not args:
         return None
@@ -456,7 +478,7 @@ class CursorBackend:
             import cursor_sdk as sdk
         except ImportError as exc:
             return _ErrorSession(f"cursor-sdk not installed: {exc}")
-        selected_model = model or self.default_model
+        selected_model = _resolve_model_selection(model or self.default_model)
         selected_mode = coerce_agent_mode(mode, default=self.default_mode)
         mcp_dict = {name: _sdk_mcp_config(spec, sdk) for name, spec in (mcp_servers or {}).items()}
         try:
@@ -511,7 +533,7 @@ class CursorBackend:
             )
 
         work_dir = str(cwd or Path.cwd())
-        selected_model = model or self.default_model
+        selected_model = _resolve_model_selection(model or self.default_model)
         selected_mode = coerce_agent_mode(mode, default=self.default_mode)
         scope_note = ""
         if allowed_tools:

--- a/fleet.example.yaml
+++ b/fleet.example.yaml
@@ -5,6 +5,9 @@
 
 # Default backend: cursor (Cursor SDK) or kimi (Kimi Code CLI)
 default_backend: cursor
+# composer-2.5 maps to the slow (non-fast) Cursor tier — agent-fleet
+# explicitly sends {fast=false} so you don't get silently routed to the
+# cheaper-quality fast variant. Use `composer-2.5-fast` to opt in.
 default_model: composer-2.5
 default_mode: agent
 default_persona: coder


### PR DESCRIPTION
## Summary

- Bare model name `composer-2.5` silently selected Cursor's `fast='true'` variant (the default returned by the SDK), so every fleet run was billed/throttled as **composer-2.5 fast** despite the README and config promising the non-fast tier.
- Adds `_resolve_model_selection()` in `cursor_backend.py` that translates string model names into the dict form Cursor expects, defaulting composer-2.5 / composer-2 to `fast=false` and routing the explicit `-fast` suffix to `fast=true`.
- Both `Agent.create` (session backend) and `Agent.prompt` (run backend) now go through the resolver. Non-composer models (`claude-*`, `gpt-*`, etc.) pass through unchanged.

## Why

User noticed billing was showing composer-2.5 fast despite `default_model: composer-2.5`. Probing `client.models.list()` confirmed:

```
SDKModel(id='composer-2.5',
  parameters=(ModelParameterDefinition(id='fast', ...)),
  variants=(
    ModelVariant(params=(ModelParameterValue(id='fast', value='true')), is_default=True),
    ModelVariant(params=(ModelParameterValue(id='fast', value='false')), is_default=False),
  ))
```

so the SDK's default-variant rule routes bare-string `composer-2.5` to the fast variant. We have to pass the params explicitly to opt out.

## Test plan

- [x] `_resolve_model_selection` unit-verified for `composer-2.5`, `composer-2.5-fast`, `composer-2`, and a passthrough (`claude-opus-4-7`)
- [x] `cursor_sdk.AgentOptions(model={"id": ..., "params": ...})` accepts the dict and `ModelSelection.from_value(...).to_json()` matches what the bridge expects
- [x] `ruff format` + `ruff check` clean
- [ ] Reviewer to confirm billing dashboard shows non-fast composer-2.5 usage on the next concurrent smoke run

🤖 Generated with [Claude Code](https://claude.com/claude-code)