### PR TITLE
fix(planner): surface real backend errors instead of opaque 'no JSON' message

### DIFF
--- a/agent_fleet/cursor_backend.py
+++ b/agent_fleet/cursor_backend.py
@@ -33,6 +33,12 @@ class CursorLLMResult:
     duration_s: float
     agent_id: str | None = None
     mcp_tool_calls: tuple[str, ...] = field(default_factory=tuple)
+    # Set when send() catches an exception and falls back to a synthetic
+    # exit_code=1 result. Callers reading only stdout will see empty output;
+    # callers that care about the underlying failure (e.g. the planner)
+    # inspect this to build a diagnostic error message instead of reporting
+    # the generic "no JSON in output" symptom.
+    cause: BaseException | None = None
 
 
 def _resolve_model_selection(model: str) -> str | dict[str, Any]:
@@ -313,10 +319,11 @@ class CursorSession:
             logger.exception("CursorSession.send failed")
             return CursorLLMResult(
                 stdout="",
-                stderr=str(exc),
+                stderr=f"{type(exc).__name__}: {exc}",
                 exit_code=1,
                 duration_s=time.monotonic() - t0,
                 agent_id=self.agent_id,
+                cause=exc,
             )
 
     def dispose(self) -> None:

--- a/agent_fleet/issue_loop/dispatch.py
+++ b/agent_fleet/issue_loop/dispatch.py
@@ -193,12 +193,30 @@ def main() -> None:
     issue_number = int(os.environ.get("ISSUE_NUMBER", "0"))
     comment_body = os.environ.get("COMMENT_BODY", "")
     persona = os.environ.get("PERSONA") or None
-    workspace = Path(os.environ.get("AGENT_FLEET_WORKSPACE", Path.cwd())).resolve()
+    workspace_env = os.environ.get("AGENT_FLEET_WORKSPACE")
+    target_config_env = os.environ.get("AGENT_FLEET_TARGET_CONFIG")
     fleet_config_path = os.environ.get("AGENT_FLEET_CONFIG")
 
     if issue_number <= 0:
         print("ISSUE_NUMBER env var required", file=sys.stderr)
         raise SystemExit(1)
