### PR TITLE
feat(pr_loop): surface failed and ignored-failed check names in CI gate

### DIFF
--- a/agent_fleet/pr_loop/github_ops.py
+++ b/agent_fleet/pr_loop/github_ops.py
@@ -197,13 +197,34 @@ def pr_comments(pr_number: int, *, cwd: Path | None = None) -> list[dict[str, An
     return json.loads(result.stdout).get("comments", [])
 
 
+@dataclass(frozen=True)
+class PrChecksSnapshot:
+    """All buckets the merge gate cares about, with ignored checks called out
+    separately so a debug log line can show ``failed=[...] ignored_failed=[...]``
+    side-by-side. Knowing which check the loop saw as failing is the entire
+    diagnostic when the merge gate refuses to merge a PR that GitHub considers
+    mergeable.
+    """
+
+    all_filtered: list[dict[str, Any]]
+    pending: list[dict[str, Any]]
+    failed: list[dict[str, Any]]
+    ignored_failed: list[dict[str, Any]]
+
+
 def pr_checks(
     pr_number: int,
     *,
     cwd: Path | None = None,
     ignored: tuple[str, ...] = (),
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return (all_checks, pending, failed) excluding ignored check names."""
+) -> PrChecksSnapshot:
+    """Snapshot of CI checks for the merge gate.
+
+    ``ignored`` names are removed from ``all_filtered`` (and therefore from
+    ``pending`` / ``failed``). Any of those ignored checks that happened to be
+    in ``bucket=fail`` are surfaced via ``ignored_failed`` for diagnostics —
+    callers that want to log "we suppressed failure X" can read that field.
+    """
     result = _gh(
         "pr",
         "checks",
@@ -214,17 +235,22 @@ def pr_checks(
         check=False,
     )
     if result.returncode != 0 or not result.stdout.strip():
-        return [], [], []
+        return PrChecksSnapshot([], [], [], [])
     try:
         checks = json.loads(result.stdout)
     except json.JSONDecodeError:
-        return [], [], []
+        return PrChecksSnapshot([], [], [], [])
 
     ignored_set = {name.lower() for name in ignored}
     filtered = [check for check in checks if str(check.get("name", "")).lower() not in ignored_set]
+    ignored_failed = [
+        c
+        for c in checks
+        if str(c.get("name", "")).lower() in ignored_set and c.get("bucket") == "fail"
+    ]
     pending = [c for c in filtered if c.get("bucket") == "pending"]
     failed = [c for c in filtered if c.get("bucket") == "fail"]
-    return filtered, pending, failed
+    return PrChecksSnapshot(filtered, pending, failed, ignored_failed)
 
 
 def pr_changed_files(pr_number: int, *, cwd: Path | None = None) -> list[str]:

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -432,18 +432,22 @@ def wait_for_ci_green(
 ) -> LifecycleResult:
     deadline = time.time() + (timeout_s or loop_config.ci_poll_timeout_s)
     while time.time() < deadline:
-        all_checks, pending, failed = github_ops.pr_checks(
+        snap = github_ops.pr_checks(
             pr_number,
             cwd=repo_root,
             ignored=loop_config.ignored_ci_checks,
         )
-        if not all_checks:
+        if not snap.all_filtered:
             time.sleep(loop_config.ci_register_poll_s)
             continue
-        if failed:
-            names = [str(c.get("name", "")) for c in failed]
-            return LifecycleResult("ci_failed", f"Failed checks: {names}")
-        if not pending:
+        if snap.failed:
+            names = [str(c.get("name", "")) for c in snap.failed]
+            ignored_names = [str(c.get("name", "")) for c in snap.ignored_failed]
+            return LifecycleResult(
+                "ci_failed",
+                f"Failed checks: {names}; suppressed-fails: {ignored_names}",
+            )
+        if not snap.pending:
             return LifecycleResult("ci_green", "All checks passed")
         time.sleep(loop_config.ci_poll_s)
     return LifecycleResult("ci_timeout", "CI did not pass within timeout")
@@ -841,18 +845,21 @@ def _run_pr_lifecycle_body(
             )
             return ci
         ci_fix_attempts += 1
+        snap = github_ops.pr_checks(
+            pr_number,
+            cwd=repo_root,
+            ignored=loop_config.ignored_ci_checks,
+        )
+        failed_names = [str(c.get("name", "")) for c in snap.failed]
+        ignored_failed_names = [str(c.get("name", "")) for c in snap.ignored_failed]
         fleet_log.emit(
             "pr_loop.ci.fix",
             pr_number=pr_number,
             attempt=ci_fix_attempts,
             max_attempts=loop_config.max_ci_fix_attempts,
+            failed_checks=failed_names,
+            ignored_failed_checks=ignored_failed_names,
         )
-        _all, _pending, failed = github_ops.pr_checks(
-            pr_number,
-            cwd=repo_root,
-            ignored=loop_config.ignored_ci_checks,
-        )
-        failed_names = [str(c.get("name", "")) for c in failed]
         wt = github_ops.checkout_branch(branch, wt, repo_root=repo_root)
         fixed = attempt_ci_fix(
             pr_number=pr_number,

--- a/agent_fleet/pr_loop/watcher.py
+++ b/agent_fleet/pr_loop/watcher.py
@@ -184,11 +184,13 @@ class PrLoopWatcher:
             if entry.get("parked"):
                 continue
 
-            _all, pending, failed = github_ops.pr_checks(
+            snap = github_ops.pr_checks(
                 pr_number,
                 cwd=self.repo.repo_root,
                 ignored=self.loop_config.ignored_ci_checks,
             )
+            pending = snap.pending
+            failed = snap.failed
 
             comments = github_ops.pr_comments(pr_number, cwd=self.repo.repo_root)
             review_body = find_reviewer_comment(comments, marker=marker)

--- a/tests/test_pr_loop.py
+++ b/tests/test_pr_loop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from agent_fleet.pr_loop import github_ops
 from agent_fleet.pr_loop.config import load_pr_loop_config
 from agent_fleet.pr_loop.review_parse import (
     find_reviewer_comment,
@@ -332,10 +333,11 @@ def test_poll_once_parks_after_max_ci_timeout_attempts(tmp_path: Path) -> None:
         # One failed check with fix_attempts < max forces lifecycle to run.
         patch(
             "agent_fleet.pr_loop.watcher.github_ops.pr_checks",
-            return_value=(
-                [{"name": "ci"}],
-                [],
-                [{"name": "ci"}],
+            return_value=github_ops.PrChecksSnapshot(
+                all_filtered=[{"name": "ci"}],
+                pending=[],
+                failed=[{"name": "ci"}],
+                ignored_failed=[],
             ),
         ),
         patch("agent_fleet.pr_loop.watcher.github_ops.pr_comments", return_value=[]),
@@ -398,7 +400,12 @@ def test_poll_once_parks_on_blocked_outcome(tmp_path: Path) -> None:
         patch("agent_fleet.pr_loop.watcher.github_ops.pr_has_label", return_value=False),
         patch(
             "agent_fleet.pr_loop.watcher.github_ops.pr_checks",
-            return_value=([{"name": "ci"}], [], [{"name": "ci"}]),
+            return_value=github_ops.PrChecksSnapshot(
+                all_filtered=[{"name": "ci"}],
+                pending=[],
+                failed=[{"name": "ci"}],
+                ignored_failed=[],
+            ),
         ),
         patch("agent_fleet.pr_loop.watcher.github_ops.pr_comments", return_value=[]),
         patch(

--- a/tests/test_pr_loop_ci_gate_diagnostics.py
+++ b/tests/test_pr_loop_ci_gate_diagnostics.py
@@ -1,0 +1,117 @@
+"""Tests for pr_loop CI-gate diagnostic surfacing.
+
+The original failure mode: the loop reported `ci_failed` for fleet PRs whose
+only failing check was on the `ignored_ci_checks` list. There was no
+diagnostic in the trace explaining which check the gate considered failed.
+These tests pin the new behavior — `PrChecksSnapshot.ignored_failed` is
+populated and `wait_for_ci_green` puts both lists in the LifecycleResult
+detail.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from agent_fleet.pr_loop import github_ops
+from agent_fleet.pr_loop.config import PrLoopConfig
+from agent_fleet.pr_loop.lifecycle import wait_for_ci_green
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _checks_payload(checks: list[dict[str, str]]) -> bytes:
+    import json
+
+    return json.dumps(checks).encode()
+
+
+def test_pr_checks_separates_ignored_failed_from_real_failed() -> None:
+    fake_stdout = _checks_payload(
+        [
+            {"name": "composer pr analysis", "state": "FAILURE", "bucket": "fail"},
+            {"name": "frontend tests", "state": "SUCCESS", "bucket": "pass"},
+            {"name": "real ci check", "state": "FAILURE", "bucket": "fail"},
+        ]
+    ).decode()
+
+    class _Result:
+        returncode = 0
+        stdout = fake_stdout
+
+    with patch("agent_fleet.pr_loop.github_ops._gh", return_value=_Result()):
+        snap = github_ops.pr_checks(
+            42,
+            cwd=None,
+            ignored=("composer pr analysis", "kimi pr analysis"),
+        )
+
+    assert [c["name"] for c in snap.failed] == ["real ci check"]
+    assert [c["name"] for c in snap.ignored_failed] == ["composer pr analysis"]
+    assert [c["name"] for c in snap.all_filtered] == ["frontend tests", "real ci check"]
+
+
+def test_pr_checks_returns_empty_ignored_failed_when_only_real_failures() -> None:
+    fake_stdout = _checks_payload(
+        [
+            {"name": "real ci check", "state": "FAILURE", "bucket": "fail"},
+        ]
+    ).decode()
+
+    class _Result:
+        returncode = 0
+        stdout = fake_stdout
+
+    with patch("agent_fleet.pr_loop.github_ops._gh", return_value=_Result()):
+        snap = github_ops.pr_checks(42, cwd=None, ignored=("composer pr analysis",))
+
+    assert [c["name"] for c in snap.failed] == ["real ci check"]
+    assert snap.ignored_failed == []
+
+
+def test_wait_for_ci_green_detail_lists_suppressed_fails(tmp_path: Path) -> None:
+    """The previously-opaque ci_failed detail must now name both the gating
+    failures AND any ignored-but-failing checks. This is the diagnostic that
+    lets an operator see at a glance whether the filter is doing its job."""
+    snap = github_ops.PrChecksSnapshot(
+        all_filtered=[{"name": "real ci check", "bucket": "fail"}],
+        pending=[],
+        failed=[{"name": "real ci check", "bucket": "fail"}],
+        ignored_failed=[{"name": "composer pr analysis", "bucket": "fail"}],
+    )
+    with patch("agent_fleet.pr_loop.lifecycle.github_ops.pr_checks", return_value=snap):
+        result = wait_for_ci_green(
+            42,
+            repo_root=tmp_path,
+            loop_config=PrLoopConfig(),
+            timeout_s=1,
+        )
+
+    assert result.status == "ci_failed"
+    assert "real ci check" in result.detail
+    assert "suppressed-fails" in result.detail
+    assert "composer pr analysis" in result.detail
+
+
+def test_wait_for_ci_green_returns_green_when_only_ignored_check_failed(
+    tmp_path: Path,
+) -> None:
+    """The whole point of the ignored filter: composer pr analysis failing
+    must NOT block the merge gate. This pins that behavior so a future change
+    can't regress it silently."""
+    snap = github_ops.PrChecksSnapshot(
+        all_filtered=[{"name": "frontend tests", "bucket": "pass"}],
+        pending=[],
+        failed=[],
+        ignored_failed=[{"name": "composer pr analysis", "bucket": "fail"}],
+    )
+    with patch("agent_fleet.pr_loop.lifecycle.github_ops.pr_checks", return_value=snap):
+        result = wait_for_ci_green(
+            42,
+            repo_root=tmp_path,
+            loop_config=PrLoopConfig(),
+            timeout_s=1,
+        )
+
+    assert result.status == "ci_green"


### PR DESCRIPTION
## Summary

Diagnostic surfacing for the pr_loop CI gate, applying the same pattern as Phase 1 (PR #38): when the merge gate refuses to merge, the operator must see exactly which check it reacted to.

## Evidence motivating the change

Every recent silphcoanalytics fleet PR (#2006, #2008, #2009, #2010, #2011, #2012) had only \`composer pr analysis\` in \`bucket=fail\` on GitHub. That check name is on the default \`ignored_ci_checks\` list. Yet \`pr_loop.ci.fix\` fired for each PR in the trace, meaning \`wait_for_ci_green\` returned \`ci_failed\`. The trace did not record which check the gate was reacting to, so this couldn't be root-caused.

## Changes

- \`pr_checks\` now returns \`PrChecksSnapshot(all_filtered, pending, failed, ignored_failed)\` instead of a 3-tuple. \`ignored_failed\` surfaces checks that matched the ignored filter AND were in \`bucket=fail\`.
- \`wait_for_ci_green\`'s \`ci_failed\` \`LifecycleResult.detail\` now includes \`suppressed-fails: [...]\` alongside the gating failed list.
- \`pr_loop.ci.fix\` span gains \`failed_checks\` and \`ignored_failed_checks\` attributes.
- 4 callers migrated to the dataclass (lifecycle x2, watcher, tests x2).

## Tests

- \`tests/test_pr_loop_ci_gate_diagnostics.py\`: 4 cases pinning the new contract:
  - \`pr_checks\` separates ignored-failed from real-failed.
  - \`pr_checks\` returns empty \`ignored_failed\` when there are only real failures.
  - \`wait_for_ci_green\` detail names suppressed fails.
  - \`wait_for_ci_green\` returns \`ci_green\` when the only failure is ignored.
- 304 passed, 3 skipped.
- \`ruff check\` clean.

## Test plan

- [x] Unit tests covering the new contract
- [x] Existing pr_loop tests migrated to \`PrChecksSnapshot\`
- [x] Full suite green
- [x] Ruff clean
- [ ] Runtime: next fleet PR that hits \`ci_failed\` will name the failing check in trace + detail

## Background

Discovered during the silphcoanalytics autonomous-fleet driving session. The original Phase 2 plan speculated about 4 outcomes (config error, drift, polling bug, sentinel mismatch); the data fit none of them. Reframed the PR around what we actually need: instrumentation, not a speculative fix. Once instrumented, the next fleet run will reveal whether the filter is broken, whether a different check is failing, or whether stale agent-fleet code was running.

This is part of the four-PR plan to reach autonomous-stable fleet (see \`plans/stable-autonomous/overview.md\` from PR #38). Phase 3 (backlog auto-dispatch) and Phase 4 (main-drift detection) land in follow-up PRs.