### PR TITLE
fix(bridge): survive uncaught EPIPE in private bridges

### DIFF
--- a/agent_fleet/bridge_daemon.py
+++ b/agent_fleet/bridge_daemon.py
@@ -495,10 +495,12 @@ def launch_private_bridge(
     log_path = bridges_dir / f"{os.getpid()}-{ts}.log"
 
     try:
-        # survive_uncaught=False: private bridges should crash loudly with
-        # stderr written to log_path; the shared daemon needs survivor
-        # handlers, but for per-process bridges they hide real diagnostics.
-        proc = _spawn_bridge_subprocess(workspace, log_path, survive_uncaught=False)
+        # survive_uncaught=True: an unhandled EPIPE inside the vendored cursor
+        # SDK BashState (when a child shell command exits with stdin still
+        # open) otherwise crashes the entire bridge. The crash is unrelated to
+        # the agent run and recoverable; surviving it keeps the dispatcher
+        # alive. Diagnostics still land in log_path via stderr.
+        proc = _spawn_bridge_subprocess(workspace, log_path, survive_uncaught=True)
     except OSError as exc:
         logger.warning("private bridge spawn failed: %s", exc)
         return None


### PR DESCRIPTION
## Summary
Private bridges were spawned with \`CURSOR_SDK_BRIDGE_SURVIVE_UNCAUGHT\` disabled. The vendored cursor SDK's BashState writes to child-shell sockets without an 'error' listener, so an EPIPE from a routine child exit crashes the entire bridge process — taking the dispatcher down with it.

Root cause traced via bridge stderr log:
\`\`\`
Error: write EPIPE
    at BashState.execute ... @cursor/sdk/dist/esm/index.js
Emitted 'error' event on Socket instance ...
\`\`\`

EPIPE has nothing to do with the agent run; flipping survive_uncaught=True lets the bridge stay alive and the dispatcher continue. Diagnostics still land in \`~/.agent-fleet/bridges/<pid>-<ts>.log\` via stderr.

## Test plan
- [x] \`ruff check\` clean
- [x] Full \`pytest\` suite passes (294 pass / 3 skip)
- [ ] Live: dispatchers complete full run without bridge-death failures