+
+    # Refuse the silent-cwd default. Manual invocations from agent-fleet's own
+    # checkout would otherwise resolve the controller's .agent-fleet.yaml as
+    # the "target", silently running the dispatch against the wrong workspace.
+    # The watcher always sets AGENT_FLEET_TARGET_CONFIG; manual callers must
+    # set one of the two.
+    if not workspace_env and not target_config_env:
+        print(
+            "Refusing to dispatch: neither AGENT_FLEET_WORKSPACE nor "
+            "AGENT_FLEET_TARGET_CONFIG is set. Set AGENT_FLEET_WORKSPACE to "
+            "the target repo root (where its .agent-fleet.yaml lives), or "
+            "AGENT_FLEET_TARGET_CONFIG to the target's config file path.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    workspace = Path(workspace_env or Path.cwd()).resolve()
 
     raise SystemExit(
         run_issue_dispatch(

--- a/agent_fleet/planner.py
+++ b/agent_fleet/planner.py
@@ -193,6 +193,21 @@ def plan(
                 allowed_tools=[],
             )
 
+        # Distinguish backend failure from "model returned prose without JSON".
+        # An exit_code != 0 OR empty stdout means the LLM call itself failed
+        # (auth error, transport timeout, swallowed exception in
+        # CursorSession.send, etc.). Retrying on that just produces the same
+        # opaque failure; raise immediately with the underlying diagnostic
+        # instead of masking it as "No JSON object found in LLM output".
+        if result.exit_code != 0 or not result.stdout.strip():
+            stderr_tail = (result.stderr or "")[-500:]
+            cause = getattr(result, "cause", None)
+            cause_str = f"; cause={type(cause).__name__}: {cause}" if cause else ""
+            raise ValueError(
+                f"PLAN backend call failed: exit_code={result.exit_code}, "
+                f"stderr_tail={stderr_tail!r}{cause_str}"
+            )
+
         try:
             data = _extract_json(result.stdout)
             validate_task_spec(data)

--- a/plans/stable-autonomous/overview.md
+++ b/plans/stable-autonomous/overview.md
@@ -1,0 +1,88 @@
+# Stable Autonomous Fleet — Plan Overview
+
+## Why now
+
+The fleet driving silphcoanalytics requires constant human babysitting. Three failure modes burn the most attention:
+
+1. The PLAN phase fails with the message `ValueError: No JSON object found in LLM output`. The message has zero diagnostic content. The dispatch logs at `dispatch-1517-retry2.log` and `dispatch-1690.log` show identical lines at second-resolution timestamps — the underlying cursor call clearly failed in some structured way, but `CursorSession.send` swallowed the exception and returned empty stdout. The planner saw empty stdout and raised the generic "no JSON" error. Hours of monitor ticks have been spent guessing whether it was a transient API failure, an auth issue, or a config drift; the swallowed exception cost all of that time. Watcher-driven dispatch happens to work because the watcher always sets `AGENT_FLEET_TARGET_CONFIG`; manual `python -m agent_fleet.issue_loop.dispatch` does not, and `resolve_repo_config` walks back to a different config — silently.
+
+2. Fleet PRs go green, then sit. `pr_loop/config.py:30` has `auto_merge: bool = True` and `lifecycle.py:876` reads it before calling `try_merge`. So PRs *should* merge on green. They have not been. Either the gate is being missed at the right wall-clock window, or `try_merge` itself returns silently on a non-clean mergeable state and never retries. Verification: the merged-state lookup uses `BEHIND` and triggers `update-branch`; `DIRTY` (the PR #2010 case) has no path; `CLEAN` should fall through and succeed. Need a runtime trace before deciding what code to change.
+
+3. The fleet drains and there is nothing to do. The watcher only reacts to `/agent --persona X` comments. With a 200-issue backlog labeled with intent, requiring the user to comment by hand is a designed-in human bottleneck.
+
+A fourth failure mode is rarer but bites hard when it happens: main moves out from under an open fleet PR. PR #2010 spent ~3 hours generating commits against a `pipeline/src/build_gold_sales_facts.py` shape that main had already moved past. By the time the conflict surfaced, the PR's acceptance criteria were stale. `pr_loop/github_ops.py:582` rebases against `origin/<branch>` only — never against `origin/main`.
+
+## Scope
+
+Four PRs to `agent-fleet`. Not silphcoanalytics. Not test infrastructure rewrites. Not observability additions beyond what the planner-bug fix forces.
+
+| # | Title | Estimate | Blast radius |
+|---|---|---|---|
+| 1 | Surface real planner errors | ~2 hr | All callers of `CursorSession.send`; gated behind keeping legacy result shape for now |
+| 2 | Verify and harden auto-merge | ~30 min | `pr_loop/lifecycle.py` merge gate; likely diagnostic-only |
+| 3 | Label-driven backlog dispatcher | ~2 hr | New module + `CombinedWatcher` tick; posts comments only |
+| 4 | Main-drift detection in pr_loop | ~2 hr | `pr_loop/lifecycle.py` cycle start; close-and-reopen path |
+
+PRs ship in order. Each is mergeable on its own. PR 1 ships first because every other PR's diagnostics depend on the planner failing loudly.
+
+## Out of scope
+
+- Any silphcoanalytics-side change. The driving target is just a witness — bugs are in agent-fleet.
+- Rewriting test infrastructure or adding shared fakes. Existing tests use local `FakeBackend` and per-test monkeypatches; that pattern stays.
+- Branch protection on silphcoanalytics. The repo is on the free plan; `gh pr merge --auto` is a no-op there. Designs must not depend on it.
+- New shared on-disk state. The label-driven dispatcher writes nothing the watcher doesn't already write.
+- Stopping the in-flight #1690 task agents. They are running in `/tmp/agent-worktrees/task-0-8d147344` and `/tmp/agent-worktrees/task-1-6b580255` and will produce a PR or fail on their own.
+
+## Constraints
+
+- Main Claude session is Opus. Per `/home/evan/.claude/CLAUDE.md`, every `Agent` tool call must pass `model: "sonnet"` or `model: "haiku"`. No Opus subagents from this session.
+- The live watcher in `~/.agent-fleet/logs/watch.log` must stay up during the rollout. Each PR's runtime change is gated so a deploy that needs the watcher to restart is its own visible step.
+- No commit with `--no-verify`, `--no-gpg-sign`, or `-i`. No `--amend`. No force-push to `main`. Commit messages via HEREDOC, trailer line `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`.
+- `.env` files at `/home/evan/Documents/silphcoanalytics/.env` and `/home/evan/.agent-fleet/.env` (mode 0600). Never staged, never printed.
+- `CURSOR_API_KEY` never echoed.
+- `AGENT_FLEET_TARGET_CONFIG` env var is the contract between watcher and dispatch. Any change to dispatch's config-resolution path is breaking for the watcher path and must be tested against the watcher fixture.
+
+## Principles applied
+
+- **fix-root-causes.** PR 1's root cause is not "the planner is too strict"; it is "the boundary swallows the diagnostic." Don't add fallback prose to the planner — strip the swallowing instead.
+- **boundary-discipline.** `CursorSession.send` is the boundary. It is the place to surface real failures, not the planner. Per-caller error handling stays at the call sites where the caller can decide.
+- **migrate-callers-then-delete-legacy-apis.** `CursorLLMResult` has nine callers. If we change `send` to raise, every caller must move in one wave. The PR-1 design keeps the result shape and adds a `cause` field so callers migrate optionally; PR 1 itself only migrates the planner.
+- **separate-before-serializing-shared-state.** PR 3's dispatcher and the watcher both touch `.agent-fleet-state.json`. The design has the dispatcher write nothing to that file — it posts a comment, the watcher's existing path picks it up 30 s later, the watcher writes `in_flight`. No new shared state and no new lock.
+- **make-operations-idempotent.** PR 3 must not double-dispatch if it runs every 10 minutes and the watcher is also active. The gate keys are: `agent-running/<issue>` mutex label, open fleet PR for the issue, presence in `in_flight`. PR 4 must not double-close an already-closed PR or double-comment a "drift detected" note.
+- **subtract-before-you-add.** PR 2 may turn out to be diagnostic-only. If the verification step in `phase-2-auto-merge.md` finds `auto_merge` already works end-to-end and the issue was just specific PRs in DIRTY state (which PR 4 handles), PR 2 collapses into a one-line log change.
+- **foundational-thinking.** Sequencing: PR 1 first, because PRs 2-4 depend on being able to read what failed. PR 4 last, because the close-and-reopen path needs PR 1's diagnostics to write a useful replan note on the reopened issue.
+
+## Alternatives considered
+
+- **PR 1 alternative: leave `CursorSession.send` as-is, only fix the planner.** Rejected. The planner is one of nine callers; the others (`researcher`, `reviewer`, `tech_lead`, `synthesizer`) read only stdout too and will hit the same opaque failure. Fixing one caller leaves a known landmine.
+- **PR 1 alternative: change `send` to raise on failure.** Rejected for this PR. Two callers (`implementer`, `fleet_scope`) already inspect `exit_code` and would need migration. Doable but doubles PR 1's blast radius. Deferred to a follow-up after PR 1's `cause` field lands.
+- **PR 2 alternative: re-implement merge as a periodic sweep.** Rejected. The lifecycle gate is the right place; if it is silently failing, the answer is to log why, not to add a parallel sweeper that races it.
+- **PR 3 alternative: dispatcher writes `in_flight` directly.** Rejected per `separate-before-serializing-shared-state`. Two writers to one JSON file is what the existing lock was added to manage; adding a third introduces a new contention surface for no benefit.
+- **PR 4 alternative: try to auto-rebase against `main` and resolve conflicts.** Rejected. Cursor agents can resolve conflicts but the time-to-resolution is unbounded; close-and-reopen with a replan note is the conservative move and preserves an audit trail.
+
+## Verification
+
+After every PR, all of these must pass from `/home/evan/Documents/agent-fleet`:
+
+```
+uv run ruff check .
+uv run pytest -q
+```
+
+Per-PR runtime verification is in each phase file. The end-state acceptance is one full autonomous cycle:
+
+1. A `fleet-ready` labeled issue gets a `/agent` comment from PR 3.
+2. The watcher dispatches it (existing path).
+3. PR opens, CI goes green, `try_merge` lands it (PR 2, possibly diagnostic-only).
+4. If main drifted mid-cycle, the PR is closed and the issue reopened with a replan note (PR 4).
+5. No manual intervention for 30 minutes. Logged in `~/.agent-fleet/logs/watch.log`.
+
+If step 5 fails, the plan failed even if every individual PR's tests pass.
+
+## Files
+
+- `phase-1-planner-bug.md`
+- `phase-2-auto-merge.md`
+- `phase-3-auto-dispatch.md`
+- `phase-4-main-drift.md`
+- `testing.md`

--- a/plans/stable-autonomous/phase-1-planner-bug.md
+++ b/plans/stable-autonomous/phase-1-planner-bug.md
@@ -1,0 +1,105 @@
+# Phase 1 — Surface real planner errors
+
+## Symptom
+
+`dispatch-1517-retry2.log` and `dispatch-1690.log` both end with:
+
+```
+File "/home/evan/Documents/agent-fleet/agent_fleet/planner.py", line 206, in plan
+    raise ValueError(last_error)
+ValueError: No JSON object found in LLM output
+```
+
+The message is identical regardless of underlying cause: an empty `stdout`, a non-zero `exit_code`, a stderr stack trace from the cursor SDK, an auth failure, or a missing config. The session bisected for half an hour before guessing — correctly — that manual dispatch was loading a different fleet config because `AGENT_FLEET_TARGET_CONFIG` was unset. That guess could have been a glance at a log line.
+
+## Root cause
+
+Two cooperating layers swallow the diagnostic.
+
+1. `agent_fleet/cursor_backend.py:312-320`. `CursorSession.send`'s bare `except Exception` returns a `CursorLLMResult(stdout="", stderr=str(exc), exit_code=1, ...)`. The exception type and traceback never reach the caller. `logger.exception` writes them to the agent_fleet logger, but the runner's log routing doesn't surface that to the per-dispatch log file.
+
+2. `agent_fleet/planner.py:81-105` and `:169-206`. `_extract_json` raises `ValueError("No JSON object found in LLM output")` for any input where the JSON-decode walk fails. Empty stdout falls into this branch indistinguishably from "stdout has prose but no JSON." The retry loop at `:175-205` (`max_retries=2`, 3 attempts total) reads `result.stdout` at `:197` and never inspects `result.exit_code` or `result.stderr`.
+
+There is also an upstream contributor: `agent_fleet/issue_loop/dispatch.py:37-189` does not require `AGENT_FLEET_TARGET_CONFIG`. When the env var is unset, `resolve_repo_config(workspace)` walks the filesystem looking for a `.agent-fleet/config.yaml` and may return a different target than the watcher used. The dispatch then runs against the wrong fleet config, which can cause the cursor session to fail in ways that look like "no JSON."
+
+The planner-bug PR addresses (1) and (2). The config-resolution divergence is fixed in the same PR because it is the proximate cause of the failures the diagnostics will now reveal, and fixing the diagnostics without fixing the divergence would just produce louder versions of the same bug.
+
+## Design
+
+### Change 1: `CursorSession.send` keeps the same return shape but attaches the original exception
+
+`CursorLLMResult` adds an optional `cause: BaseException | None = None` field. On the swallow path, the catch sets `cause=exc` before returning. Callers that want it can inspect `result.cause`; existing callers are unchanged.
+
+This preserves the current contract for the eight callers that read only `stdout`. The follow-up PR (out of scope here) migrates them to raise on `exit_code != 0`. That migration is `migrate-callers-then-delete-legacy-apis` territory and earns its own PR.
+
+### Change 2: `planner._extract_json` and the retry loop check `exit_code` and `stderr`
+
+In `planner.py:175-205`, after `result = session.send(...)`:
+
+- If `result.exit_code != 0` or `result.stdout.strip() == ""`, build an error message that includes `exit_code`, the last 500 chars of `stderr`, and (if present) `type(result.cause).__name__` and `str(result.cause)`. Do not retry on these — the cursor call itself failed, retrying will likely produce the same opaque failure. Raise immediately with the rich message.
+- Only the "got prose but no JSON" case is worth retrying. Keep `max_retries=2` for that branch.
+- The raised `ValueError` message format: `"PLAN cursor call failed: exit_code={n}, stderr_tail={...}, cause={...}"`. The runner's exception handler at `runner.py:736-748` already calls `logger.exception` which writes the full traceback; the message text is what shows up in `result.error` and on PR comments via the runner.
+
+### Change 3: `dispatch.py` fails loudly when config resolution is ambiguous
+
+`agent_fleet/issue_loop/dispatch.py:53-55` already exits 1 when `resolve_repo_config` returns None. Extend the check: if `AGENT_FLEET_TARGET_CONFIG` is unset *and* `find_repo_config` had to walk to find a match, log a warning naming the resolved path and the workspace. If both env vars (`AGENT_FLEET_WORKSPACE` and `AGENT_FLEET_TARGET_CONFIG`) are unset, exit 2 with a message telling the operator which env vars to set. This is not a code style change — it is the difference between a five-second log read and a thirty-minute bisect.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `agent_fleet/cursor_backend.py` | Add `cause` field to `CursorLLMResult`; populate in the catch at `:312-320`. |
+| `agent_fleet/planner.py` | At `:175-205`, branch on `exit_code` and empty stdout; raise rich error. |
+| `agent_fleet/issue_loop/dispatch.py` | At `:53-55`, distinguish unset-env vs walked-and-found-other; exit 2 on the former. |
+| `tests/test_planner.py` (or equivalent) | Add test that `plan(...)` raises with `exit_code` in the message when `session.send` returns `CursorLLMResult(exit_code=1, stderr="boom")`. |
+| `tests/test_cursor_session.py` | Add test that `CursorSession.send`'s swallow path populates `cause`. |
+| `tests/test_dispatch.py` (or new) | Add test that `main()` exits 2 when both env vars are unset. |
+
+## Verification
+
+### Static
+
+```
+cd /home/evan/Documents/agent-fleet
+uv run ruff check .
+uv run pytest -q tests/test_planner.py tests/test_cursor_session.py
+uv run pytest -q
+```
+
+### Runtime reproduction
+
+Reproduce the original failure with the new diagnostics. From `/home/evan/Documents/agent-fleet`, with `AGENT_FLEET_TARGET_CONFIG` deliberately unset:
+
+```
+unset AGENT_FLEET_TARGET_CONFIG
+ISSUE_NUMBER=1517 COMMENT_BODY="/agent --persona data" PERSONA=data \
+  AGENT_FLEET_WORKSPACE=/home/evan/Documents/silphcoanalytics \
+  python -m agent_fleet.issue_loop.dispatch 2>&1 | tail -40
+```
+
+Expected: exit 2 with a message naming `AGENT_FLEET_TARGET_CONFIG` as required. Not the old `ValueError: No JSON object found in LLM output`.
+
+Then with the env var set but a deliberately bad cursor API key:
+
+```
+export AGENT_FLEET_TARGET_CONFIG=/home/evan/Documents/silphcoanalytics/.agent-fleet/config.yaml
+CURSOR_API_KEY=invalid-on-purpose ISSUE_NUMBER=1517 ... python -m agent_fleet.issue_loop.dispatch 2>&1 | tail -40
+```
+
+Expected: `ValueError: PLAN cursor call failed: exit_code=1, stderr_tail=..., cause=...` with the cursor SDK's actual auth error visible in `stderr_tail` or `cause`.
+
+### Live regression
+
+The watcher path must keep working. Confirm by:
+
+```
+tail -n 0 -F ~/.agent-fleet/logs/watch.log &
+gh issue comment 1736 --repo glassmarkets/silphcoanalytics --body '/agent --persona data'
+# wait one watcher poll (~30 s)
+```
+
+Expected: the watcher logs `Issue #1736: dispatching persona=data` and spawns a process. The phase-1 changes must not alter the watcher's success path.
+
+## Rollback
+
+Single revert of the PR commit. No DB or state migration. `cause` field is additive on a dataclass; removing it is also additive in reverse.

--- a/plans/stable-autonomous/phase-2-auto-merge.md
+++ b/plans/stable-autonomous/phase-2-auto-merge.md
@@ -1,0 +1,83 @@
+# Phase 2 — Verify and harden auto-merge
+
+## Symptom
+
+User has had to `gh pr merge --squash` clean fleet PRs by hand for two driving sessions. The expectation per the original four-PR ask was that `pr_loop` would auto-merge on green.
+
+## What is actually true
+
+`pr_loop` already has the wiring.
+
+- `agent_fleet/pr_loop/config.py:30` — `auto_merge: bool = True` by default.
+- `agent_fleet/pr_loop/config.py:65` — same default when read from YAML.
+- `agent_fleet/pr_loop/lifecycle.py:828-881`:
+  - Line 828: `while True:` loop polling CI.
+  - Line 830: `wait_for_ci_green(ci_poll_s=10s)`.
+  - Line 835: break on green.
+  - Line 876: `if not loop_config.auto_merge: return LifecycleResult("ready", ...)`. We do not hit this branch with the default.
+  - Line 881: `try_merge(...)`.
+- `agent_fleet/pr_loop/github_ops.py:367-395` — `merge_pr` calls `gh pr merge --squash` (immediate), polls `MERGED` state up to 95 s. If `mergeStateStatus == BEHIND`, calls `gh pr update-branch`. If `DIRTY` — no handling. If `CLEAN` and squash succeeds — returns success.
+
+So either the lifecycle never reached `try_merge`, or `try_merge` returned a non-success and nothing retried.
+
+## Investigation step (do before writing code)
+
+Read `~/.agent-fleet/logs/watch.log` and `~/.agent-fleet/traces/spans-2026-05-27.jsonl` for the most recent fleet PR that went green and was not merged. Grep for `pr_loop.merge`, `pr_loop.ready`, `try_merge`. Three plausible outcomes:
+
+1. `pr_loop.ready` emitted with `auto_merge=False`: someone set the YAML to `false` for that target. Fix: revert the YAML override; no code change.
+2. `try_merge` emitted `mergeStateStatus=DIRTY` and stopped: PR 4 (main-drift) covers this. No PR 2 code change needed; PR 2 collapses into a comment in `lifecycle.py` noting "DIRTY handled by phase 4."
+3. `try_merge` succeeded per the log but the PR is still open per `gh pr view`: GitHub API lag or a polling bug. Investigate `merge_pr`'s 95 s timeout; extend or add a retry.
+4. The CI poll never breaks: `wait_for_ci_green` may be returning a sentinel that the break at `:835` doesn't recognize. Read the code at `:830-835` against the actual log.
+
+Pick the actual outcome before writing code. The scoping question is: is there a code defect, or did this PR's premise dissolve under inspection?
+
+## If outcome (1) — no code change
+
+Edit the relevant target config YAML in `~/.agent-fleet/` or `targets/`, set `auto_merge: true`. No PR.
+
+## If outcome (2) — defer to PR 4 entirely
+
+Open PR 2 as a small comment-only diff in `lifecycle.py:828` documenting that DIRTY is the responsibility of phase 4's drift detector. Or skip PR 2.
+
+## If outcome (3) or (4) — code change
+
+### Outcome 3 design
+
+`github_ops.py:367-395` polls `MERGED` state. If the poll loop hits its 95 s ceiling but GitHub reports `state != MERGED`, log the actual mergeable/mergeStateStatus pair and return failure. Lifecycle at `:881` checks the return and re-tries `try_merge` once after a 30 s sleep, capped at 3 attempts per lifecycle cycle.
+
+Idempotent: `gh pr merge --squash` on an already-merged PR returns success or a benign "already merged" error; the retry path tolerates both.
+
+### Outcome 4 design
+
+Read `pr_loop/ci.py` (or wherever `wait_for_ci_green` lives) to confirm the sentinel returned on green. If the comparison at `lifecycle.py:835` is `== "green"` and the helper returns an enum or a different string, fix the comparison. This is a one-line fix; the test is `tests/test_pr_loop_lifecycle.py` with a stub `wait_for_ci_green`.
+
+## Files touched (worst case)
+
+| File | Change |
+|---|---|
+| `agent_fleet/pr_loop/github_ops.py` | At `merge_pr`, distinguish poll-timeout-but-CLEAN from poll-timeout-with-different-state. Log both. |
+| `agent_fleet/pr_loop/lifecycle.py` | At `:881`, retry `try_merge` up to 3 times with backoff if the return is `(False, reason="poll_timeout")`. |
+| `tests/test_pr_loop_lifecycle.py` | Add test for the retry path with a stubbed `merge_pr` that returns timeout then success. |
+
+## Verification
+
+### Static
+
+```
+cd /home/evan/Documents/agent-fleet
+uv run pytest -q tests/test_pr_loop_lifecycle.py
+```
+
+### Runtime
+
+After phase 1 ships and the planner stops dying, dispatch one issue end-to-end:
+
+```
+gh issue comment 1736 --repo glassmarkets/silphcoanalytics --body '/agent --persona data'
+```
+
+Watch `~/.agent-fleet/logs/watch.log` for the PR open, CI green, and `pr_loop.merge` success spans. Acceptance: PR transitions from open → merged with zero human action.
+
+## Rollback
+
+Single revert. The retry loop is bounded so a regression is bounded too.

--- a/plans/stable-autonomous/phase-3-auto-dispatch.md
+++ b/plans/stable-autonomous/phase-3-auto-dispatch.md
@@ -1,0 +1,117 @@
+# Phase 3 — Label-driven backlog dispatcher
+
+## Symptom
+
+When the fleet drains, nothing happens until the user posts a `/agent --persona X` comment by hand. With a sized backlog, this is a human-bottleneck-by-design.
+
+## Design
+
+A new module reads GitHub issues labeled `fleet-ready`, picks a budget-respecting subset, and **posts `/agent --persona X` comments**. The watcher's existing comment-trigger path picks those comments up on its next 30 s poll and dispatches them. The dispatcher writes no state of its own.
+
+This is the `separate-before-serializing-shared-state` principle directly applied. The dispatcher and the watcher both have legitimate need to know what is in flight. Rather than coordinate via a new lock on `.agent-fleet-state.json`, the dispatcher uses GitHub comments as the message bus and lets the watcher remain the sole writer of `in_flight`.
+
+### New module: `agent_fleet/issue_loop/backlog_dispatcher.py`
+
+Class `BacklogDispatcher` with a single public method `dispatch_once(now: datetime) -> DispatchTickResult`.
+
+```
+BacklogDispatcher(
+  repo: TargetRepo,
+  capacity: FleetCapacityGate,
+  state_path: Path,
+  label: str = "fleet-ready",
+  persona_label_prefix: str = "fleet-persona/",
+  default_persona: str = "data",
+)
+```
+
+### `dispatch_once` algorithm
+
+1. Load current `.agent-fleet-state.json` (read-only; the watcher still owns writes).
+2. List open issues with the `fleet-ready` label via `gh issue list --repo <repo> --label fleet-ready --state open --json number,labels,title`.
+3. For each issue, determine eligibility (cheap checks first):
+   - **Skip if** the issue number is in `in_flight` (live PIDs only — reap dead ones first via `reap_in_flight`).
+   - **Skip if** any open PR exists with branch matching `agent-fleet/<persona>/<issue>` (GitHub query: `gh pr list --search "head:agent-fleet/..." --state open`).
+   - **Skip if** the issue has the `agent-running/<issue>` mutex label (set by `dispatch.py:66-71`).
+4. For each remaining issue, pick the persona:
+   - First label matching `fleet-persona/<X>` → `X`.
+   - Else `default_persona`.
+5. Ask `FleetCapacityGate.try_admit(persona=...)` whether the dispatch fits the per-persona, per-issue, fleet-wide budget. Stop iterating when the gate refuses.
+6. For each admitted issue, `gh issue comment <num> --body '/agent --persona <X> <!-- backlog-dispatcher -->'`. The trailing HTML comment is the marker the dispatcher uses on the *next* tick to know "we already asked; if the watcher hasn't dispatched, leave it alone for one more tick."
+7. Return `DispatchTickResult(considered=N, skipped_for_reason={...}, dispatched=[(issue_num, persona), ...])` for logging.
+
+### Idempotency
+
+`make-operations-idempotent` applies. If the dispatcher runs twice in 30 s before the watcher's first poll, it would re-post the comment. Mitigation: the marker comment check. The eligibility step adds:
+
+- **Skip if** the issue has a comment containing `<!-- backlog-dispatcher -->` within the last 5 minutes (`gh issue view --comments`, filtered client-side).
+
+This bounds re-posts to one every 5 minutes per issue worst case, even with a crashing dispatcher.
+
+### Wiring into `CombinedWatcher`
+
+`agent_fleet/issue_loop/watcher.py:302-318` already has the polling loop. Add a `BacklogDispatcher` per target, tick interval default 10 min (configurable per target). On each tick:
+
+```python
+result = backlog_dispatcher.dispatch_once(now)
+fleet_log.emit("backlog.tick", **asdict(result))
+```
+
+The watcher already has a per-target rate limiter; reuse it.
+
+### Config
+
+New section in `targets/<repo>.yaml`:
+
+```yaml
+backlog_dispatcher:
+  enabled: true
+  label: fleet-ready
+  persona_label_prefix: fleet-persona/
+  default_persona: data
+  tick_interval_s: 600
+```
+
+Default `enabled: false` for safety. Operator opts in per target.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `agent_fleet/issue_loop/backlog_dispatcher.py` | New module. |
+| `agent_fleet/issue_loop/watcher.py` | At `CombinedWatcher.poll_once`, run each target's backlog dispatcher tick. |
+| `agent_fleet/issue_loop/config.py` | Parse the new `backlog_dispatcher` section. |
+| `tests/test_backlog_dispatcher.py` | New. Mock `gh` responses; assert eligibility skip reasons; assert idempotent re-tick. |
+| `targets/glassmarkets-silphcoanalytics.yaml` (or equivalent) | Opt-in with `enabled: true`. |
+
+## Verification
+
+### Static
+
+```
+cd /home/evan/Documents/agent-fleet
+uv run pytest -q tests/test_backlog_dispatcher.py
+```
+
+### Runtime
+
+Apply the `fleet-ready` label to two issues (say #1736 and #1702). Restart the watcher with the new config:
+
+```
+gh issue edit 1736 --repo glassmarkets/silphcoanalytics --add-label fleet-ready
+gh issue edit 1702 --repo glassmarkets/silphcoanalytics --add-label fleet-ready
+systemctl --user restart agent-fleet-watcher  # or equivalent
+tail -F ~/.agent-fleet/logs/watch.log
+```
+
+Acceptance: within 10 minutes, `backlog.tick` span shows `dispatched=[(1736, data), (1702, data)]` (assuming capacity has room for both). Within 11 minutes, watcher logs show two dispatches kicked off.
+
+Then immediately remove the label from one issue and re-add it; verify the dispatcher does NOT re-comment because in_flight reflects the running dispatch.
+
+### Live regression
+
+The watcher's comment-trigger path must remain untouched by phase 3. Confirm by manually posting a `/agent` comment on a non-labeled issue and verifying it dispatches as before.
+
+## Rollback
+
+Set `backlog_dispatcher.enabled: false` in the target config and restart the watcher. The module stays in the tree; the runtime behavior reverts.

--- a/plans/stable-autonomous/phase-4-main-drift.md
+++ b/plans/stable-autonomous/phase-4-main-drift.md
@@ -1,0 +1,94 @@
+# Phase 4 — Main-drift detection in pr_loop
+
+## Symptom
+
+PR #2010 (silphcoanalytics issue #1399) generated commits for ~3 hours against a `pipeline/src/build_gold_sales_facts.py` shape that main had moved past via PR #2012 (compact parquet, `id_confidence` direction changed from `Float64` to `Utf8`). The conflict surfaced at merge time:
+
+```
+pipeline/tests/test_build_gold_sales_facts.py:102
+<<<<<<< HEAD
+    assert out.schema["id_confidence"] == pl.Float64
+=======
+    assert out.schema["id_confidence"] == pl.Utf8  # projected to Utf8 in unified schema
+>>>>>>> origin/main
+```
+
+The acceptance criteria itself had become stale — not a fixable conflict. `pr_loop` had no view into this until the merge gate hit DIRTY.
+
+## What pr_loop does today
+
+`agent_fleet/pr_loop/github_ops.py:578-582` — `_sync_branch_before_push` rebases the worktree against `origin/<branch>`, never against `origin/main`. `merge_pr` at `:367-395` reads `mergeStateStatus`; for `BEHIND` it calls `gh pr update-branch` (which merges main into the PR branch); for `DIRTY` it does nothing.
+
+So drift goes undetected until the very last step. The fix is to check drift at the *start* of every lifecycle cycle, not at merge time.
+
+## Design
+
+Add a drift-check at the top of each `lifecycle.run_cycle` iteration in `agent_fleet/pr_loop/lifecycle.py`.
+
+### Algorithm
+
+At cycle start, after refreshing the worktree (`checkout_branch`):
+
+1. `git fetch origin main` (in the PR worktree).
+2. `git merge-base --is-ancestor origin/main HEAD` — if true, no drift; continue.
+3. Else, `git merge --no-commit --no-ff origin/main` in a scratch state:
+   - Use `git merge-tree origin/main HEAD` to detect conflicts without touching the working tree. Simpler and reversible.
+4. If `merge-tree` reports no conflict markers, drift exists but is auto-mergeable. Run `gh pr update-branch` (the existing BEHIND path) and continue the cycle.
+5. If `merge-tree` reports conflict markers, drift is **unresolvable in this loop**:
+   - **Comment** on the PR with: which files conflicted, the main commit SHA of the conflicting merge base, and a one-line explanation that the PR's premise has changed.
+   - **Close** the PR with `gh pr close --delete-branch=false`.
+   - **Reopen** the source issue (parse `agent_fleet/<persona>/<issue>` from the branch name) with `gh issue reopen <num>` if it was closed, and post a comment naming the conflict and asking the next dispatcher to replan.
+   - Return `LifecycleResult("drift", "main moved out from under PR")`.
+
+### Idempotency
+
+`make-operations-idempotent` applies hard here. The lifecycle can re-enter; the close/reopen must not double-fire.
+
+- The PR comment carries a marker `<!-- pr_loop:drift-detected -->`. Before posting, check existing comments; skip if marker already present in the last 24 h.
+- `gh pr close` on an already-closed PR is a no-op (returns success). Safe.
+- `gh issue reopen` on an open issue is a no-op. Safe.
+- The issue replan comment carries `<!-- pr_loop:replan -->` and is similarly de-duped against the last 24 h.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `agent_fleet/pr_loop/lifecycle.py` | Add `_detect_drift(ctx)` called at `run_cycle` top. New `LifecycleResult("drift", ...)` outcome. |
+| `agent_fleet/pr_loop/github_ops.py` | Add `merge_tree_against(base: str) -> MergeTreeResult` helper. Add `comment_pr(num, body, marker)` and `close_pr(num)` if not already present. |
+| `agent_fleet/pr_loop/config.py` | Add `drift_check: bool = True` (default on; safe because the read path is just `git merge-tree`). |
+| `tests/test_pr_loop_drift.py` | New. Stub `git merge-tree` output for no-drift, auto-mergeable-drift, and conflict cases. Assert the close+reopen happens exactly once per cycle and is idempotent across cycles. |
+
+## Verification
+
+### Static
+
+```
+cd /home/evan/Documents/agent-fleet
+uv run pytest -q tests/test_pr_loop_drift.py
+```
+
+### Runtime
+
+Recreate the PR #2010 scenario at small scale:
+
+1. Branch off a stable commit on silphcoanalytics, open a fleet PR.
+2. Land a conflicting change on main directly (test target).
+3. Wait one pr_loop cycle on the fleet PR.
+
+Acceptance:
+- The PR receives one comment with the conflict file list and the `<!-- pr_loop:drift-detected -->` marker.
+- The PR is closed.
+- The source issue is reopened with a replan comment.
+- A second pr_loop cycle on the same PR (still closed) does NOT re-comment or re-close.
+
+### Live regression
+
+The non-drift path must remain fast. Time `lifecycle.run_cycle` before and after; the new drift check adds one `git fetch` and one `git merge-tree`, expected ~1-2 s overhead per cycle. If observed overhead is >5 s, gate the check to once per N cycles.
+
+## Open question
+
+Cursor agents could in principle resolve simple conflicts. Worth a follow-up PR after this one lands: if `git merge-tree` reports a low-complexity conflict (e.g., only `pyproject.toml` version bump), spawn a one-shot cursor session to resolve it. Out of scope for this PR — the conservative close-and-reopen is the right baseline.
+
+## Rollback
+
+Set `drift_check: false` in the target's pr_loop config and restart the watcher. Or single revert.

--- a/plans/stable-autonomous/testing.md
+++ b/plans/stable-autonomous/testing.md
@@ -1,0 +1,32 @@
+# Testing matrix
+
+| PR | Static (every PR) | Phase-specific unit tests | Runtime reproduction | Live regression check |
+|---|---|---|---|---|
+| 1 | `uv run ruff check .` + `uv run pytest -q` | `tests/test_planner.py` (rich error on `exit_code != 0`); `tests/test_cursor_session.py` (`cause` populated on swallow); `tests/test_dispatch.py` (exits 2 on missing env vars) | Unset `AGENT_FLEET_TARGET_CONFIG`, run `python -m agent_fleet.issue_loop.dispatch` for #1517; assert exit code 2 and named env var in stderr. Then set env vars + bad `CURSOR_API_KEY`; assert `PLAN cursor call failed: exit_code=...` with auth detail. | Comment `/agent --persona data` on a real issue; watcher dispatches; runner completes PLAN. |
+| 2 | Same | `tests/test_pr_loop_lifecycle.py` (retry path with stubbed `merge_pr` timeout-then-success) | Dispatch one issue end-to-end, observe PR open → green → merged with zero human action. | Watcher merge spans show `pr_loop.merge` success for the next 3 fleet PRs. |
+| 3 | Same | `tests/test_backlog_dispatcher.py` (skip reasons; capacity gating; marker-comment idempotency) | Label 2 issues `fleet-ready`; restart watcher; within 11 min, both dispatch. Re-toggle label; assert no double-dispatch. | Non-labeled issues still dispatch via existing comment-trigger path. |
+| 4 | Same | `tests/test_pr_loop_drift.py` (no-drift, auto-mergeable, hard conflict; close/reopen idempotency across cycles) | Create artificial conflict against main; observe one drift comment, PR close, issue reopen; second cycle silent. | `lifecycle.run_cycle` runtime overhead from drift check ≤ 5 s. |
+
+## End-to-end acceptance (all four PRs landed)
+
+One full autonomous cycle with zero human intervention for 30 minutes:
+
+1. A `fleet-ready` labeled issue gets a `/agent` comment from PR 3.
+2. Watcher dispatches; runner PLAN/RESEARCH/IMPLEMENT completes.
+3. PR opens, CI goes green, `try_merge` lands it (PR 2 retry path or vanilla `try_merge`).
+4. If main drifted mid-cycle, PR is closed and issue reopened with replan note (PR 4).
+5. `~/.agent-fleet/logs/watch.log` records the full cycle without manual intervention.
+
+If step 5 fails — manual `/agent` comments or manual merges happen during the 30 min — the plan failed even if every per-PR test passes.
+
+## Verification of plan itself
+
+Before implementation starts, run a `figure-it-out`-style dry-run review:
+
+- Confirm `auto_merge` is already `True` by default (it is — `pr_loop/config.py:30`).
+- Confirm watcher's `AGENT_FLEET_TARGET_CONFIG` env injection (`watcher.py:150`).
+- Confirm silphcoanalytics has no branch protection (confirmed: free plan, `gh pr merge --auto` is no-op).
+- Confirm `dispatch.py` exit-1 path at `:53-55` (manual dispatch divergence cause).
+- Confirm `pr_loop/github_ops.py:582` rebases against `origin/<branch>` only (no main rebase).
+
+All five confirmed during exploration. The plan is grounded.

--- a/tests/test_cursor_session.py
+++ b/tests/test_cursor_session.py
@@ -198,6 +198,29 @@ def test_session_send_hard_fails_when_mcp_required_but_unused(
     assert result.mcp_tool_calls == ()
 
 
+def test_session_send_populates_cause_when_sdk_raises(
+    fake_sdk: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """When the underlying SDK send() raises, the swallow path must record the
+    original exception on CursorLLMResult.cause so callers (the planner) can
+    surface a real diagnostic instead of an empty stdout."""
+    boom = RuntimeError("upstream transport timeout")
+    agent = MagicMock(
+        agent_id="agent-xyz",
+        send=MagicMock(side_effect=boom),
+        dispose=MagicMock(),
+    )
+    fake_sdk.Agent.create.return_value = agent
+    backend = CursorBackend(api_key="x")
+    sess = backend.create_session(persona_name="coder", cwd=tmp_path)
+    result = sess.send("hi", max_tokens=1, timeout_s=1)
+    assert result.exit_code == 1
+    assert result.cause is boom
+    assert "RuntimeError" in result.stderr
+    assert "upstream transport timeout" in result.stderr
+
+
 def test_session_send_maps_error_status_to_nonzero_exit(
     fake_sdk: MagicMock,
     tmp_path: Path,

--- a/tests/test_dispatch_env_guard.py
+++ b/tests/test_dispatch_env_guard.py
@@ -1,0 +1,60 @@
+"""Tests for the dispatch.py env-var guard against silent cwd fallback."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _run_dispatch(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "agent_fleet.issue_loop.dispatch"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_dispatch_refuses_when_neither_workspace_nor_target_config_set() -> None:
+    """Without AGENT_FLEET_WORKSPACE or AGENT_FLEET_TARGET_CONFIG, dispatch
+    silently used Path.cwd() and could resolve the controller's own config as
+    the target. Now it must exit 2 with a named error."""
+    proc = _run_dispatch(
+        {
+            "PATH": "/usr/bin:/bin",
+            "ISSUE_NUMBER": "999",
+            "PERSONA": "data",
+        }
+    )
+    assert proc.returncode == 2, proc.stderr
+    assert "AGENT_FLEET_WORKSPACE" in proc.stderr
+    assert "AGENT_FLEET_TARGET_CONFIG" in proc.stderr
+
+
+def test_dispatch_rejects_unset_issue_number_before_env_guard() -> None:
+    """ISSUE_NUMBER validation must still fire before the workspace guard;
+    operator typo on issue number should yield the existing exit 1, not the
+    new exit 2."""
+    proc = _run_dispatch({"PATH": "/usr/bin:/bin"})
+    assert proc.returncode == 1, proc.stderr
+    assert "ISSUE_NUMBER" in proc.stderr
+
+
+def test_dispatch_passes_env_guard_when_workspace_set(tmp_path: Path) -> None:
+    """Setting AGENT_FLEET_WORKSPACE alone (no target_config) must clear the
+    guard. The dispatch itself will fail later (no .agent-fleet.yaml in
+    tmp_path) — but with the existing exit 1 path, not the guard's exit 2."""
+    proc = _run_dispatch(
+        {
+            "PATH": "/usr/bin:/bin",
+            "ISSUE_NUMBER": "999",
+            "PERSONA": "data",
+            "AGENT_FLEET_WORKSPACE": str(tmp_path),
+        }
+    )
+    assert proc.returncode != 2, proc.stderr

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,121 @@
+"""Tests for the planner phase error-surfacing path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from agent_fleet.cursor_backend import CursorLLMResult
+from agent_fleet.planner import plan
+
+
+class _FakePersonaResolver:
+    def list_personas(self) -> list[str]:
+        return ["data", "backend", "frontend"]
+
+    def load(self, name: str):  # noqa: ANN202
+        raise NotImplementedError
+
+
+@dataclass
+class _FakeSession:
+    """LLMSession stub that returns canned CursorLLMResults."""
+
+    result: CursorLLMResult
+    sends: list[str] = field(default_factory=list)
+    agent_id: str | None = "agent-fake"
+
+    def send(self, prompt: str, **_: object) -> CursorLLMResult:
+        self.sends.append(prompt)
+        return self.result
+
+    def dispose(self) -> None:
+        pass
+
+
+class _FakeBackend:
+    def run(self, *_a: object, **_kw: object) -> CursorLLMResult:
+        raise AssertionError("backend.run should not be called when session is provided")
+
+
+def test_plan_raises_with_diagnostics_on_nonzero_exit_code() -> None:
+    """When the LLM call fails (exit_code != 0), plan() must surface the
+    backend's stderr instead of masking it as 'no JSON in output'."""
+    boom = RuntimeError("cursor SDK auth failure")
+    session = _FakeSession(
+        result=CursorLLMResult(
+            stdout="",
+            stderr="RuntimeError: cursor SDK auth failure",
+            exit_code=1,
+            duration_s=0.1,
+            cause=boom,
+        )
+    )
+    with pytest.raises(ValueError) as excinfo:
+        plan(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            backend=_FakeBackend(),  # type: ignore[arg-type]
+            persona_resolver=_FakePersonaResolver(),  # type: ignore[arg-type]
+            session=session,  # type: ignore[arg-type]
+        )
+
+    msg = str(excinfo.value)
+    assert "PLAN backend call failed" in msg
+    assert "exit_code=1" in msg
+    assert "cursor SDK auth failure" in msg
+    assert "RuntimeError" in msg
+    # Should not retry on backend failure — single send.
+    assert len(session.sends) == 1
+
+
+def test_plan_raises_with_diagnostics_on_empty_stdout() -> None:
+    """Empty stdout with exit_code=0 (rare but possible) must still surface as
+    a backend-call failure, not the misleading 'no JSON' error."""
+    session = _FakeSession(
+        result=CursorLLMResult(
+            stdout="   \n  ",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+        )
+    )
+    with pytest.raises(ValueError) as excinfo:
+        plan(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            backend=_FakeBackend(),  # type: ignore[arg-type]
+            persona_resolver=_FakePersonaResolver(),  # type: ignore[arg-type]
+            session=session,  # type: ignore[arg-type]
+        )
+    assert "PLAN backend call failed" in str(excinfo.value)
+    assert len(session.sends) == 1
+
+
+def test_plan_still_retries_on_unparseable_prose() -> None:
+    """When the model returns non-JSON prose with exit_code=0, the old retry
+    loop must still kick in — that's the original use case."""
+    session = _FakeSession(
+        result=CursorLLMResult(
+            stdout="here is some prose without any json structure",
+            stderr="",
+            exit_code=0,
+            duration_s=0.1,
+        )
+    )
+    with pytest.raises(ValueError) as excinfo:
+        plan(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            backend=_FakeBackend(),  # type: ignore[arg-type]
+            persona_resolver=_FakePersonaResolver(),  # type: ignore[arg-type]
+            session=session,  # type: ignore[arg-type]
+            max_retries=2,
+        )
+    # The old behaviour: retry 3 times (initial + 2 retries) on parse failure.
+    assert len(session.sends) == 3
+    assert "No JSON object found" in str(excinfo.value)


### PR DESCRIPTION
## Summary

The planner reported \`No JSON object found in LLM output\` for every backend failure. Three layers conspired to discard the underlying diagnostic; this PR fixes all three.

1. **`CursorSession.send` swallowed exceptions silently.** It returned `CursorLLMResult(stdout="", exit_code=1)` with `stderr=str(exc)`, but the exception type was thrown away. New `CursorLLMResult.cause: BaseException | None` field carries the original exception through the boundary.

2. **`planner._extract_json` parsed `stdout` regardless of `exit_code`.** A backend transport timeout or auth error burned the full retry budget producing the same opaque parse error. New pre-parse check: if `exit_code != 0` or `stdout.strip()` is empty, raise immediately with `exit_code`, `stderr` tail, and `cause` type+message. The prose-without-JSON retry path is preserved.

3. **`issue_loop/dispatch.main()` defaulted to `Path.cwd()`.** Manual invocations from agent-fleet's own checkout silently resolved the controller's own `.agent-fleet.yaml` as the "target", running dispatch against the wrong workspace. New env-var guard: refuse to run when neither `AGENT_FLEET_WORKSPACE` nor `AGENT_FLEET_TARGET_CONFIG` is set; exit 2 with a named message. Watcher path always sets one of these, so it's unaffected.

## Verification matrix

| Layer | Verification | Result |
|---|---|---|
| `CursorLLMResult.cause` | `test_session_send_populates_cause_when_sdk_raises` | pass |
| Planner exit_code/empty stdout pre-check | `test_planner.py::test_plan_raises_with_diagnostics_on_nonzero_exit_code` + `…_on_empty_stdout` | pass |
| Planner retry path preserved | `test_planner.py::test_plan_still_retries_on_unparseable_prose` | pass |
| dispatch.py env guard | `test_dispatch_env_guard.py` (3 subprocess tests) | pass |
| Runtime reproduction | `env -i PATH=… ISSUE_NUMBER=999 PERSONA=data uv run python -m agent_fleet.issue_loop.dispatch` | exit=2 with refusal message |
| Regression | `pytest -q` | 307 passed, 3 skipped |
| Lint | `ruff check` | clean |

## Test plan

- [x] Unit tests for all three layers
- [x] Subprocess test for env guard (the change is in `main()`, not importable)
- [x] Full test suite green
- [x] Ruff clean
- [x] Runtime repro of original failure mode shows new diagnostic instead of silent fallback

## Background

Discovered during the silphcoanalytics fleet driving session. Manual dispatch on issue #1690 (silphco) failed with the cryptic "No JSON object found" error. Tracing showed the cursor SDK was hitting a transport failure that `CursorSession.send`'s boundary catch was swallowing. This PR is Phase 1 of a four-PR plan to reach stable autonomy (see `plans/stable-autonomous/overview.md`). Phases 2-4 (auto-merge, backlog auto-dispatch, main-drift detection) land in follow-up PRs.