### PR TITLE
fix(pr_loop): sidecar PID-lock for worktree sweeper

### DIFF
--- a/agent_fleet/integrations/local_git.py
+++ b/agent_fleet/integrations/local_git.py
@@ -168,6 +168,9 @@ class LocalGitOps:
         if result.returncode != 0:
             raise RuntimeError(f"git worktree add failed: {result.stderr.strip()}")
         self._active_worktrees.append(target)
+        from agent_fleet.pr_loop.worktree import claim_worktree_lock
+
+        claim_worktree_lock(target)
         return target
 
     def teardown_workspace(self, worktree: Path, *, forensic: bool = False) -> None:
@@ -184,6 +187,9 @@ class LocalGitOps:
             worktree.exists(),
             "".join(traceback.format_stack(limit=8)),
         )
+        from agent_fleet.pr_loop.worktree import release_worktree_lock
+
+        release_worktree_lock(worktree)
         self._run(["worktree", "remove", "--force", str(worktree)], cwd=self.repo_root)
         if worktree.exists():
             shutil.rmtree(worktree, ignore_errors=True)

--- a/agent_fleet/pr_loop/worktree.py
+++ b/agent_fleet/pr_loop/worktree.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import re
 import subprocess
 from dataclasses import dataclass
@@ -103,8 +104,10 @@ def _parse_worktree_list(stdout: str) -> list[dict[str, str]]:
 def _worktree_in_use(worktree_path: Path) -> bool:
     """True if any process has *worktree_path* (or a descendant) as its cwd.
 
-    Walks /proc/*/cwd. Used to avoid deleting a worktree out from under a
-    live dispatcher whose branch hasn't yet become an open PR.
+    Walks /proc/*/cwd. Coarse heuristic — misses processes that take the
+    worktree as an argument but run from elsewhere (the common case for
+    cursor-agent and ``git -C <path>`` calls). Kept as defense-in-depth
+    alongside the precise PID-lock check in ``_worktree_locked``.
     """
     try:
         target = worktree_path.resolve()
@@ -155,8 +158,82 @@ def _alive_dispatch_issue_numbers() -> set[int]:
     return out
 
 
+def _worktree_lock_path(worktree_path: Path) -> Path:
+    """Sidecar lock file path for *worktree_path*. Lives next to the worktree dir."""
+    return worktree_path.parent / f"{worktree_path.name}.lock"
+
+
+def _proc_start_time(pid: int) -> int | None:
+    """Read field 22 (starttime, clock ticks since boot) from /proc/<pid>/stat."""
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+    except OSError, PermissionError:
+        return None
+    # Field 2 is comm in parens, which may contain spaces. Split after the
+    # closing paren so subsequent fields are positional.
+    rparen = stat.rfind(")")
+    if rparen < 0:
+        return None
+    rest = stat[rparen + 2 :].split()
+    # rest[0] is field 3 (state); starttime is field 22, so index 19 here.
+    try:
+        return int(rest[19])
+    except IndexError, ValueError:
+        return None
+
+
+def claim_worktree_lock(worktree_path: Path, pid: int | None = None) -> None:
+    """Write a sidecar lock declaring *pid* (default: caller) owns *worktree_path*.
+
+    Format: ``<pid> <starttime_clock_ticks>``. The starttime pins a specific
+    process incarnation so PID reuse cannot trick the sweeper into preserving
+    an orphaned worktree.
+    """
+    owner = pid if pid is not None else os.getpid()
+    start = _proc_start_time(owner)
+    if start is None:
+        return
+    lock = _worktree_lock_path(worktree_path)
+    with contextlib.suppress(OSError):
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text(f"{owner} {start}\n")
+
+
+def release_worktree_lock(worktree_path: Path) -> None:
+    """Remove the sidecar lock for *worktree_path* if present."""
+    with contextlib.suppress(OSError):
+        _worktree_lock_path(worktree_path).unlink()
+
+
+def _worktree_locked(worktree_path: Path) -> bool:
+    """True if a live process declared ownership of *worktree_path* via lock file.
+
+    The lock binds (pid, starttime) — a recycled PID with a different starttime
+    is treated as stale, so the sweeper can reclaim worktrees abandoned by
+    crashed dispatchers without waiting for a watcher restart.
+    """
+    lock = _worktree_lock_path(worktree_path)
+    try:
+        text = lock.read_text().strip()
+    except OSError, ValueError:
+        return False
+    parts = text.split()
+    if len(parts) < 2:
+        return False
+    try:
+        pid = int(parts[0])
+        recorded_start = int(parts[1])
+    except ValueError:
+        return False
+    actual_start = _proc_start_time(pid)
+    return actual_start is not None and actual_start == recorded_start
+
+
 def remove_worktree(repo_root: Path, worktree_path: Path) -> bool:
     """Force-remove *worktree_path* from the git worktree registry. Returns True on success."""
+    if _worktree_locked(worktree_path):
+        logger.info("Skipping worktree removal — locked by live owner: %s", worktree_path)
+        return False
     if _worktree_in_use(worktree_path):
         logger.info("Skipping worktree removal — in use: %s", worktree_path)
         return False
@@ -168,6 +245,7 @@ def remove_worktree(repo_root: Path, worktree_path: Path) -> bool:
         timeout=30,
     )
     if rm.returncode == 0:
