### PR TITLE
fix(pr_loop): skip worktree removal when in use by live dispatcher

### DIFF
--- a/agent_fleet/pr_loop/worktree.py
+++ b/agent_fleet/pr_loop/worktree.py
@@ -117,7 +117,7 @@ def _worktree_in_use(worktree_path: Path) -> bool:
             continue
         try:
             cwd = (entry / "cwd").resolve()
-        except (OSError, PermissionError):
+        except OSError, PermissionError:
             continue
         try:
             cwd.relative_to(target)

--- a/agent_fleet/pr_loop/worktree.py
+++ b/agent_fleet/pr_loop/worktree.py
@@ -99,8 +99,39 @@ def _parse_worktree_list(stdout: str) -> list[dict[str, str]]:
     return entries
 
 
+def _worktree_in_use(worktree_path: Path) -> bool:
+    """True if any process has *worktree_path* (or a descendant) as its cwd.
+
+    Walks /proc/*/cwd. Used to avoid deleting a worktree out from under a
+    live dispatcher whose branch hasn't yet become an open PR.
+    """
+    try:
+        target = worktree_path.resolve()
+    except OSError:
+        return False
+    proc = Path("/proc")
+    if not proc.is_dir():
+        return False
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            cwd = (entry / "cwd").resolve()
+        except (OSError, PermissionError):
+            continue
+        try:
+            cwd.relative_to(target)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
 def remove_worktree(repo_root: Path, worktree_path: Path) -> bool:
     """Force-remove *worktree_path* from the git worktree registry. Returns True on success."""
+    if _worktree_in_use(worktree_path):
+        logger.info("Skipping worktree removal — in use: %s", worktree_path)
+        return False
     rm = subprocess.run(
         ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(worktree_path)],
         capture_output=True,


### PR DESCRIPTION
## Summary
- \`sweep_orphan_worktrees\` was deleting live dispatchers' worktrees mid-run, because the dispatcher's branch only becomes an open PR at the OPEN_PR phase (~30 min into the run).
- Add \`/proc/*/cwd\` check so we never remove a directory currently in use.

## Test plan
- [x] \`ruff check\` clean
- [x] \`pytest tests/test_worktree.py\` 10 passed
- [ ] Live verify: dispatchers' worktrees survive the full run after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)