### PR TITLE
fix(pr_loop): treat blocked outcome as terminal

### DIFF
--- a/agent_fleet/pr_loop/watcher.py
+++ b/agent_fleet/pr_loop/watcher.py
@@ -244,7 +244,7 @@ class PrLoopWatcher:
             if outcome.status == "merged":
                 new_entry["merged"] = True
                 state["last_merge_ts"] = time.time()
-            if outcome.status == "parked":
+            if outcome.status in {"parked", "blocked"}:
                 new_entry["parked"] = True
             if (
                 outcome.status == "ci_timeout"

--- a/tests/test_pr_loop.py
+++ b/tests/test_pr_loop.py
@@ -336,3 +336,52 @@ def test_poll_once_parks_after_max_ci_timeout_attempts(tmp_path: Path) -> None:
         assert str(loop_config.max_ci_timeout_attempts) in str(entry.get("last_detail", ""))
 
     assert mock_lifecycle.call_count == loop_config.max_ci_timeout_attempts
+
+
+def test_poll_once_parks_on_blocked_outcome(tmp_path: Path) -> None:
+    """A `blocked` lifecycle outcome must set parked=True so the watcher stops re-entering."""
+    from unittest.mock import MagicMock, patch
+
+    from agent_fleet.pr_loop.config import PrLoopConfig
+    from agent_fleet.pr_loop.lifecycle import LifecycleResult
+    from agent_fleet.pr_loop.watcher import PrLoopWatcher
+    from agent_fleet.repo import RepoConfig
+    from agent_fleet.state import get_pr_state, load_state
+
+    repo = RepoConfig(repo_root=tmp_path, default_branch="main")
+    loop_config = PrLoopConfig(enabled=True)
+    watcher = PrLoopWatcher(repo, loop_config, fleet_config=MagicMock())
+
+    fake_pr: dict[str, object] = {
+        "number": 99,
+        "headRefName": "fleet/coder/99-abc12345",
+        "labels": [],
+        "isDraft": False,
+    }
+    blocked_result = LifecycleResult(status="blocked", detail="out-of-scope files: foo.py")
+
+    with (
+        patch(
+            "agent_fleet.pr_loop.watcher.github_ops.list_open_fleet_prs",
+            return_value=[fake_pr],
+        ),
+        patch("agent_fleet.pr_loop.watcher.github_ops.pr_has_label", return_value=False),
+        patch(
+            "agent_fleet.pr_loop.watcher.github_ops.pr_checks",
+            return_value=([{"name": "ci"}], [], [{"name": "ci"}]),
+        ),
+        patch("agent_fleet.pr_loop.watcher.github_ops.pr_comments", return_value=[]),
+        patch(
+            "agent_fleet.pr_loop.watcher.run_pr_lifecycle",
+            return_value=blocked_result,
+        ) as mock_lifecycle,
+    ):
+        results = watcher.poll_once()
+        assert results[0]["status"] == "blocked"
+        entry = get_pr_state(load_state(watcher.state_file), 99)
+        assert entry.get("parked") is True, "blocked outcome must park the PR"
+
+        # Second poll: PR is parked, lifecycle must not run again.
+        results2 = watcher.poll_once()
+        assert mock_lifecycle.call_count == 1, "parked PR must not re-enter lifecycle"
+        assert results2 == [] or all(r.get("pr") != "99" for r in results2)


### PR DESCRIPTION
## Summary
- `PrLoopWatcher.poll_once` only set `parked=True` for `parked` and threshold-`ci_timeout` outcomes.
- A `blocked` outcome (out-of-scope file guard, human-requested changes, protected paths) left the PR un-parked, so the watcher re-entered the lifecycle every poll (~70s).
- Observed live on silphco PR #1997: `pr_loop.start` / `pr_loop.end blocked` log churn every 70s with no progress.
- Fix: also park on `blocked`. Add a regression test.

## Test plan
- [x] `uv run pytest tests/test_pr_loop.py` (20 passed)
- [ ] Restart agent-fleet-watch and confirm PR #1997 stops looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)