### PR TITLE
fix(bridge): actually reconnect private bridge on disconnect

### DIFF
--- a/agent_fleet/bridge_daemon.py
+++ b/agent_fleet/bridge_daemon.py
@@ -447,6 +447,13 @@ def apply_bridge_env(*, force: bool = False, wait_s: float = 0.0) -> bool:
 _private_bridges_by_workspace: dict[str, dict[str, Any]] = {}
 
 
+def invalidate_private_bridge(workspace: str) -> None:
+    """Drop the cached private bridge for ``workspace`` so the next launch
+    call spawns a fresh subprocess. Used by reconnect after disconnect."""
+    workspace_key = str(Path(workspace).resolve())
+    _private_bridges_by_workspace.pop(workspace_key, None)
+
+
 def launch_private_bridge(
     workspace: str, *, timeout_s: float = _DEFAULT_TIMEOUT_S
 ) -> dict[str, Any] | None:

--- a/agent_fleet/cursor_backend.py
+++ b/agent_fleet/cursor_backend.py
@@ -470,21 +470,31 @@ class CursorBackend:
         return status == "finished" and (not text or not text.strip())
 
     @classmethod
-    def _reconnect_bridge(cls) -> None:
+    def _reconnect_bridge(cls, *, workspace: str | None = None) -> None:
         try:
             from cursor_sdk._client import close_default_client
 
             close_default_client()
         except Exception:
             logger.debug("close_default_client failed", exc_info=True)
-        if os.environ.get("AGENT_FLEET_SHARED_BRIDGE") != "1":
+        if os.environ.get("AGENT_FLEET_SHARED_BRIDGE") == "1":
+            try:
+                from agent_fleet.bridge_daemon import apply_bridge_env
+
+                apply_bridge_env(force=True, wait_s=15.0)
+            except Exception:
+                logger.debug("apply_bridge_env failed during reconnect", exc_info=True)
+            return
+        # Private-bridge mode: drop the dead bridge from the per-workspace cache
+        # so the next launch_private_bridge call spawns a fresh subprocess.
+        if workspace is None:
             return
         try:
-            from agent_fleet.bridge_daemon import apply_bridge_env
+            from agent_fleet.bridge_daemon import invalidate_private_bridge
 
-            apply_bridge_env(force=True, wait_s=15.0)
+            invalidate_private_bridge(workspace)
         except Exception:
-            logger.debug("apply_bridge_env failed during reconnect", exc_info=True)
+            logger.debug("invalidate_private_bridge failed", exc_info=True)
 
     def __init__(
         self,
@@ -626,6 +636,7 @@ class CursorBackend:
         t0 = time.monotonic()
 
         def _execute() -> CursorLLMResult:
+            nonlocal sdk_client
             bridge_attempt = 0
             run_attempt = 0
             while True:
@@ -656,7 +667,9 @@ class CursorBackend:
                             exc,
                         )
                         time.sleep(delay)
-                        CursorBackend._reconnect_bridge()
+                        CursorBackend._reconnect_bridge(workspace=work_dir)
+                        # Rebuild the SDK client so it points at the new bridge URL.
+                        sdk_client = self._build_fleet_client(sdk, work_dir)
                         continue
                     return CursorLLMResult(
                         stdout="",


### PR DESCRIPTION
## Summary
- Reconnect path was a no-op in private-bridge mode (the default). The retry loop caught the right errors, slept the backoff, but \`_reconnect_bridge\` early-returned and the same dead bridge URL was retried 3x.
- Add \`invalidate_private_bridge\` and call it from \`_reconnect_bridge\` so the next \`launch_private_bridge\` spawns a fresh subprocess.
- Rebuild \`sdk_client\` after reconnect so it points at the new bridge URL (\`nonlocal\` so the closure rebinds the enclosing frame).

## Why
Observed in tonight's wave: 2 of 4 dispatchers failed with bridge \`ConnectError\`/\`RemoteProtocolError\`. Logs showed the retry firing 3x with growing backoff, each attempt hitting the same dead bridge — confirming the reconnect was inert.

## Test plan
- [x] \`ruff check\` / \`ruff format --check\` clean
- [x] Existing \`tests/test_cursor_session.py\` passes
- [ ] Live: dispatch a wave and inject a SIGKILL on a bridge subprocess; verify retry recovers