+        release_worktree_lock(worktree_path)
         logger.info("Removed worktree %s", worktree_path)
         return True
     logger.warning("Failed to remove worktree %s: %s", worktree_path, rm.stderr.strip())

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -194,7 +194,7 @@ def test_prepare_task_workspace_keep_on_success(tmp_path: Path) -> None:
 def test_sweep_orphan_worktrees(tmp_path: Path) -> None:
     """Sweep removes worktrees whose branch is not in active_branches."""
     from agent_fleet.integrations.local_git import LocalGitOps
-    from agent_fleet.pr_loop.worktree import sweep_orphan_worktrees
+    from agent_fleet.pr_loop.worktree import release_worktree_lock, sweep_orphan_worktrees
 
     repo_path = tmp_path / "repo"
     _init_git_repo(repo_path)
@@ -204,6 +204,11 @@ def test_sweep_orphan_worktrees(tmp_path: Path) -> None:
 
     orphan_wt = git_ops.setup_workspace(repo_path, "orphan-run", "main", branch_name="fleet/orphan")
     active_wt = git_ops.setup_workspace(repo_path, "active-run", "main", branch_name="fleet/active")
+
+    # setup_workspace claims a lock for the current PID; drop the orphan's
+    # lock so the sweep treats it as eligible for removal.
+    release_worktree_lock(orphan_wt)
+    release_worktree_lock(active_wt)
 
     assert orphan_wt.exists()
     assert active_wt.exists()
@@ -217,3 +222,55 @@ def test_sweep_orphan_worktrees(tmp_path: Path) -> None:
     assert removed == 1
     assert not orphan_wt.exists(), "orphan worktree should have been removed"
     assert active_wt.exists(), "active worktree should be kept"
+
+
+def test_sweep_skips_worktree_locked_by_live_owner(tmp_path: Path) -> None:
+    """A worktree with a sidecar lock pointing to a live PID survives the sweep."""
+    from agent_fleet.integrations.local_git import LocalGitOps
+    from agent_fleet.pr_loop.worktree import sweep_orphan_worktrees
+
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)
+
+    base = tmp_path / "worktrees"
+    git_ops = LocalGitOps(repo_path, use_worktree=True, worktree_base=base)
+
+    # setup_workspace auto-claims a lock for the current pytest PID.
+    live_wt = git_ops.setup_workspace(repo_path, "live-run", "main", branch_name="fleet/live")
+    assert (live_wt.parent / f"{live_wt.name}.lock").exists()
+
+    removed = sweep_orphan_worktrees(
+        repo_path,
+        base_path=base,
+        active_branches=set(),
+    )
+
+    assert removed == 0
+    assert live_wt.exists(), "live-locked worktree must survive the sweep"
+
+
+def test_sweep_removes_worktree_with_stale_pid_lock(tmp_path: Path) -> None:
+    """A lock whose PID is dead (or recycled with different starttime) is stale."""
+    from agent_fleet.integrations.local_git import LocalGitOps
+    from agent_fleet.pr_loop.worktree import _worktree_lock_path, sweep_orphan_worktrees
+
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)
+
+    base = tmp_path / "worktrees"
+    git_ops = LocalGitOps(repo_path, use_worktree=True, worktree_base=base)
+
+    wt = git_ops.setup_workspace(repo_path, "stale-run", "main", branch_name="fleet/stale")
+    # Overwrite the auto-claimed lock with a guaranteed-dead-or-mismatched record:
+    # PID 1 (init) exists, but with an obviously bogus starttime so the
+    # (pid, starttime) tuple does not validate.
+    _worktree_lock_path(wt).write_text("1 999999999999\n")
+
+    removed = sweep_orphan_worktrees(
+        repo_path,
+        base_path=base,
+        active_branches=set(),
+    )
+
+    assert removed == 1
+    assert not wt.exists(), "stale-lock worktree should be reclaimed"


### PR DESCRIPTION
## Summary

- Adds a `<worktree>.lock` sidecar file (containing `<pid> <starttime_ticks>`) claimed at `setup_workspace` and released at `teardown_workspace`.
- `sweep_orphan_worktrees` rejects removal when a lock points to a live process (PID + `/proc/<pid>/stat` field 22 starttime both match), so PID reuse can't preserve an orphan.
- Cwd scan (`_worktree_in_use`) and `ISSUE_NUMBER` env scan stay as defense-in-depth.

## Why

Sub-task worktrees (`task-N-<id>`) were getting swept mid-run. The existing `_worktree_in_use` heuristic walks `/proc/*/cwd`, but cursor-agent and `git -C <path>` invocations take the worktree path as an argument rather than running from it — so the sweeper saw no cwd reference and deleted the live worktree. The dispatcher then crashed 30+ minutes later with `FileNotFoundError` on push (observed at `task-2-eaa7a322`).

A precise PID-lock is the simplest fix: it doesn't depend on where any process happens to be cwd'd, and the starttime check means a crashed dispatcher's lock auto-expires on the next sweep without needing a watcher restart.

## Test plan

- [x] `pytest tests/test_worktree.py tests/test_pr_loop.py` → 33/33 pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] New tests: `test_sweep_skips_worktree_locked_by_live_owner`, `test_sweep_removes_worktree_with_stale_pid_lock`
- [ ] Watch next silphco dispatch for a sub-task surviving sweep cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)