### PR TITLE
fix(fleet): preserve worktrees forensically + persist agent stdout

### DIFF
--- a/agent_fleet/cursor_backend.py
+++ b/agent_fleet/cursor_backend.py
@@ -467,9 +467,7 @@ class CursorBackend:
         # its server-side budget — neither benefits from immediate retry.
         if status == "error":
             return True
-        if status == "finished" and (not text or not text.strip()):
-            return True
-        return False
+        return status == "finished" and (not text or not text.strip())
 
     @classmethod
     def _reconnect_bridge(cls) -> None:

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -579,7 +579,7 @@ class FleetDispatcher:
             except Exception as exc:
                 logger.exception("Fleet task %s failed", task_index)
                 if task_workspace is not None:
-                    task_workspace.teardown(keep=False)
+                    task_workspace.teardown(keep=True)
                 fleet_log.emit("fleet.task.error", error=str(exc))
                 record_completed_task_experience(
                     task_index=task_index,

--- a/agent_fleet/integrations/local_git.py
+++ b/agent_fleet/integrations/local_git.py
@@ -177,6 +177,7 @@ class LocalGitOps:
         if not self.use_worktree or worktree.resolve() == self.repo_root.resolve():
             return
         import traceback
+
         logger.warning(
             "teardown_workspace REMOVING worktree=%s exists=%s caller_stack:\n%s",
             worktree,

--- a/agent_fleet/integrations/local_git.py
+++ b/agent_fleet/integrations/local_git.py
@@ -172,9 +172,17 @@ class LocalGitOps:
 
     def teardown_workspace(self, worktree: Path, *, forensic: bool = False) -> None:
         if forensic:
+            logger.info("teardown_workspace SKIP (forensic) worktree=%s", worktree)
             return
         if not self.use_worktree or worktree.resolve() == self.repo_root.resolve():
             return
+        import traceback
+        logger.warning(
+            "teardown_workspace REMOVING worktree=%s exists=%s caller_stack:\n%s",
+            worktree,
+            worktree.exists(),
+            "".join(traceback.format_stack(limit=8)),
+        )
         self._run(["worktree", "remove", "--force", str(worktree)], cwd=self.repo_root)
         if worktree.exists():
             shutil.rmtree(worktree, ignore_errors=True)

--- a/agent_fleet/level_up/record.py
+++ b/agent_fleet/level_up/record.py
@@ -228,7 +228,7 @@ def maybe_trigger_auto_learn(
             last = json.loads(marker.read_text(encoding="utf-8"))
             if now - float(last.get("ts", 0)) < cooldown:
                 return
-        except (json.JSONDecodeError, TypeError, ValueError):
+        except json.JSONDecodeError, TypeError, ValueError:
             pass
 
     total_rows = 0

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -162,6 +162,15 @@ def run_execute_phase(
             mode=parse_agent_mode(persona.mode),
             allowed_tools=list(persona.allowed_tools),
         )
+    _persist_execute_artifact(
+        persona=persona.name,
+        task=task,
+        workspace=workspace,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        exit_code=result.exit_code,
+        agent_id=result.agent_id,
+    )
     return {
         "phase": "execute",
         "persona": persona.name,
@@ -171,6 +180,43 @@ def run_execute_phase(
         "duration_s": result.duration_s,
         "agent_id": result.agent_id,
     }
+
+
+def _persist_execute_artifact(
+    *,
+    persona: str,
+    task: FleetTask,
+    workspace: Path,
+    stdout: str,
+    stderr: str,
+    exit_code: int,
+    agent_id: str | None,
+) -> None:
+    """Write execute-phase output to ~/.agent-fleet/runs/ so deliverables survive worktree teardown."""
+    import json
+    import time
+    from pathlib import Path as _Path
+
+    try:
+        runs_root = _Path.home() / ".agent-fleet" / "runs"
+        run_id = agent_id or f"run-{int(time.time())}"
+        target = runs_root / run_id
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "stdout.md").write_text(stdout or "", encoding="utf-8")
+        if stderr:
+            (target / "stderr.txt").write_text(stderr, encoding="utf-8")
+        meta = {
+            "persona": persona,
+            "goal": task.goal,
+            "workspace": str(workspace),
+            "exit_code": exit_code,
+            "agent_id": agent_id,
+            "ts": time.time(),
+        }
+        (target / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    except Exception:
+        import logging
+        logging.getLogger(__name__).exception("persist_execute_artifact failed")
 
 
 def run_scope_phase(

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -192,10 +192,20 @@ def _persist_execute_artifact(
     exit_code: int,
     agent_id: str | None,
 ) -> None:
-    """Write execute-phase output to ~/.agent-fleet/runs/ so deliverables survive worktree teardown."""
+    """Write execute-phase output to ~/.agent-fleet/runs/ so deliverables survive worktree teardown.
+
+    Also snapshots uncommitted/untracked files from the worktree so a future
+    redispatch can resume from where the agent left off even if the worktree
+    is wiped out-of-band (e.g. cursor-sdk bash subprocess churn).
+    """
     import json
+    import logging
+    import shutil
+    import subprocess
     import time
     from pathlib import Path as _Path
+
+    log = logging.getLogger(__name__)
 
     try:
         runs_root = _Path.home() / ".agent-fleet" / "runs"
@@ -215,8 +225,79 @@ def _persist_execute_artifact(
         }
         (target / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
     except Exception:
-        import logging
         logging.getLogger(__name__).exception("persist_execute_artifact failed")
+        return
+
+    # Best-effort filesystem snapshot of the worktree state. Failures here
+    # must never break the run — stdout/meta have already been persisted.
+    try:
+        if not workspace.exists() or not (workspace / ".git").exists():
+            return
+
+        def _git(args: list[str]) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                ["git", *args],
+                cwd=str(workspace),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+        status = _git(["status", "--porcelain", "-z"])
+        if status.returncode != 0 or not status.stdout:
+            return
+
+        files_dir = target / "files"
+        entries: list[dict[str, str]] = []
+        # -z output uses NUL separators; rename entries use a double NUL.
+        tokens = status.stdout.split("\0")
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            if not tok:
+                i += 1
+                continue
+            code = tok[:2]
+            path = tok[3:] if len(tok) > 3 else ""
+            if code.startswith(("R", "C")):
+                # Rename/copy: next -z token is the source path; skip it.
+                i += 2
+            else:
+                i += 1
+            if not path:
+                continue
+            entries.append({"code": code, "path": path})
+            src = workspace / path
+            if src.is_file():
+                dst = files_dir / path
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    shutil.copy2(src, dst)
+                except OSError as exc:
+                    log.warning("snapshot copy failed for %s: %s", path, exc)
+
+        if not entries:
+            return
+
+        # Capture working-tree diff vs HEAD (covers tracked file edits but not
+        # untracked files; the raw file copies above cover those).
+        diff = _git(["diff", "HEAD", "--binary"])
+        if diff.returncode == 0 and diff.stdout:
+            (target / "worktree.patch").write_text(diff.stdout, encoding="utf-8")
+
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"])
+        head_sha = _git(["rev-parse", "HEAD"])
+        snapshot_meta = {
+            "ts": time.time(),
+            "workspace": str(workspace),
+            "branch": branch.stdout.strip() if branch.returncode == 0 else None,
+            "head": head_sha.stdout.strip() if head_sha.returncode == 0 else None,
+            "entries": entries,
+        }
+        (target / "snapshot.json").write_text(json.dumps(snapshot_meta, indent=2), encoding="utf-8")
+    except Exception:
+        log.exception("persist_execute_artifact: snapshot step failed")
 
 
 def run_scope_phase(


### PR DESCRIPTION
## Summary
- exception-path teardown in dispatcher now keeps the worktree (was wiping unconditionally)
- log warning + caller stack on every \`teardown_workspace\` call to pin down the worktree-disappearance bug
- persist execute-phase stdout/stderr/meta to \`~/.agent-fleet/runs/<agent_id>/\` so deliverables survive even if the worktree is destroyed mid-run

## Context
The cursor-sdk fleet sessions have been dropping deliverables: audits that the agent successfully produces (\`docs/audits/...\`) are lost because the per-task worktree at \`/tmp/agent-worktrees/task-N-<uuid>\` vanishes during the run. This PR doesn't yet fix the root cause of the disappearance — it adds the instrumentation and forensic preservation needed to identify it on the next run, plus a fallback so the agent's stdout (which typically includes the full report) is never lost.

## Test plan
- [ ] Dispatch a fresh audit and inspect \`~/.agent-fleet/runs/<agent_id>/\` for stdout.md
- [ ] If a worktree vanishes again, grep dispatcher logs for "teardown_workspace REMOVING" to capture the caller stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)