### PR TITLE
fix(commit): never stage .venv/node_modules/caches in fleet commits

### DIFF
--- a/agent_fleet/integrations/local_git.py
+++ b/agent_fleet/integrations/local_git.py
@@ -206,7 +206,19 @@ class LocalGitOps:
         last_stderr = ""
         last_stdout = ""
         for _ in range(max_hook_retries + 1):
-            self._run(["add", "-A"], cwd=worktree)
+            # Filter forbidden paths (.venv, node_modules, caches) so a stray
+            # symlink in the worktree can't end up in a fleet PR.
+            from agent_fleet.pr_loop.github_ops import _is_forbidden_path
+
+            scan = self._run(["status", "--porcelain", "-uall"], cwd=worktree)
+            stage_paths = [
+                line[3:].strip()
+                for line in scan.stdout.splitlines()
+                if line.strip() and len(line) > 3 and not _is_forbidden_path(line[3:].strip())
+            ]
+            if not stage_paths:
+                return None
+            self._run(["add", "-A", "--", *stage_paths], cwd=worktree)
             result = self._run(
                 ["commit", "-m", message],
                 cwd=worktree,

--- a/agent_fleet/pr_loop/github_ops.py
+++ b/agent_fleet/pr_loop/github_ops.py
@@ -78,7 +78,9 @@ def _is_forbidden_path(path: str) -> bool:
     here regardless of repo .gitignore state.
     """
     norm = "/" + path.lstrip("/")
-    return any(frag in norm or norm.endswith(frag.rstrip("/")) for frag in _FORBIDDEN_PATH_FRAGMENTS)
+    return any(
+        frag in norm or norm.endswith(frag.rstrip("/")) for frag in _FORBIDDEN_PATH_FRAGMENTS
+    )
 
 
 def _changed_files(worktree: Path, *, exclude: tuple[str, ...] = ()) -> list[str]:
@@ -88,9 +90,7 @@ def _changed_files(worktree: Path, *, exclude: tuple[str, ...] = ()) -> list[str
     # -uall expands untracked directories so per-file forbidden-path filters
     # can fire (a default `--porcelain` reports `pipeline/` for an entire
     # untracked dir, hiding a stray `.venv` inside).
-    status = _git_run(
-        ["git", "status", "--porcelain", "-uall"], cwd=worktree, timeout=30
-    )
+    status = _git_run(["git", "status", "--porcelain", "-uall"], cwd=worktree, timeout=30)
     out: list[str] = []
     for line in status.stdout.splitlines():
         if not line.strip() or len(line) <= 3:

--- a/agent_fleet/pr_loop/github_ops.py
+++ b/agent_fleet/pr_loop/github_ops.py
@@ -59,16 +59,47 @@ def _git_run(
         )
 
 
+_FORBIDDEN_PATH_FRAGMENTS = (
+    "/.venv/",
+    "/.venv",
+    "/node_modules/",
+    "/__pycache__/",
+    "/.pytest_cache/",
+    "/.mypy_cache/",
+    "/.ruff_cache/",
+)
+
+
+def _is_forbidden_path(path: str) -> bool:
+    """True if *path* is a build/runtime artifact a fleet PR must never publish.
+
+    `.venv` symlinks (or directories) accidentally staged by `git add -A`
+    have poisoned merged PRs and broken self-hosted CI. We hard-block them
+    here regardless of repo .gitignore state.
+    """
+    norm = "/" + path.lstrip("/")
+    return any(frag in norm or norm.endswith(frag.rstrip("/")) for frag in _FORBIDDEN_PATH_FRAGMENTS)
+
+
 def _changed_files(worktree: Path, *, exclude: tuple[str, ...] = ()) -> list[str]:
     if not Path(worktree).is_dir():
         return []
     exclude_set = set(exclude)
-    status = _git_run(["git", "status", "--porcelain"], cwd=worktree, timeout=30)
-    return [
-        line[3:].strip()
-        for line in status.stdout.splitlines()
-        if line.strip() and len(line) > 3 and line[3:].strip() not in exclude_set
-    ]
+    # -uall expands untracked directories so per-file forbidden-path filters
+    # can fire (a default `--porcelain` reports `pipeline/` for an entire
+    # untracked dir, hiding a stray `.venv` inside).
+    status = _git_run(
+        ["git", "status", "--porcelain", "-uall"], cwd=worktree, timeout=30
+    )
+    out: list[str] = []
+    for line in status.stdout.splitlines():
+        if not line.strip() or len(line) <= 3:
+            continue
+        path = line[3:].strip()
+        if path in exclude_set or _is_forbidden_path(path):
+            continue
+        out.append(path)
+    return out
 
 
 def run_commit_preflight(
@@ -502,7 +533,18 @@ def commit_and_push(
     max_hook_retries = 2
     last_commit_output = ""
     for attempt in range(max_hook_retries + 1):
-        _git_run(["git", "add", "-A"], cwd=worktree, timeout=60, check=True)
+        # Re-scan after hooks (autofixers may add/remove files), filter
+        # forbidden paths, and stage explicitly — never `git add -A` which
+        # would pick up stray .venv / node_modules drops in the worktree.
+        stage_paths = _changed_files(worktree, exclude=exclude)
+        if not stage_paths:
+            return CommitPushResult(False, "no_changes", "No publishable changes after filter")
+        _git_run(
+            ["git", "add", "-A", "--", *stage_paths],
+            cwd=worktree,
+            timeout=60,
+            check=True,
+        )
         commit = _git_run(
             ["git", "commit", "-m", message],
             cwd=worktree,

--- a/tests/test_pr_loop.py
+++ b/tests/test_pr_loop.py
@@ -184,6 +184,36 @@ def _init_repo_with_remote(tmp_path: Path) -> tuple[Path, Path]:
     return remote, local
 
 
+def test_commit_and_push_skips_forbidden_paths(tmp_path: Path) -> None:
+    """A stray .venv symlink in the worktree must not end up in the commit.
+
+    Regression guard: silphco PR #2000 committed pipeline/.venv as a
+    self-symlink because `git add -A` blindly staged everything.
+    """
+    from agent_fleet.pr_loop.github_ops import commit_and_push
+
+    _, local = _init_repo_with_remote(tmp_path)
+    subprocess.run(["git", "checkout", "-b", "feature-branch"], cwd=local, check=True)
+    (local / "feature.txt").write_text("feature\n", encoding="utf-8")
+    pipeline = local / "pipeline"
+    pipeline.mkdir()
+    (pipeline / ".venv").symlink_to(pipeline / ".venv")  # self-referential
+    (local / "node_modules").mkdir()
+    (local / "node_modules" / "junk.js").write_text("// junk\n", encoding="utf-8")
+
+    result = commit_and_push(local, "test: forbidden filter", "feature-branch")
+    assert result.ok is True
+    committed = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=local,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert "feature.txt" in committed
+    assert not any(".venv" in p or "node_modules" in p for p in committed), committed
+
+
 def test_commit_and_push_retries_after_pre_commit_autofix(tmp_path: Path) -> None:
     """Pre-commit hook auto-rewrites a file and exits 1 on first call;
     commit_and_push should re-stage and succeed instead of returning False."""


### PR DESCRIPTION
## Summary
Root-cause fix for the campaign-stalling silphco CI infra bug.

silphco PR #2000 committed \`pipeline/.venv\` as a self-referential symlink, breaking the self-hosted runner's \`actions/checkout\` step on every subsequent PR (\`Too many levels of symbolic links\`). It got in because the fleet's publish step runs \`git add -A\` blindly, and the runner's source checkout shares directory layout with the venv it provisions there.

- \`_changed_files\` filters \`.venv\`, \`node_modules\`, \`__pycache__\`, \`*_cache\` paths before staging.
- Use \`git status --porcelain -uall\` so the filter sees individual files inside untracked dirs.
- Replace \`git add -A\` with \`git add -A -- <filtered>\` as a belt-and-braces guard.

## Test plan
- [x] New regression \`test_commit_and_push_skips_forbidden_paths\` creates a self-symlink \`pipeline/.venv\` + \`node_modules/\` in a worktree, runs \`commit_and_push\`, asserts neither lands in the commit.
- [x] Full test suite 296 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)