### PR TITLE
fix(bridge): per-process bridges with stderr capture + 1800s stream timeout

### DIFF
--- a/agent_fleet/bridge_daemon.py
+++ b/agent_fleet/bridge_daemon.py
@@ -166,13 +166,19 @@ def _discovery_to_state(discovery: dict[str, Any], pid: int) -> dict[str, Any]:
     }
 
 
-def _spawn_bridge_subprocess(workspace: str, log_path: Path) -> subprocess.Popen:
-    # cursor-sdk-bridge has a documented opt-in env var that installs
-    # process-level uncaughtException/unhandledRejection survivors. Without
-    # it, an EPIPE on a peer-disconnect socket bubbles up as an unhandled
-    # stream 'error' event and kills the node process, which is fatal when
-    # multiple concurrent agent-fleet runs share one bridge.
-    env = {**os.environ, "CURSOR_SDK_BRIDGE_SURVIVE_UNCAUGHT": "1"}
+def _spawn_bridge_subprocess(
+    workspace: str, log_path: Path, *, survive_uncaught: bool = True
+) -> subprocess.Popen:
+    # cursor-sdk-bridge has an opt-in env var that installs process-level
+    # uncaughtException/unhandledRejection survivors. The shared daemon
+    # needs this — one stray EPIPE would otherwise kill the bridge for all
+    # concurrent clients. But for per-process bridges it hides real crash
+    # diagnostics; private callers pass survive_uncaught=False.
+    env = {**os.environ}
+    if survive_uncaught:
+        env["CURSOR_SDK_BRIDGE_SURVIVE_UNCAUGHT"] = "1"
+    else:
+        env.pop("CURSOR_SDK_BRIDGE_SURVIVE_UNCAUGHT", None)
     log_fh = log_path.open("ab", buffering=0)
     try:
         return subprocess.Popen(
@@ -460,31 +466,48 @@ def launch_private_bridge(
     log_path = bridges_dir / f"{os.getpid()}-{ts}.log"
 
     try:
-        proc = _spawn_bridge_subprocess(workspace, log_path)
+        # survive_uncaught=False: private bridges should crash loudly with
+        # stderr written to log_path; the shared daemon needs survivor
+        # handlers, but for per-process bridges they hide real diagnostics.
+        proc = _spawn_bridge_subprocess(workspace, log_path, survive_uncaught=False)
     except OSError as exc:
         logger.warning("private bridge spawn failed: %s", exc)
         return None
+
+    def _kill_process_group() -> None:
+        """SIGTERM then SIGKILL the bridge's whole process group.
+
+        ``start_new_session=True`` made proc the process-group leader, with
+        any sh/node descendants in the same group. Plain ``proc.terminate``
+        only signals proc itself, so a shell wrapper's node child can be
+        leaked. Signal the group instead.
+        """
+        if proc.poll() is not None:
+            return
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=2)
 
     deadline = time.monotonic() + timeout_s
     try:
         discovery = _read_discovery_from_log(log_path, deadline)
     except Exception as exc:
         logger.warning("private bridge discovery failed: %s", exc)
-        with contextlib.suppress(Exception):
-            proc.terminate()
+        _kill_process_group()
         return None
 
     state = _discovery_to_state(discovery, proc.pid)
     state["log_path"] = str(log_path)
 
-    def _cleanup() -> None:
-        with contextlib.suppress(Exception):
-            if proc.poll() is None:
-                proc.terminate()
-                with contextlib.suppress(subprocess.TimeoutExpired):
-                    proc.wait(timeout=5)
-
-    atexit.register(_cleanup)
+    atexit.register(_kill_process_group)
     return state
 
 

--- a/agent_fleet/bridge_daemon.py
+++ b/agent_fleet/bridge_daemon.py
@@ -434,6 +434,60 @@ def apply_bridge_env(*, force: bool = False, wait_s: float = 0.0) -> bool:
     return True
 
 
+def launch_private_bridge(
+    workspace: str, *, timeout_s: float = _DEFAULT_TIMEOUT_S
+) -> dict[str, Any] | None:
+    """Spawn a fresh per-process bridge with stderr captured to disk.
+
+    Unlike the shared daemon, this bridge is owned by the calling process:
+    stderr is written to ``~/.agent-fleet/bridges/<pid>-<ts>.log`` and an
+    atexit handler tears it down on process exit. Use this when concurrent
+    dispatches need their own bridges to avoid the shared-bridge contention
+    (cursor-sdk bridge is not concurrency-safe across processes).
+
+    Returns the discovery state dict (url/auth_token/pid/log_path) on
+    success, or None if spawn or discovery failed.
+    """
+    import atexit
+
+    bridges_dir = agent_fleet_home() / "bridges"
+    try:
+        bridges_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("private bridge log dir setup failed: %s", exc)
+        return None
+    ts = time.strftime("%Y%m%dT%H%M%S")
+    log_path = bridges_dir / f"{os.getpid()}-{ts}.log"
+
+    try:
+        proc = _spawn_bridge_subprocess(workspace, log_path)
+    except OSError as exc:
+        logger.warning("private bridge spawn failed: %s", exc)
+        return None
+
+    deadline = time.monotonic() + timeout_s
+    try:
+        discovery = _read_discovery_from_log(log_path, deadline)
+    except Exception as exc:
+        logger.warning("private bridge discovery failed: %s", exc)
+        with contextlib.suppress(Exception):
+            proc.terminate()
+        return None
+
+    state = _discovery_to_state(discovery, proc.pid)
+    state["log_path"] = str(log_path)
+
+    def _cleanup() -> None:
+        with contextlib.suppress(Exception):
+            if proc.poll() is None:
+                proc.terminate()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=5)
+
+    atexit.register(_cleanup)
+    return state
+
+
 def _main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="agent_fleet.bridge_daemon")
     parser.add_argument("--supervisor", action="store_true", help="Run the supervisor loop")

--- a/agent_fleet/cursor_backend.py
+++ b/agent_fleet/cursor_backend.py
@@ -526,17 +526,38 @@ class CursorBackend:
         selected_model = _resolve_model_selection(model or self.default_model)
         selected_mode = coerce_agent_mode(mode, default=self.default_mode)
         mcp_dict = {name: _sdk_mcp_config(spec, sdk) for name, spec in (mcp_servers or {}).items()}
+        # Long pytest/vitest audits stream chunked events for >10 minutes;
+        # the cursor-sdk default stream_timeout of 600s causes spurious
+        # ReadTimeout aborts. 1800s matches our session default_timeout_s.
+        client_kwargs: dict[str, Any] = {"stream_timeout": 1800.0}
+        if os.environ.get("AGENT_FLEET_SHARED_BRIDGE") != "1":
+            try:
+                from agent_fleet.bridge_daemon import launch_private_bridge
+
+                bridge_info = launch_private_bridge(str(cwd))
+                if bridge_info is not None:
+                    client_kwargs["base_url"] = bridge_info["url"]
+                    client_kwargs["auth_token"] = bridge_info["auth_token"]
+            except Exception:
+                logger.debug("launch_private_bridge failed; SDK auto-spawn", exc_info=True)
         try:
-            agent = sdk.Agent.create(
-                sdk.AgentOptions(
-                    model=selected_model,
-                    api_key=self.api_key,
-                    local=sdk.LocalAgentOptions(cwd=str(cwd)),
-                    mcp_servers=mcp_dict or None,
-                    mode=selected_mode,
-                    name=f"fleet:{persona_name}",
-                ),
+            client = sdk.Client(**client_kwargs)
+        except Exception:
+            logger.debug("sdk.Client init failed; falling back to default", exc_info=True)
+            client = None
+        try:
+            agent_options = sdk.AgentOptions(
+                model=selected_model,
+                api_key=self.api_key,
+                local=sdk.LocalAgentOptions(cwd=str(cwd)),
+                mcp_servers=mcp_dict or None,
+                mode=selected_mode,
+                name=f"fleet:{persona_name}",
             )
+            if client is not None:
+                agent = sdk.Agent.create(agent_options, client=client)
+            else:
+                agent = sdk.Agent.create(agent_options)
         except Exception as exc:
             return _ErrorSession(f"Agent.create failed: {exc}")
         return CursorSession(


### PR DESCRIPTION
## Summary

Two regressions in concurrent agent-fleet dispatch since the shared-bridge work:

1. **Bridge crashes were unrecoverable.** When `AGENT_FLEET_SHARED_BRIDGE` is unset (the default after #25), cursor-sdk auto-spawns a private bridge but pipes stderr to the parent process. When the parent exits, the bridge crash messages are lost forever — leaving only post-mortem `httpx.RemoteProtocolError: peer closed connection` stack traces with no diagnostic value.
2. **600s stream timeout fires during long audits.** The SDK's `DEFAULT_STREAM_TIMEOUT_SECONDS = 600` causes spurious `httpx.ReadTimeout` aborts on pytest/vitest 5x runs that stream chunked events for 10+ minutes.

## Changes

- `bridge_daemon.launch_private_bridge(workspace)` — spawn a fresh bridge owned by the calling process, capture stderr to `~/.agent-fleet/bridges/<pid>-<ts>.log`, register atexit teardown.
- `cursor_backend.CursorBackend.create_session` — when not using the shared daemon, call `launch_private_bridge`, build `sdk.Client(base_url, auth_token, stream_timeout=1800)`, pass to `Agent.create(options, client=client)`.

Bridges spawned by this code now have their crash messages on disk and survive long-running audits.

## Test plan

- [x] Ruff check + format clean
- [x] Runtime import verified (`launch_private_bridge` resolves)
- [x] Live test: 2 concurrent silphco audit dispatches (#1716 data + #1717 frontend) spawned with this code, each got its own private bridge bound to its own worktree (`/tmp/agent-worktrees/task-0-*`), per-PID stderr logs created in `~/.agent-fleet/bridges/`
- [ ] Verify all concurrent dispatches complete without RemoteProtocolError/ReadTimeout (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)