### PR TITLE
feat(pr_loop): detect main-drift at lifecycle start and close stale PRs

### DIFF
--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -159,20 +159,24 @@ def cmd_loop(args: argparse.Namespace) -> int:
     watcher = PrLoopWatcher(repo, repo.pr_loop, fleet_config=config)
     if args.pr_number:
         branch = args.branch
-        if not branch:
-            import subprocess
+        base_ref_name = ""
+        import subprocess
 
-            result = subprocess.run(
-                ["gh", "pr", "view", str(args.pr_number), "--json", "headRefName"],
-                capture_output=True,
-                text=True,
-                check=False,
-                cwd=workspace,
-            )
-            if result.returncode != 0:
-                print("error: --branch required or gh must resolve PR head", file=sys.stderr)
-                return 1
-            branch = json.loads(result.stdout).get("headRefName", "")
+        view = subprocess.run(
+            ["gh", "pr", "view", str(args.pr_number), "--json", "headRefName,baseRefName"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=workspace,
+        )
+        if view.returncode == 0:
+            payload = json.loads(view.stdout)
+            if not branch:
+                branch = payload.get("headRefName", "")
+            base_ref_name = payload.get("baseRefName", "")
+        if not branch:
+            print("error: --branch required or gh must resolve PR head", file=sys.stderr)
+            return 1
 
         result = run_pr_lifecycle(
             pr_number=args.pr_number,
@@ -181,6 +185,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
             loop_config=repo.pr_loop,
             fleet_config=config,
             skip_review_wait=bool(args.skip_review_wait),
+            base_ref_name=base_ref_name,
         )
         print(json.dumps({"status": result.status, "detail": result.detail}, indent=2))
         return 0 if result.status in {"merged", "ready", "no_findings", "ci_green"} else 1

--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -174,6 +174,12 @@ def cmd_loop(args: argparse.Namespace) -> int:
             if not branch:
                 branch = payload.get("headRefName", "")
             base_ref_name = payload.get("baseRefName", "")
+        if not base_ref_name:
+            print(
+                f"warning: could not resolve baseRefName for PR #{args.pr_number}; "
+                f"drift will be judged against repo.default_branch",
+                file=sys.stderr,
+            )
         if not branch:
             print("error: --branch required or gh must resolve PR head", file=sys.stderr)
             return 1

--- a/agent_fleet/dispatcher_task.py
+++ b/agent_fleet/dispatcher_task.py
@@ -24,10 +24,14 @@ if TYPE_CHECKING:
 
 
 def _resolve_pr_base_ref(pr_number: int, workspace: object | None) -> str:
-    """Fetch baseRefName via `gh pr view`; return empty string on any failure."""
+    """Fetch baseRefName via `gh pr view`; log + return "" on any failure so the
+    caller falls back to repo.default_branch with a visible warning rather than
+    silently judging drift against the wrong base."""
     import json
+    import logging
     import subprocess
 
+    logger = logging.getLogger(__name__)
     cwd = str(workspace) if workspace else None
     try:
         view = subprocess.run(
@@ -37,14 +41,36 @@ def _resolve_pr_base_ref(pr_number: int, workspace: object | None) -> str:
             check=False,
             cwd=cwd,
         )
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "gh pr view baseRefName failed for PR #%s: %s; drift will use repo.default_branch",
+            pr_number,
+            exc,
+        )
         return ""
     if view.returncode != 0:
+        logger.warning(
+            "gh pr view baseRefName for PR #%s exited %s: %s; drift will use repo.default_branch",
+            pr_number,
+            view.returncode,
+            (view.stderr or "").strip()[:200],
+        )
         return ""
     try:
-        return str(json.loads(view.stdout).get("baseRefName") or "")
-    except (ValueError, json.JSONDecodeError):
+        base = str(json.loads(view.stdout).get("baseRefName") or "")
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "gh pr view JSON parse failed for PR #%s: %s; drift will use repo.default_branch",
+            pr_number,
+            exc,
+        )
         return ""
+    if not base:
+        logger.warning(
+            "gh pr view returned empty baseRefName for PR #%s; drift will use repo.default_branch",
+            pr_number,
+        )
+    return base
 
 
 def _stderr_from_phases(phase_results: list[dict[str, object]]) -> str:

--- a/agent_fleet/dispatcher_task.py
+++ b/agent_fleet/dispatcher_task.py
@@ -23,6 +23,30 @@ if TYPE_CHECKING:
     from agent_fleet.repo import RepoConfig
 
 
+def _resolve_pr_base_ref(pr_number: int, workspace: object | None) -> str:
+    """Fetch baseRefName via `gh pr view`; return empty string on any failure."""
+    import json
+    import subprocess
+
+    cwd = str(workspace) if workspace else None
+    try:
+        view = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "baseRefName"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd,
+        )
+    except (OSError, ValueError):
+        return ""
+    if view.returncode != 0:
+        return ""
+    try:
+        return str(json.loads(view.stdout).get("baseRefName") or "")
+    except (ValueError, json.JSONDecodeError):
+        return ""
+
+
 def _stderr_from_phases(phase_results: list[dict[str, object]]) -> str:
     for item in reversed(phase_results):
         raw = item.get("stderr")
@@ -251,6 +275,7 @@ def maybe_publish_and_pr_loop(
     ):
         from agent_fleet.pr_loop.lifecycle import run_pr_lifecycle
 
+        base_ref_name = _resolve_pr_base_ref(pr_number, run_workspace)
         loop_result = run_pr_lifecycle(
             pr_number=pr_number,
             branch=task_workspace.branch_name,
@@ -260,6 +285,7 @@ def maybe_publish_and_pr_loop(
             worktree=run_workspace,
             skip_review_wait=False,
             persona=task.persona,
+            base_ref_name=base_ref_name,
         )
         pr_loop_status = loop_result.status
         if loop_result.status == "merged":

--- a/agent_fleet/pr_loop/config.py
+++ b/agent_fleet/pr_loop/config.py
@@ -33,6 +33,7 @@ class PrLoopConfig:
     ignored_ci_checks: tuple[str, ...] = field(
         default_factory=lambda: ("composer pr analysis", "kimi pr analysis")
     )
+    drift_check: bool = True
 
 
 def load_pr_loop_config(_repo_root: Path, raw: dict[str, Any] | None) -> PrLoopConfig | None:
@@ -66,4 +67,5 @@ def load_pr_loop_config(_repo_root: Path, raw: dict[str, Any] | None) -> PrLoopC
         fix_persona=(str(section["fix_persona"]) if section.get("fix_persona") else None),
         ci_fix_persona=(str(section["ci_fix_persona"]) if section.get("ci_fix_persona") else None),
         ignored_ci_checks=tuple(str(c).lower() for c in ignored),
+        drift_check=bool(section.get("drift_check", True)),
     )

--- a/agent_fleet/pr_loop/github_ops.py
+++ b/agent_fleet/pr_loop/github_ops.py
@@ -171,7 +171,7 @@ def list_open_fleet_prs(
         "--state",
         "open",
         "--json",
-        "number,headRefName,headRefOid,labels,isDraft,mergeable,mergeStateStatus,createdAt",
+        "number,headRefName,headRefOid,baseRefName,labels,isDraft,mergeable,mergeStateStatus,createdAt",
         "--limit",
         "50",
         cwd=cwd,
@@ -412,14 +412,17 @@ class MergeTreeResult:
     """True when main merges into the branch without conflicts."""
     conflict_files: tuple[str, ...]
     """File paths that have conflict markers (empty when clean)."""
+    git_error: bool = False
+    """True when git itself failed (bad ref, wrong cwd, version mismatch, etc.).
+    Callers must NOT treat this as a conflict."""
 
 
 def merge_tree_against(base: str, head: str, *, cwd: Path) -> MergeTreeResult:
     """Dry-run merge of *base* into *head* without touching the working tree.
 
     Uses ``git merge-tree --write-tree --name-only <head> <base>`` (git >= 2.38).
-    Exit code 1 means conflicts; exit code 0 means clean.  The ``--name-only``
-    flag makes stdout a list of conflict file names, one per line.
+    Exit code 0 means clean; exit code 1 means conflicts; any other exit code is
+    a git error (bad ref, missing binary, etc.) and must NOT be treated as conflict.
     """
     result = _git_run(
         ["git", "merge-tree", "--write-tree", "--name-only", head, base],
@@ -428,19 +431,46 @@ def merge_tree_against(base: str, head: str, *, cwd: Path) -> MergeTreeResult:
     )
     if result.returncode == 0:
         return MergeTreeResult(clean=True, conflict_files=())
-    # exit code 1 → conflicts; any other non-zero is also treated as conflict
-    conflict_files = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
-    return MergeTreeResult(clean=False, conflict_files=conflict_files)
+    if result.returncode == 1:
+        conflict_files = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+        return MergeTreeResult(clean=False, conflict_files=conflict_files)
+    # exit code > 1 → git error; do not treat as conflict
+    logger.warning(
+        "merge-tree exited %d (git error, not conflict): %s",
+        result.returncode,
+        (result.stderr or "").strip()[:300],
+    )
+    return MergeTreeResult(clean=False, conflict_files=(), git_error=True)
+
+
+def is_pr_closed(pr_number: int, *, cwd: Path | None = None) -> bool:
+    """Return True if the PR is in a closed or merged state on GitHub."""
+    result = _gh("pr", "view", str(pr_number), "--json", "state", cwd=cwd, check=False)
+    if result.returncode != 0:
+        return False
+    try:
+        state = json.loads(result.stdout).get("state", "").upper()
+        return state in {"CLOSED", "MERGED"}
+    except Exception:
+        return False
 
 
 def close_pr(pr_number: int, *, cwd: Path | None = None) -> bool:
-    """Close a PR without deleting the branch.  Safe if already closed."""
+    """Close a PR without deleting the branch.  Safe if already closed.
+
+    Returns True when the PR is now closed (including already-closed).
+    Returns False on real errors (network, auth, etc.).
+    "Already closed" is idempotent; "not found" is treated as already-closed and
+    logged at WARNING so callers can retry safely.
+    """
     result = _gh("pr", "close", str(pr_number), cwd=cwd, check=False)
     if result.returncode == 0:
         return True
-    # "already closed" is not an error condition
     stderr_lower = (result.stderr or "").lower()
-    if "already closed" in stderr_lower or "not found" in stderr_lower:
+    if "already closed" in stderr_lower:
+        return True
+    if "not found" in stderr_lower:
+        logger.warning("close_pr #%s: PR not found (treating as already closed)", pr_number)
         return True
     logger.warning("close_pr #%s failed: %s", pr_number, (result.stderr or "").strip()[:300])
     return False

--- a/agent_fleet/pr_loop/github_ops.py
+++ b/agent_fleet/pr_loop/github_ops.py
@@ -429,9 +429,7 @@ def merge_tree_against(base: str, head: str, *, cwd: Path) -> MergeTreeResult:
     if result.returncode == 0:
         return MergeTreeResult(clean=True, conflict_files=())
     # exit code 1 → conflicts; any other non-zero is also treated as conflict
-    conflict_files = tuple(
-        line.strip() for line in result.stdout.splitlines() if line.strip()
-    )
+    conflict_files = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
     return MergeTreeResult(clean=False, conflict_files=conflict_files)
 
 
@@ -450,9 +448,7 @@ def close_pr(pr_number: int, *, cwd: Path | None = None) -> bool:
 
 def issue_comments(issue_number: int, *, cwd: Path | None = None) -> list[dict[str, Any]]:
     """Return the comment list for a GitHub issue (not a PR)."""
-    result = _gh(
-        "issue", "view", str(issue_number), "--json", "comments", cwd=cwd, check=False
-    )
+    result = _gh("issue", "view", str(issue_number), "--json", "comments", cwd=cwd, check=False)
     if result.returncode != 0:
         return []
     try:
@@ -469,9 +465,7 @@ def reopen_issue(issue_number: int, *, cwd: Path | None = None) -> bool:
     stderr_lower = (result.stderr or "").lower()
     if "already open" in stderr_lower or "not found" in stderr_lower:
         return True
-    logger.warning(
-        "reopen_issue #%s failed: %s", issue_number, (result.stderr or "").strip()[:300]
-    )
+    logger.warning("reopen_issue #%s failed: %s", issue_number, (result.stderr or "").strip()[:300])
     return False
 
 

--- a/agent_fleet/pr_loop/github_ops.py
+++ b/agent_fleet/pr_loop/github_ops.py
@@ -399,6 +399,87 @@ def mark_pr_ready(pr_number: int, *, cwd: Path | None = None) -> None:
     _gh("pr", "ready", str(pr_number), cwd=cwd, check=False)
 
 
+# ---------------------------------------------------------------------------
+# Drift-detection helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MergeTreeResult:
+    """Result of a git merge-tree dry-run between a branch and origin/main."""
+
+    clean: bool
+    """True when main merges into the branch without conflicts."""
+    conflict_files: tuple[str, ...]
+    """File paths that have conflict markers (empty when clean)."""
+
+
+def merge_tree_against(base: str, head: str, *, cwd: Path) -> MergeTreeResult:
+    """Dry-run merge of *base* into *head* without touching the working tree.
+
+    Uses ``git merge-tree --write-tree --name-only <head> <base>`` (git >= 2.38).
+    Exit code 1 means conflicts; exit code 0 means clean.  The ``--name-only``
+    flag makes stdout a list of conflict file names, one per line.
+    """
+    result = _git_run(
+        ["git", "merge-tree", "--write-tree", "--name-only", head, base],
+        cwd=cwd,
+        timeout=60,
+    )
+    if result.returncode == 0:
+        return MergeTreeResult(clean=True, conflict_files=())
+    # exit code 1 → conflicts; any other non-zero is also treated as conflict
+    conflict_files = tuple(
+        line.strip() for line in result.stdout.splitlines() if line.strip()
+    )
+    return MergeTreeResult(clean=False, conflict_files=conflict_files)
+
+
+def close_pr(pr_number: int, *, cwd: Path | None = None) -> bool:
+    """Close a PR without deleting the branch.  Safe if already closed."""
+    result = _gh("pr", "close", str(pr_number), cwd=cwd, check=False)
+    if result.returncode == 0:
+        return True
+    # "already closed" is not an error condition
+    stderr_lower = (result.stderr or "").lower()
+    if "already closed" in stderr_lower or "not found" in stderr_lower:
+        return True
+    logger.warning("close_pr #%s failed: %s", pr_number, (result.stderr or "").strip()[:300])
+    return False
+
+
+def issue_comments(issue_number: int, *, cwd: Path | None = None) -> list[dict[str, Any]]:
+    """Return the comment list for a GitHub issue (not a PR)."""
+    result = _gh(
+        "issue", "view", str(issue_number), "--json", "comments", cwd=cwd, check=False
+    )
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout).get("comments", [])
+    except json.JSONDecodeError:
+        return []
+
+
+def reopen_issue(issue_number: int, *, cwd: Path | None = None) -> bool:
+    """Reopen a closed issue.  Safe (no-op) if already open."""
+    result = _gh("issue", "reopen", str(issue_number), cwd=cwd, check=False)
+    if result.returncode == 0:
+        return True
+    stderr_lower = (result.stderr or "").lower()
+    if "already open" in stderr_lower or "not found" in stderr_lower:
+        return True
+    logger.warning(
+        "reopen_issue #%s failed: %s", issue_number, (result.stderr or "").strip()[:300]
+    )
+    return False
+
+
+def post_issue_comment(body: str, issue_number: int, *, cwd: Path | None = None) -> None:
+    """Post a comment on a GitHub issue."""
+    _gh("issue", "comment", str(issue_number), "--body", body, cwd=cwd, check=False)
+
+
 def checkout_branch(branch: str, worktree: Path, *, repo_root: Path) -> Path:
     from agent_fleet.pr_loop.worktree import (
         registered_worktree_for_branch,

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 import textwrap
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -38,6 +40,9 @@ from agent_fleet.state import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
+
     from agent_fleet.pr_loop.config import PrLoopConfig
 
 logger = logging.getLogger(__name__)
@@ -619,6 +624,184 @@ def try_merge(
     return LifecycleResult("merge_error", "gh pr merge failed")
 
 
+_DRIFT_PR_MARKER = "<!-- pr_loop:drift-detected -->"
+_DRIFT_ISSUE_MARKER = "<!-- pr_loop:replan -->"
+_DEDUP_WINDOW = timedelta(hours=24)
+_BRANCH_ISSUE_RE = re.compile(r"(?:agent[-_]fleet|fleet|agent)/[^/]+/(\d+)")
+
+
+def _issue_number_from_branch(branch: str) -> int | None:
+    """Extract the source issue number from a fleet branch name.
+
+    Supports patterns like ``fleet/<persona>/<issue>-…`` and
+    ``agent_fleet/<persona>/<issue>``.
+    """
+    m = _BRANCH_ISSUE_RE.search(branch)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def _marker_within_window(
+    comments: Sequence[Mapping[str, Any]],
+    marker: str,
+    window: timedelta = _DEDUP_WINDOW,
+) -> bool:
+    """Return True if *marker* appears in any comment created within *window*."""
+    now = datetime.now(tz=UTC)
+    for c in comments:
+        body = str(c.get("body") or "")
+        if marker not in body:
+            continue
+        created_raw = c.get("createdAt") or c.get("created_at") or ""
+        if not created_raw:
+            return True  # no timestamp → assume recent
+        try:
+            created = datetime.fromisoformat(str(created_raw).replace("Z", "+00:00"))
+            if now - created < window:
+                return True
+        except ValueError:
+            return True  # unparseable → assume recent
+    return False
+
+
+def _detect_drift(
+    *,
+    pr_number: int,
+    branch: str,
+    worktree: Path,
+    repo_root: Path,
+    loop_config: PrLoopConfig,
+) -> LifecycleResult | None:
+    """Check whether origin/main has drifted under the PR branch.
+
+    Returns:
+        ``None`` — no drift; caller continues normally.
+        ``LifecycleResult("behind", …)`` — drift is auto-mergeable; caller should
+            proceed (update-branch already requested).
+        ``LifecycleResult("drift", …)`` — unresolvable conflict; PR closed, issue
+            re-queued.
+    """
+    if not loop_config.drift_check:
+        return None
+
+    # Step 1: fetch origin/main
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", "main"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    if fetch.returncode != 0:
+        logger.warning(
+            "drift-check: git fetch origin main failed for PR #%s: %s",
+            pr_number,
+            (fetch.stderr or "").strip()[:300],
+        )
+        return None  # can't check → skip drift gate, continue cycle
+
+    # Step 2: is origin/main already an ancestor of HEAD?
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    if ancestor.returncode == 0:
+        # origin/main is already reachable from HEAD — no drift
+        return None
+
+    # Step 3: dry-run merge to see if it's clean or conflicted
+    merge_result = github_ops.merge_tree_against("origin/main", "HEAD", cwd=worktree)
+
+    if merge_result.clean:
+        # Auto-mergeable: use the existing update-branch path
+        logger.info(
+            "drift-check: PR #%s is behind origin/main but auto-mergeable; "
+            "requesting update-branch",
+            pr_number,
+        )
+        github_ops.update_branch(pr_number, cwd=repo_root)
+        return LifecycleResult("behind", "main moved ahead; update-branch requested")
+
+    # Step 4: unresolvable conflict
+    conflict_files = merge_result.conflict_files
+
+    # Idempotency: skip all actions if drift comment already posted within 24 h
+    existing_pr_comments = github_ops.pr_comments(pr_number, cwd=repo_root)
+    if _marker_within_window(existing_pr_comments, _DRIFT_PR_MARKER):
+        logger.info(
+            "drift-check: PR #%s already has drift comment within 24h; skipping actions",
+            pr_number,
+        )
+        return LifecycleResult("drift", "main moved out from under PR (already actioned)")
+
+    # Get the current main commit SHA for the comment
+    rev = subprocess.run(
+        ["git", "rev-parse", "--short", "origin/main"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    main_sha = rev.stdout.strip() if rev.returncode == 0 else "unknown"
+
+    files_block = (
+        "\n".join(f"- `{f}`" for f in conflict_files) if conflict_files else "- (unknown)"
+    )
+    pr_comment_body = textwrap.dedent(f"""\
+        **Drift detected — unresolvable merge conflict with `main`.**
+
+        The PR's premise has changed: `origin/main` (at `{main_sha}`) introduced
+        edits that conflict with this branch and cannot be auto-merged.
+
+        **Conflicting files:**
+        {files_block}
+
+        This PR has been closed automatically. The source issue will be re-opened
+        with a replan comment so the next dispatcher can start fresh.
+
+        {_DRIFT_PR_MARKER}
+    """)
+
+    github_ops.post_pr_comment(pr_comment_body, pr_number, cwd=repo_root)
+    github_ops.close_pr(pr_number, cwd=repo_root)
+
+    # Reopen + comment on the source issue (best-effort)
+    issue_number = _issue_number_from_branch(branch)
+    if issue_number is None:
+        logger.warning(
+            "drift-check: PR #%s branch %r has no parseable issue number; "
+            "skipping issue reopen",
+            pr_number,
+            branch,
+        )
+    else:
+        github_ops.reopen_issue(issue_number, cwd=repo_root)
+        existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
+        if not _marker_within_window(existing_issue_comments, _DRIFT_ISSUE_MARKER):
+            issue_comment_body = textwrap.dedent(f"""\
+                **Replan needed — fleet PR #{pr_number} closed due to merge conflict with `main`.**
+
+                `origin/main` at `{main_sha}` introduced changes that conflict with the
+                PR branch.  The conflicting files were:
+                {files_block}
+
+                Please replan this issue from scratch, taking the current state of `main`
+                into account.
+
+                {_DRIFT_ISSUE_MARKER}
+            """)
+            github_ops.post_issue_comment(issue_comment_body, issue_number, cwd=repo_root)
+
+    return LifecycleResult("drift", "main moved out from under PR")
+
+
 def run_pr_lifecycle(
     *,
     pr_number: int,
@@ -702,6 +885,22 @@ def _run_pr_lifecycle_body(
             base = repo.worktree_base or Path("/tmp/agent-fleet-loop")
             wt = resolve_worktree_path(branch, repo_root=repo_root, worktree_base=base)
             logger.info("Resolved worktree for %s → %s", branch, wt)
+
+    # Drift check: compare origin/main against the PR branch before anything else.
+    # We use repo_root as the git context (always valid) since the per-PR worktree
+    # may not be set up yet at this point in the cycle.
+    _wt_is_git = wt.exists() and ((wt / ".git").exists() or (wt / ".git").is_file())
+    _git_cwd = wt if _wt_is_git else repo_root
+    drift = _detect_drift(
+        pr_number=pr_number,
+        branch=branch,
+        worktree=_git_cwd,
+        repo_root=repo_root,
+        loop_config=loop_config,
+    )
+    if drift is not None and drift.status == "drift":
+        fleet_log.emit("pr_loop.drift", pr_number=pr_number, detail=drift.detail)
+        return drift
 
     review_body: str | None = find_reviewer_comment(
         github_ops.pr_comments(pr_number, cwd=repo_root),

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -749,24 +749,21 @@ def _detect_drift(
     # Step 4: unresolvable conflict
     conflict_files = merge_result.conflict_files
 
-    # Idempotency: full action requires BOTH the PR closed AND the source issue
-    # reopened with a replan marker (when an issue number is parseable). A prior
-    # cycle that closed the PR but failed to reopen+replan must keep retrying;
-    # checking the PR state alone would silently abandon those issues.
+    # Idempotency: a prior cycle is "already actioned" only when every visible
+    # marker for this drift has been posted. The PR marker is posted LAST, so
+    # its presence implies the issue marker (when an issue is parseable) was
+    # already posted by the same cycle. Gating on the PR marker alone avoids
+    # the bug where a no-issue branch (issue_number is None) would skip the
+    # PR-marker post on subsequent cycles.
     issue_number = _issue_number_from_branch(branch)
     pr_already_closed = github_ops.is_pr_closed(pr_number, cwd=repo_root)
-    issue_already_replanned = False
+    pr_marker_posted = False
     if pr_already_closed:
-        if issue_number is None:
-            issue_already_replanned = True
-        else:
-            existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
-            issue_already_replanned = _marker_within_window(
-                existing_issue_comments, _DRIFT_ISSUE_MARKER
-            )
-    if pr_already_closed and issue_already_replanned:
+        existing_pr_comments = github_ops.pr_comments(pr_number, cwd=repo_root)
+        pr_marker_posted = _marker_within_window(existing_pr_comments, _DRIFT_PR_MARKER)
+    if pr_already_closed and pr_marker_posted:
         logger.info(
-            "drift-check: PR #%s already closed and issue replan posted; skipping",
+            "drift-check: PR #%s already closed and drift marker posted; skipping",
             pr_number,
         )
         return LifecycleResult(

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -749,12 +749,24 @@ def _detect_drift(
     # Step 4: unresolvable conflict
     conflict_files = merge_result.conflict_files
 
-    # Idempotency: the real state-of-record is whether the PR is already closed.
-    # A comment marker alone is insufficient because the comment may exist while
-    # close_pr failed on a previous cycle.
-    if github_ops.is_pr_closed(pr_number, cwd=repo_root):
+    # Idempotency: full action requires BOTH the PR closed AND the source issue
+    # reopened with a replan marker (when an issue number is parseable). A prior
+    # cycle that closed the PR but failed to reopen+replan must keep retrying;
+    # checking the PR state alone would silently abandon those issues.
+    issue_number = _issue_number_from_branch(branch)
+    pr_already_closed = github_ops.is_pr_closed(pr_number, cwd=repo_root)
+    issue_already_replanned = False
+    if pr_already_closed:
+        if issue_number is None:
+            issue_already_replanned = True
+        else:
+            existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
+            issue_already_replanned = _marker_within_window(
+                existing_issue_comments, _DRIFT_ISSUE_MARKER
+            )
+    if pr_already_closed and issue_already_replanned:
         logger.info(
-            "drift-check: PR #%s is already closed; skipping destructive actions",
+            "drift-check: PR #%s already closed and issue replan posted; skipping",
             pr_number,
         )
         return LifecycleResult(
@@ -788,7 +800,6 @@ def _detect_drift(
             "drift", f"{default_branch} moved out from under PR (close failed, will retry)"
         )
 
-    issue_number = _issue_number_from_branch(branch)
     if issue_number is None:
         logger.warning(
             "drift-check: PR #%s branch %r has no parseable issue number; skipping issue reopen",
@@ -799,47 +810,53 @@ def _detect_drift(
         reopen_ok = github_ops.reopen_issue(issue_number, cwd=repo_root)
         if not reopen_ok:
             logger.warning(
-                "drift-check: reopen_issue #%s failed; posting PR marker anyway",
+                "drift-check: reopen_issue #%s failed; aborting before PR marker so next "
+                "cycle retries the reopen+comment",
                 issue_number,
             )
-        else:
-            existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
-            if not _marker_within_window(existing_issue_comments, _DRIFT_ISSUE_MARKER):
-                replan_header = (
-                    f"**Replan needed — fleet PR #{pr_number} closed due to"
-                    f" merge conflict with `{default_branch}`.**"
-                )
-                issue_comment_body = textwrap.dedent(f"""\
-                    {replan_header}
+            return LifecycleResult(
+                "drift",
+                f"{default_branch} moved out from under PR (issue reopen failed, will retry)",
+            )
+        existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
+        if not _marker_within_window(existing_issue_comments, _DRIFT_ISSUE_MARKER):
+            replan_header = (
+                f"**Replan needed — fleet PR #{pr_number} closed due to"
+                f" merge conflict with `{default_branch}`.**"
+            )
+            issue_comment_body = textwrap.dedent(f"""\
+                {replan_header}
 
-                    `{origin_base}` at `{base_sha}` introduced changes that conflict with the
-                    PR branch.  The conflicting files were:
-                    {files_block}
+                `{origin_base}` at `{base_sha}` introduced changes that conflict with the
+                PR branch.  The conflicting files were:
+                {files_block}
 
-                    Please replan this issue from scratch, taking the current state
-                    of `{default_branch}` into account.
+                Please replan this issue from scratch, taking the current state
+                of `{default_branch}` into account.
 
-                    {_DRIFT_ISSUE_MARKER}
-                """)
-                github_ops.post_issue_comment(issue_comment_body, issue_number, cwd=repo_root)
+                {_DRIFT_ISSUE_MARKER}
+            """)
+            github_ops.post_issue_comment(issue_comment_body, issue_number, cwd=repo_root)
 
     # Post the PR comment with the drift marker last — its presence is the
     # UI hint; the actual idempotency gate is the PR state check above.
-    pr_comment_body = textwrap.dedent(f"""\
-        **Drift detected — unresolvable merge conflict with `{default_branch}`.**
+    existing_pr_comments = github_ops.pr_comments(pr_number, cwd=repo_root)
+    if not _marker_within_window(existing_pr_comments, _DRIFT_PR_MARKER):
+        pr_comment_body = textwrap.dedent(f"""\
+            **Drift detected — unresolvable merge conflict with `{default_branch}`.**
 
-        The PR's premise has changed: `{origin_base}` (at `{base_sha}`) introduced
-        edits that conflict with this branch and cannot be auto-merged.
+            The PR's premise has changed: `{origin_base}` (at `{base_sha}`) introduced
+            edits that conflict with this branch and cannot be auto-merged.
 
-        **Conflicting files:**
-        {files_block}
+            **Conflicting files:**
+            {files_block}
 
-        This PR has been closed automatically. The source issue will be re-opened
-        with a replan comment so the next dispatcher can start fresh.
+            This PR has been closed automatically. The source issue will be re-opened
+            with a replan comment so the next dispatcher can start fresh.
 
-        {_DRIFT_PR_MARKER}
-    """)
-    github_ops.post_pr_comment(pr_comment_body, pr_number, cwd=repo_root)
+            {_DRIFT_PR_MARKER}
+        """)
+        github_ops.post_pr_comment(pr_comment_body, pr_number, cwd=repo_root)
 
     return LifecycleResult("drift", f"{default_branch} moved out from under PR")
 

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -750,18 +750,26 @@ def _detect_drift(
     conflict_files = merge_result.conflict_files
 
     # Idempotency: a prior cycle is "already actioned" only when every visible
-    # marker for this drift has been posted. The PR marker is posted LAST, so
-    # its presence implies the issue marker (when an issue is parseable) was
-    # already posted by the same cycle. Gating on the PR marker alone avoids
-    # the bug where a no-issue branch (issue_number is None) would skip the
-    # PR-marker post on subsequent cycles.
+    # marker for this drift has been posted. When an issue is parseable, we
+    # require BOTH the issue replan marker AND the PR drift marker — the
+    # post_issue_comment call uses check=False, so a silent failure can leave
+    # the issue un-replanned even after the PR marker lands. When no issue is
+    # parseable, the PR marker alone is the recovery signal.
     issue_number = _issue_number_from_branch(branch)
     pr_already_closed = github_ops.is_pr_closed(pr_number, cwd=repo_root)
-    pr_marker_posted = False
+    recovery_complete = False
     if pr_already_closed:
         existing_pr_comments = github_ops.pr_comments(pr_number, cwd=repo_root)
         pr_marker_posted = _marker_within_window(existing_pr_comments, _DRIFT_PR_MARKER)
-    if pr_already_closed and pr_marker_posted:
+        if issue_number is None:
+            recovery_complete = pr_marker_posted
+        else:
+            existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
+            issue_marker_posted = _marker_within_window(
+                existing_issue_comments, _DRIFT_ISSUE_MARKER
+            )
+            recovery_complete = pr_marker_posted and issue_marker_posted
+    if pr_already_closed and recovery_complete:
         logger.info(
             "drift-check: PR #%s already closed and drift marker posted; skipping",
             pr_number,

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -672,8 +672,13 @@ def _detect_drift(
     worktree: Path,
     repo_root: Path,
     loop_config: PrLoopConfig,
+    default_branch: str = "main",
 ) -> LifecycleResult | None:
-    """Check whether origin/main has drifted under the PR branch.
+    """Check whether the default branch has drifted under the PR branch.
+
+    Args:
+        default_branch: The repo's base branch (e.g. "main", "master").  Used
+            instead of the hardcoded literal "main".
 
     Returns:
         ``None`` — no drift; caller continues normally.
@@ -685,9 +690,12 @@ def _detect_drift(
     if not loop_config.drift_check:
         return None
 
-    # Step 1: fetch origin/main
+    origin_base = f"origin/{default_branch}"
+
+    # Step 1: fetch origin/<default_branch> and the PR branch so we compare
+    # against the PR's actual remote head, not whatever is checked out locally.
     fetch = subprocess.run(
-        ["git", "fetch", "origin", "main"],
+        ["git", "fetch", "origin", default_branch, branch],
         cwd=worktree,
         capture_output=True,
         text=True,
@@ -696,15 +704,19 @@ def _detect_drift(
     )
     if fetch.returncode != 0:
         logger.warning(
-            "drift-check: git fetch origin main failed for PR #%s: %s",
+            "drift-check: git fetch failed for PR #%s: %s",
             pr_number,
             (fetch.stderr or "").strip()[:300],
         )
         return None  # can't check → skip drift gate, continue cycle
 
-    # Step 2: is origin/main already an ancestor of HEAD?
+    # Use origin/<branch> as the comparison head so we always check against the
+    # PR's remote tip, regardless of what is locally checked out.
+    pr_head_ref = f"origin/{branch}"
+
+    # Step 2: is origin/<default_branch> already an ancestor of the PR head?
     ancestor = subprocess.run(
-        ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
+        ["git", "merge-base", "--is-ancestor", origin_base, pr_head_ref],
         cwd=worktree,
         capture_output=True,
         text=True,
@@ -712,50 +724,111 @@ def _detect_drift(
         timeout=30,
     )
     if ancestor.returncode == 0:
-        # origin/main is already reachable from HEAD — no drift
+        # origin/<default_branch> is already reachable from PR head — no drift
         return None
 
     # Step 3: dry-run merge to see if it's clean or conflicted
-    merge_result = github_ops.merge_tree_against("origin/main", "HEAD", cwd=worktree)
+    merge_result = github_ops.merge_tree_against(origin_base, pr_head_ref, cwd=worktree)
 
-    if merge_result.clean:
-        # Auto-mergeable: use the existing update-branch path
-        logger.info(
-            "drift-check: PR #%s is behind origin/main but auto-mergeable; "
-            "requesting update-branch",
+    if merge_result.git_error:
+        logger.warning(
+            "drift-check: merge-tree returned a git error for PR #%s; skipping drift gate",
             pr_number,
         )
+        return None
+
+    if merge_result.clean:
+        logger.info(
+            "drift-check: PR #%s is behind %s but auto-mergeable; requesting update-branch",
+            pr_number,
+            origin_base,
+        )
         github_ops.update_branch(pr_number, cwd=repo_root)
-        return LifecycleResult("behind", "main moved ahead; update-branch requested")
+        return LifecycleResult("behind", f"{default_branch} moved ahead; update-branch requested")
 
     # Step 4: unresolvable conflict
     conflict_files = merge_result.conflict_files
 
-    # Idempotency: skip all actions if drift comment already posted within 24 h
-    existing_pr_comments = github_ops.pr_comments(pr_number, cwd=repo_root)
-    if _marker_within_window(existing_pr_comments, _DRIFT_PR_MARKER):
+    # Idempotency: the real state-of-record is whether the PR is already closed.
+    # A comment marker alone is insufficient because the comment may exist while
+    # close_pr failed on a previous cycle.
+    if github_ops.is_pr_closed(pr_number, cwd=repo_root):
         logger.info(
-            "drift-check: PR #%s already has drift comment within 24h; skipping actions",
+            "drift-check: PR #%s is already closed; skipping destructive actions",
             pr_number,
         )
-        return LifecycleResult("drift", "main moved out from under PR (already actioned)")
+        return LifecycleResult(
+            "drift", f"{default_branch} moved out from under PR (already actioned)"
+        )
 
-    # Get the current main commit SHA for the comment
+    # Get the current base-branch commit SHA for the comment
     rev = subprocess.run(
-        ["git", "rev-parse", "--short", "origin/main"],
+        ["git", "rev-parse", "--short", origin_base],
         cwd=worktree,
         capture_output=True,
         text=True,
         check=False,
         timeout=30,
     )
-    main_sha = rev.stdout.strip() if rev.returncode == 0 else "unknown"
+    base_sha = rev.stdout.strip() if rev.returncode == 0 else "unknown"
 
     files_block = "\n".join(f"- `{f}`" for f in conflict_files) if conflict_files else "- (unknown)"
-    pr_comment_body = textwrap.dedent(f"""\
-        **Drift detected — unresolvable merge conflict with `main`.**
 
-        The PR's premise has changed: `origin/main` (at `{main_sha}`) introduced
+    # Sequence: close PR → reopen issue → post issue comment → post PR comment.
+    # The PR comment carries the _DRIFT_PR_MARKER which gates future retries.
+    # Posting it LAST means a partial failure on any earlier step leaves the
+    # marker un-posted, so the next cycle will retry the full sequence.
+    close_ok = github_ops.close_pr(pr_number, cwd=repo_root)
+    if not close_ok:
+        logger.warning(
+            "drift-check: close_pr #%s failed; aborting so next cycle can retry",
+            pr_number,
+        )
+        return LifecycleResult(
+            "drift", f"{default_branch} moved out from under PR (close failed, will retry)"
+        )
+
+    issue_number = _issue_number_from_branch(branch)
+    if issue_number is None:
+        logger.warning(
+            "drift-check: PR #%s branch %r has no parseable issue number; skipping issue reopen",
+            pr_number,
+            branch,
+        )
+    else:
+        reopen_ok = github_ops.reopen_issue(issue_number, cwd=repo_root)
+        if not reopen_ok:
+            logger.warning(
+                "drift-check: reopen_issue #%s failed; posting PR marker anyway",
+                issue_number,
+            )
+        else:
+            existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
+            if not _marker_within_window(existing_issue_comments, _DRIFT_ISSUE_MARKER):
+                replan_header = (
+                    f"**Replan needed — fleet PR #{pr_number} closed due to"
+                    f" merge conflict with `{default_branch}`.**"
+                )
+                issue_comment_body = textwrap.dedent(f"""\
+                    {replan_header}
+
+                    `{origin_base}` at `{base_sha}` introduced changes that conflict with the
+                    PR branch.  The conflicting files were:
+                    {files_block}
+
+                    Please replan this issue from scratch, taking the current state
+                    of `{default_branch}` into account.
+
+                    {_DRIFT_ISSUE_MARKER}
+                """)
+                github_ops.post_issue_comment(issue_comment_body, issue_number, cwd=repo_root)
+
+    # Post the PR comment with the drift marker last — its presence is the
+    # UI hint; the actual idempotency gate is the PR state check above.
+    pr_comment_body = textwrap.dedent(f"""\
+        **Drift detected — unresolvable merge conflict with `{default_branch}`.**
+
+        The PR's premise has changed: `{origin_base}` (at `{base_sha}`) introduced
         edits that conflict with this branch and cannot be auto-merged.
 
         **Conflicting files:**
@@ -766,37 +839,9 @@ def _detect_drift(
 
         {_DRIFT_PR_MARKER}
     """)
-
     github_ops.post_pr_comment(pr_comment_body, pr_number, cwd=repo_root)
-    github_ops.close_pr(pr_number, cwd=repo_root)
 
-    # Reopen + comment on the source issue (best-effort)
-    issue_number = _issue_number_from_branch(branch)
-    if issue_number is None:
-        logger.warning(
-            "drift-check: PR #%s branch %r has no parseable issue number; skipping issue reopen",
-            pr_number,
-            branch,
-        )
-    else:
-        github_ops.reopen_issue(issue_number, cwd=repo_root)
-        existing_issue_comments = github_ops.issue_comments(issue_number, cwd=repo_root)
-        if not _marker_within_window(existing_issue_comments, _DRIFT_ISSUE_MARKER):
-            issue_comment_body = textwrap.dedent(f"""\
-                **Replan needed — fleet PR #{pr_number} closed due to merge conflict with `main`.**
-
-                `origin/main` at `{main_sha}` introduced changes that conflict with the
-                PR branch.  The conflicting files were:
-                {files_block}
-
-                Please replan this issue from scratch, taking the current state of `main`
-                into account.
-
-                {_DRIFT_ISSUE_MARKER}
-            """)
-            github_ops.post_issue_comment(issue_comment_body, issue_number, cwd=repo_root)
-
-    return LifecycleResult("drift", "main moved out from under PR")
+    return LifecycleResult("drift", f"{default_branch} moved out from under PR")
 
 
 def run_pr_lifecycle(
@@ -809,6 +854,7 @@ def run_pr_lifecycle(
     worktree: Path | None = None,
     skip_review_wait: bool = False,
     persona: str | None = None,
+    base_ref_name: str = "",
 ) -> LifecycleResult:
     """Run address-review → CI wait/fix → merge for one PR."""
     fleet_config = fleet_config or load_fleet_config()
@@ -835,6 +881,7 @@ def run_pr_lifecycle(
                 skip_review_wait=skip_review_wait,
                 persona=persona,
                 fleet_log=fleet_log,
+                base_ref_name=base_ref_name,
             )
         except Exception as exc:
             fleet_log.emit("pr_loop.error", level="error", error=str(exc))
@@ -859,6 +906,7 @@ def _run_pr_lifecycle_body(
     skip_review_wait: bool,
     persona: str,
     fleet_log: FleetLogger,
+    base_ref_name: str = "",
 ) -> LifecycleResult:
     """Inner PR lifecycle implementation (expects bound FleetLogger)."""
     repo_root = repo.repo_root
@@ -883,17 +931,17 @@ def _run_pr_lifecycle_body(
             wt = resolve_worktree_path(branch, repo_root=repo_root, worktree_base=base)
             logger.info("Resolved worktree for %s → %s", branch, wt)
 
-    # Drift check: compare origin/main against the PR branch before anything else.
-    # We use repo_root as the git context (always valid) since the per-PR worktree
-    # may not be set up yet at this point in the cycle.
-    _wt_is_git = wt.exists() and ((wt / ".git").exists() or (wt / ".git").is_file())
-    _git_cwd = wt if _wt_is_git else repo_root
+    # Drift check: always run against repo_root (guaranteed to be a valid git
+    # context) and pass the PR head ref + base branch so _detect_drift fetches
+    # and compares the correct remote refs regardless of local checkout state.
+    default_branch = base_ref_name or repo.default_branch
     drift = _detect_drift(
         pr_number=pr_number,
         branch=branch,
-        worktree=_git_cwd,
+        worktree=repo_root,
         repo_root=repo_root,
         loop_config=loop_config,
+        default_branch=default_branch,
     )
     if drift is not None and drift.status == "drift":
         fleet_log.emit("pr_loop.drift", pr_number=pr_number, detail=drift.detail)

--- a/agent_fleet/pr_loop/lifecycle.py
+++ b/agent_fleet/pr_loop/lifecycle.py
@@ -751,9 +751,7 @@ def _detect_drift(
     )
     main_sha = rev.stdout.strip() if rev.returncode == 0 else "unknown"
 
-    files_block = (
-        "\n".join(f"- `{f}`" for f in conflict_files) if conflict_files else "- (unknown)"
-    )
+    files_block = "\n".join(f"- `{f}`" for f in conflict_files) if conflict_files else "- (unknown)"
     pr_comment_body = textwrap.dedent(f"""\
         **Drift detected — unresolvable merge conflict with `main`.**
 
@@ -776,8 +774,7 @@ def _detect_drift(
     issue_number = _issue_number_from_branch(branch)
     if issue_number is None:
         logger.warning(
-            "drift-check: PR #%s branch %r has no parseable issue number; "
-            "skipping issue reopen",
+            "drift-check: PR #%s branch %r has no parseable issue number; skipping issue reopen",
             pr_number,
             branch,
         )

--- a/agent_fleet/pr_loop/watcher.py
+++ b/agent_fleet/pr_loop/watcher.py
@@ -174,6 +174,7 @@ class PrLoopWatcher:
             pr_number = _pr_number(pr)
             branch = str(pr.get("headRefName") or "")
             head_ref_oid = str(pr.get("headRefOid") or "")
+            base_ref_name = str(pr.get("baseRefName") or "")
             entry = get_pr_state(state, pr_number)
             entry = maybe_unpark_pr_entry(entry, head_ref_oid=head_ref_oid)
             if head_ref_oid:
@@ -227,6 +228,7 @@ class PrLoopWatcher:
                 loop_config=self.loop_config,
                 fleet_config=self.fleet_config,
                 skip_review_wait=True,
+                base_ref_name=base_ref_name,
             )
 
             new_ci_timeout_attempts = (

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -175,6 +175,10 @@ def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
             return_value=[],
         ),
         patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=[],
+        ),
+        patch(
             "agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment",
             side_effect=record_post_issue,
         ) as mock_issue_comment,
@@ -212,11 +216,18 @@ def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
     assert call_order.index("post_issue") < call_order.index("post_pr")
 
 
-# Case 4: idempotency — PR is already closed on GitHub → all actions skipped
+# Case 4: idempotency — PR closed AND source issue already has replan marker → all
+# destructive actions skipped. Closing the PR alone is not enough; a prior cycle
+# that closed the PR but failed to reopen+replan must keep retrying, which means
+# the gate also requires _DRIFT_ISSUE_MARKER present on the source issue.
 def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
     fetch_ok = _make_proc(0)
     ancestor_fail = _make_proc(1)
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
+    recent = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
+    issue_comments_with_marker = [
+        {"body": f"replan body {_DRIFT_ISSUE_MARKER}", "createdAt": recent}
+    ]
 
     with (
         patch("subprocess.run") as mock_run,
@@ -228,6 +239,10 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
             "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
             return_value=True,
         ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
+            return_value=issue_comments_with_marker,
+        ),
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
@@ -238,7 +253,7 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.status == "drift"
-    # All destructive actions skipped because PR is already closed
+    # All destructive actions skipped: PR already closed AND issue already replanned
     mock_post_pr.assert_not_called()
     mock_close.assert_not_called()
     mock_reopen.assert_not_called()
@@ -277,6 +292,10 @@ def test_detect_drift_no_issue_in_branch(tmp_path: Path) -> None:
         ) as mock_close,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=[],
+        ),
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
     ):
         mock_run.side_effect = [fetch_ok, ancestor_fail, sha_proc]
@@ -371,6 +390,112 @@ def test_detect_drift_close_failure_no_marker_posted(tmp_path: Path) -> None:
     assert result.status == "drift"
     mock_post_pr.assert_not_called()
     mock_reopen.assert_not_called()
+
+
+def test_detect_drift_reopen_failure_no_pr_marker_posted(tmp_path: Path) -> None:
+    """If reopen_issue fails, the PR drift marker must NOT be posted (allow retry).
+
+    A retry that finds an old marker on the PR would treat the work as done and
+    silently drop the replan, so we must abort BEFORE the PR comment when the
+    reopen step itself failed.
+    """
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    sha_proc = _make_proc(0, stdout="sha9999\n")
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("svc/x.py",))
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=False,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.close_pr",
+            return_value=True,
+        ) as mock_close,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue",
+            return_value=False,
+        ) as mock_reopen,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
+            return_value=[],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=[],
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail, sha_proc]
+        result = _call_detect_drift(tmp_path, branch="fleet/coder/42-abc")
+
+    assert result is not None
+    assert result.status == "drift"
+    assert "reopen failed" in result.detail
+    mock_close.assert_called_once()
+    mock_reopen.assert_called_once()
+    # PR marker NOT posted so next cycle retries
+    mock_post_pr.assert_not_called()
+    mock_issue_comment.assert_not_called()
+
+
+def test_detect_drift_pr_closed_but_issue_not_replanned_retries(tmp_path: Path) -> None:
+    """PR already closed but no replan marker on issue → re-run reopen + replan.
+
+    A prior cycle that closed the PR but crashed before reopening the issue
+    must not be silently abandoned. The gate skips destructive actions only
+    when BOTH the PR is closed AND the source issue has a recent replan marker.
+    """
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("x.py",))
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.close_pr",
+            return_value=True,
+        ) as mock_close,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue",
+            return_value=True,
+        ) as mock_reopen,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
+            return_value=[],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=[],
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail, _make_proc(0, stdout="sha\n")]
+        result = _call_detect_drift(tmp_path, branch="fleet/coder/42-abc")
+
+    assert result is not None
+    assert result.status == "drift"
+    # close_pr is idempotent (already-closed = success); reopen + replan + marker run
+    mock_close.assert_called_once()
+    mock_reopen.assert_called_once_with(42, cwd=tmp_path)
+    mock_issue_comment.assert_called_once()
+    mock_post_pr.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -1,0 +1,302 @@
+"""Tests for Phase 4 drift detection in pr_loop lifecycle."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent_fleet.pr_loop.config import PrLoopConfig
+from agent_fleet.pr_loop.github_ops import MergeTreeResult
+from agent_fleet.pr_loop.lifecycle import (
+    _DRIFT_ISSUE_MARKER,
+    _DRIFT_PR_MARKER,
+    LifecycleResult,
+    _detect_drift,
+    _issue_number_from_branch,
+    _marker_within_window,
+)
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+
+def test_issue_number_from_branch_fleet_pattern() -> None:
+    assert _issue_number_from_branch("fleet/coder/1399-abc12345") == 1399
+
+
+def test_issue_number_from_branch_agent_fleet_pattern() -> None:
+    assert _issue_number_from_branch("agent_fleet/data/1532-xyz") == 1532
+
+
+def test_issue_number_from_branch_no_match() -> None:
+    assert _issue_number_from_branch("main") is None
+    assert _issue_number_from_branch("feature/add-stuff") is None
+
+
+def test_marker_within_window_present_recent() -> None:
+    now = datetime.now(tz=UTC)
+    recent = (now - timedelta(hours=1)).isoformat()
+    comments = [{"body": f"body {_DRIFT_PR_MARKER}", "createdAt": recent}]
+    assert _marker_within_window(comments, _DRIFT_PR_MARKER) is True
+
+
+def test_marker_within_window_present_old() -> None:
+    now = datetime.now(tz=UTC)
+    old = (now - timedelta(hours=25)).isoformat()
+    comments = [{"body": f"body {_DRIFT_PR_MARKER}", "createdAt": old}]
+    assert _marker_within_window(comments, _DRIFT_PR_MARKER) is False
+
+
+def test_marker_within_window_absent() -> None:
+    comments = [{"body": "no marker here", "createdAt": datetime.now(tz=UTC).isoformat()}]
+    assert _marker_within_window(comments, _DRIFT_PR_MARKER) is False
+
+
+def test_marker_within_window_no_timestamp_treated_as_recent() -> None:
+    comments = [{"body": f"body {_DRIFT_PR_MARKER}"}]
+    assert _marker_within_window(comments, _DRIFT_PR_MARKER) is True
+
+
+# ---------------------------------------------------------------------------
+# _detect_drift integration tests (subprocess-mocked)
+# ---------------------------------------------------------------------------
+
+
+def _loop_config(*, drift_check: bool = True) -> PrLoopConfig:
+    return PrLoopConfig(enabled=True, drift_check=drift_check)
+
+
+def _call_detect_drift(
+    tmp_path: Path,
+    branch: str = "fleet/coder/42-abc",
+    loop_config: PrLoopConfig | None = None,
+) -> LifecycleResult | None:
+    return _detect_drift(
+        pr_number=42,
+        branch=branch,
+        worktree=tmp_path,
+        repo_root=tmp_path,
+        loop_config=loop_config or _loop_config(),
+    )
+
+
+def _make_proc(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+# Case 1: no drift — merge-base says main is already ancestor
+def test_detect_drift_no_drift(tmp_path: Path) -> None:
+    fetch_ok = _make_proc(0)
+    ancestor_ok = _make_proc(0)  # is-ancestor returns 0 → no drift
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [fetch_ok, ancestor_ok]
+        result = _call_detect_drift(tmp_path)
+
+    assert result is None
+    assert mock_run.call_count == 2
+
+
+# Case 2: auto-mergeable drift — merge-base says NOT ancestor, merge-tree is clean
+def test_detect_drift_auto_mergeable(tmp_path: Path) -> None:
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)  # main NOT ancestor → drift exists
+    clean_tree = MergeTreeResult(clean=True, conflict_files=())
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=clean_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.update_branch",
+        ) as mock_update,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail]
+        result = _call_detect_drift(tmp_path)
+
+    assert result is not None
+    assert result.status == "behind"
+    mock_update.assert_called_once_with(42, cwd=tmp_path)
+
+
+# Case 3: unresolvable drift, first call → PR comment + close + issue reopen
+def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    sha_proc = _make_proc(0, stdout="abc1234\n")
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("pipeline/model.py",))
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=[],  # no prior drift comment
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue",
+        ) as mock_reopen,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
+            return_value=[],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment",
+        ) as mock_issue_comment,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail, sha_proc]
+        result = _call_detect_drift(tmp_path, branch="fleet/coder/42-abc")
+
+    assert result is not None
+    assert result.status == "drift"
+
+    # PR comment posted with drift marker
+    mock_post_pr.assert_called_once()
+    pr_body = mock_post_pr.call_args[0][0]
+    assert _DRIFT_PR_MARKER in pr_body
+    assert "pipeline/model.py" in pr_body
+    assert "abc1234" in pr_body
+
+    # PR closed exactly once
+    mock_close.assert_called_once_with(42, cwd=tmp_path)
+
+    # Issue reopened and replan comment posted
+    mock_reopen.assert_called_once_with(42, cwd=tmp_path)
+    mock_issue_comment.assert_called_once()
+    issue_body = mock_issue_comment.call_args[0][0]
+    assert _DRIFT_ISSUE_MARKER in issue_body
+    assert "pipeline/model.py" in issue_body
+
+
+# Case 4: idempotency — drift comment already within 24h → all actions skipped
+def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    recent_ts = datetime.now(tz=UTC).isoformat()
+    existing_drift_comment = [
+        {"body": f"old comment {_DRIFT_PR_MARKER}", "createdAt": recent_ts}
+    ]
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=existing_drift_comment,
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail]
+        result = _call_detect_drift(tmp_path)
+
+    assert result is not None
+    assert result.status == "drift"
+    # All actions must be skipped because the marker is already present
+    mock_post_pr.assert_not_called()
+    mock_close.assert_not_called()
+    mock_reopen.assert_not_called()
+    mock_issue_comment.assert_not_called()
+
+
+# Case 5: drift_check=False → entire detection skipped
+def test_detect_drift_disabled(tmp_path: Path) -> None:
+    with patch("subprocess.run") as mock_run:
+        result = _call_detect_drift(tmp_path, loop_config=_loop_config(drift_check=False))
+
+    assert result is None
+    mock_run.assert_not_called()
+
+
+# Case 6: branch without parseable issue number → comment+close PR but skip issue reopen
+def test_detect_drift_no_issue_in_branch(tmp_path: Path) -> None:
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    sha_proc = _make_proc(0, stdout="deadbeef\n")
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("Makefile",))
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=[],
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail, sha_proc]
+        result = _call_detect_drift(tmp_path, branch="feature/no-issue-number")
+
+    assert result is not None
+    assert result.status == "drift"
+    # PR actions still happen
+    mock_post_pr.assert_called_once()
+    mock_close.assert_called_once()
+    # Issue actions skipped because no issue number parseable
+    mock_reopen.assert_not_called()
+    mock_issue_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+def test_pr_loop_config_drift_check_default() -> None:
+    from agent_fleet.pr_loop.config import load_pr_loop_config
+
+    cfg = load_pr_loop_config(Path("/tmp"), {"pr_loop": {"enabled": True}})
+    assert cfg is not None
+    assert cfg.drift_check is True
+
+
+def test_pr_loop_config_drift_check_disabled() -> None:
+    from agent_fleet.pr_loop.config import load_pr_loop_config
+
+    cfg = load_pr_loop_config(
+        Path("/tmp"), {"pr_loop": {"enabled": True, "drift_check": False}}
+    )
+    assert cfg is not None
+    assert cfg.drift_check is False
+
+
+# ---------------------------------------------------------------------------
+# MergeTreeResult dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_merge_tree_result_clean() -> None:
+    r = MergeTreeResult(clean=True, conflict_files=())
+    assert r.clean is True
+    assert r.conflict_files == ()
+
+
+def test_merge_tree_result_conflict() -> None:
+    r = MergeTreeResult(clean=False, conflict_files=("a.py", "b.py"))
+    assert r.clean is False
+    assert "a.py" in r.conflict_files

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -225,8 +225,8 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
     ancestor_fail = _make_proc(1)
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
     recent = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
-    issue_comments_with_marker = [
-        {"body": f"replan body {_DRIFT_ISSUE_MARKER}", "createdAt": recent}
+    pr_comments_with_marker = [
+        {"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}
     ]
 
     with (
@@ -240,8 +240,8 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
             return_value=True,
         ),
         patch(
-            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
-            return_value=issue_comments_with_marker,
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=pr_comments_with_marker,
         ),
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
@@ -253,7 +253,7 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.status == "drift"
-    # All destructive actions skipped: PR already closed AND issue already replanned
+    # All destructive actions skipped: PR already closed AND PR drift marker present
     mock_post_pr.assert_not_called()
     mock_close.assert_not_called()
     mock_reopen.assert_not_called()

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -228,6 +228,9 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
     pr_comments_with_marker = [
         {"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}
     ]
+    issue_comments_with_marker = [
+        {"body": f"replan body {_DRIFT_ISSUE_MARKER}", "createdAt": recent}
+    ]
 
     with (
         patch("subprocess.run") as mock_run,
@@ -243,6 +246,10 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
             "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
             return_value=pr_comments_with_marker,
         ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
+            return_value=issue_comments_with_marker,
+        ),
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
@@ -253,11 +260,64 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.status == "drift"
-    # All destructive actions skipped: PR already closed AND PR drift marker present
+    # All destructive actions skipped: PR already closed AND both markers present
     mock_post_pr.assert_not_called()
     mock_close.assert_not_called()
     mock_reopen.assert_not_called()
     mock_issue_comment.assert_not_called()
+
+
+def test_detect_drift_pr_marker_but_no_issue_marker_retries(tmp_path: Path) -> None:
+    """PR closed + PR marker but issue replan marker missing → retry replan path."""
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
+    recent = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
+    pr_comments_with_marker = [
+        {"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}
+    ]
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=True,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
+            return_value=pr_comments_with_marker,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
+            return_value=[],
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.close_pr",
+            return_value=True,
+        ) as mock_close,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue",
+            return_value=True,
+        ) as mock_reopen,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail, _make_proc(0, stdout="sha\n")]
+        result = _call_detect_drift(tmp_path, branch="fleet/coder/42-abc")
+
+    assert result is not None
+    assert result.status == "drift"
+    # post_issue_comment uses check=False so silent failure can leave issue
+    # un-replanned; the retry must re-run reopen + replan even though PR marker is present.
+    mock_close.assert_called_once()
+    mock_reopen.assert_called_once_with(42, cwd=tmp_path)
+    mock_issue_comment.assert_called_once()
+    # PR marker should not be re-posted since _marker_within_window finds the recent one.
+    mock_post_pr.assert_not_called()
 
 
 # Case 5: drift_check=False → entire detection skipped

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -225,9 +225,7 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
     ancestor_fail = _make_proc(1)
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
     recent = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
-    pr_comments_with_marker = [
-        {"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}
-    ]
+    pr_comments_with_marker = [{"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}]
     issue_comments_with_marker = [
         {"body": f"replan body {_DRIFT_ISSUE_MARKER}", "createdAt": recent}
     ]
@@ -273,9 +271,7 @@ def test_detect_drift_pr_marker_but_no_issue_marker_retries(tmp_path: Path) -> N
     ancestor_fail = _make_proc(1)
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
     recent = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
-    pr_comments_with_marker = [
-        {"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}
-    ]
+    pr_comments_with_marker = [{"body": f"drift body {_DRIFT_PR_MARKER}", "createdAt": recent}]
 
     with (
         patch("subprocess.run") as mock_run,

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -72,6 +72,7 @@ def _call_detect_drift(
     tmp_path: Path,
     branch: str = "fleet/coder/42-abc",
     loop_config: PrLoopConfig | None = None,
+    default_branch: str = "main",
 ) -> LifecycleResult | None:
     return _detect_drift(
         pr_number=42,
@@ -79,6 +80,7 @@ def _call_detect_drift(
         worktree=tmp_path,
         repo_root=tmp_path,
         loop_config=loop_config or _loop_config(),
+        default_branch=default_branch,
     )
 
 
@@ -127,12 +129,28 @@ def test_detect_drift_auto_mergeable(tmp_path: Path) -> None:
     mock_update.assert_called_once_with(42, cwd=tmp_path)
 
 
-# Case 3: unresolvable drift, first call → PR comment + close + issue reopen
+# Case 3: unresolvable drift, first call → close PR, reopen issue, PR comment last
 def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
     fetch_ok = _make_proc(0)
     ancestor_fail = _make_proc(1)
     sha_proc = _make_proc(0, stdout="abc1234\n")
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("pipeline/model.py",))
+
+    call_order: list[str] = []
+
+    def record_close(*_a: object, **_kw: object) -> bool:
+        call_order.append("close")
+        return True
+
+    def record_reopen(*_a: object, **_kw: object) -> bool:
+        call_order.append("reopen")
+        return True
+
+    def record_post_pr(*_a: object, **_kw: object) -> None:
+        call_order.append("post_pr")
+
+    def record_post_issue(*_a: object, **_kw: object) -> None:
+        call_order.append("post_issue")
 
     with (
         patch("subprocess.run") as mock_run,
@@ -141,13 +159,16 @@ def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
             return_value=conflict_tree,
         ),
         patch(
-            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
-            return_value=[],  # no prior drift comment
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=False,
         ),
-        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
-        patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.close_pr",
+            side_effect=record_close,
+        ) as mock_close,
         patch(
             "agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue",
+            side_effect=record_reopen,
         ) as mock_reopen,
         patch(
             "agent_fleet.pr_loop.lifecycle.github_ops.issue_comments",
@@ -155,7 +176,12 @@ def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
         ),
         patch(
             "agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment",
+            side_effect=record_post_issue,
         ) as mock_issue_comment,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment",
+            side_effect=record_post_pr,
+        ) as mock_post_pr,
     ):
         mock_run.side_effect = [fetch_ok, ancestor_fail, sha_proc]
         result = _call_detect_drift(tmp_path, branch="fleet/coder/42-abc")
@@ -180,13 +206,16 @@ def test_detect_drift_conflict_first_call(tmp_path: Path) -> None:
     assert _DRIFT_ISSUE_MARKER in issue_body
     assert "pipeline/model.py" in issue_body
 
+    # close and reopen must happen BEFORE post_pr (marker is last)
+    assert call_order.index("close") < call_order.index("post_pr")
+    assert call_order.index("reopen") < call_order.index("post_pr")
+    assert call_order.index("post_issue") < call_order.index("post_pr")
 
-# Case 4: idempotency — drift comment already within 24h → all actions skipped
+
+# Case 4: idempotency — PR is already closed on GitHub → all actions skipped
 def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
     fetch_ok = _make_proc(0)
     ancestor_fail = _make_proc(1)
-    recent_ts = datetime.now(tz=UTC).isoformat()
-    existing_drift_comment = [{"body": f"old comment {_DRIFT_PR_MARKER}", "createdAt": recent_ts}]
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
 
     with (
@@ -196,8 +225,8 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
             return_value=conflict_tree,
         ),
         patch(
-            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
-            return_value=existing_drift_comment,
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=True,
         ),
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
@@ -209,7 +238,7 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.status == "drift"
-    # All actions must be skipped because the marker is already present
+    # All destructive actions skipped because PR is already closed
     mock_post_pr.assert_not_called()
     mock_close.assert_not_called()
     mock_reopen.assert_not_called()
@@ -225,7 +254,7 @@ def test_detect_drift_disabled(tmp_path: Path) -> None:
     mock_run.assert_not_called()
 
 
-# Case 6: branch without parseable issue number → comment+close PR but skip issue reopen
+# Case 6: branch without parseable issue number → close PR + PR comment but skip issue reopen
 def test_detect_drift_no_issue_in_branch(tmp_path: Path) -> None:
     fetch_ok = _make_proc(0)
     ancestor_fail = _make_proc(1)
@@ -239,13 +268,16 @@ def test_detect_drift_no_issue_in_branch(tmp_path: Path) -> None:
             return_value=conflict_tree,
         ),
         patch(
-            "agent_fleet.pr_loop.lifecycle.github_ops.pr_comments",
-            return_value=[],
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=False,
         ),
-        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
-        patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.close_pr",
+            return_value=True,
+        ) as mock_close,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
         patch("agent_fleet.pr_loop.lifecycle.github_ops.post_issue_comment") as mock_issue_comment,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
     ):
         mock_run.side_effect = [fetch_ok, ancestor_fail, sha_proc]
         result = _call_detect_drift(tmp_path, branch="feature/no-issue-number")
@@ -258,6 +290,155 @@ def test_detect_drift_no_issue_in_branch(tmp_path: Path) -> None:
     # Issue actions skipped because no issue number parseable
     mock_reopen.assert_not_called()
     mock_issue_comment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: drift uses PR head ref (origin/<branch>), not local HEAD
+# ---------------------------------------------------------------------------
+
+
+def test_detect_drift_uses_pr_head_ref_not_local_head(tmp_path: Path) -> None:
+    """merge_tree_against must be called with origin/<branch>, not 'HEAD'."""
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    clean_tree = MergeTreeResult(clean=True, conflict_files=())
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=clean_tree,
+        ) as mock_merge_tree,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.update_branch"),
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail]
+        _call_detect_drift(tmp_path, branch="fleet/coder/42-feature")
+
+    merge_tree_call = mock_merge_tree.call_args
+    head_arg = merge_tree_call[0][1]
+    assert head_arg == "origin/fleet/coder/42-feature", (
+        f"Expected origin/<branch> but got {head_arg!r}"
+    )
+    assert head_arg != "HEAD"
+
+
+def test_detect_drift_fetch_includes_pr_branch(tmp_path: Path) -> None:
+    """git fetch must include both default_branch and the PR branch."""
+    fetch_ok = _make_proc(0)
+    ancestor_ok = _make_proc(0)
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [fetch_ok, ancestor_ok]
+        _call_detect_drift(tmp_path, branch="fleet/coder/42-feature")
+
+    fetch_call_args = mock_run.call_args_list[0][0][0]
+    assert "main" in fetch_call_args
+    assert "fleet/coder/42-feature" in fetch_call_args
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: close+reopen partial failure returns retry-safe result (no marker)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_drift_close_failure_no_marker_posted(tmp_path: Path) -> None:
+    """If close_pr fails, the drift marker must NOT be posted (allow retry)."""
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    conflict_tree = MergeTreeResult(clean=False, conflict_files=("a.py",))
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=conflict_tree,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.is_pr_closed",
+            return_value=False,
+        ),
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.close_pr",
+            return_value=False,
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.reopen_issue") as mock_reopen,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail, _make_proc(0, stdout="sha1234\n")]
+        result = _call_detect_drift(tmp_path)
+
+    assert result is not None
+    assert result.status == "drift"
+    mock_post_pr.assert_not_called()
+    mock_reopen.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: non-main default_branch is used instead of hardcoded "origin/main"
+# ---------------------------------------------------------------------------
+
+
+def test_detect_drift_non_main_default_branch(tmp_path: Path) -> None:
+    """Drift check must use the configured default_branch, not 'main'."""
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    clean_tree = MergeTreeResult(clean=True, conflict_files=())
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=clean_tree,
+        ) as mock_merge_tree,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.update_branch"),
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail]
+        result = _call_detect_drift(tmp_path, default_branch="develop")
+
+    assert result is not None
+    assert result.status == "behind"
+    assert "develop" in result.detail
+
+    base_arg = mock_merge_tree.call_args[0][0]
+    assert base_arg == "origin/develop"
+
+    fetch_call_args = mock_run.call_args_list[0][0][0]
+    assert "develop" in fetch_call_args
+    assert "main" not in fetch_call_args
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: merge-tree exit code > 1 is a git error, NOT a conflict
+# ---------------------------------------------------------------------------
+
+
+def test_merge_tree_result_git_error_flag() -> None:
+    r = MergeTreeResult(clean=False, conflict_files=(), git_error=True)
+    assert r.git_error is True
+    assert r.clean is False
+
+
+def test_detect_drift_merge_tree_git_error_skips_close(tmp_path: Path) -> None:
+    """When merge-tree returns a git error (exit > 1), drift is skipped entirely."""
+    fetch_ok = _make_proc(0)
+    ancestor_fail = _make_proc(1)
+    git_error_tree = MergeTreeResult(clean=False, conflict_files=(), git_error=True)
+
+    with (
+        patch("subprocess.run") as mock_run,
+        patch(
+            "agent_fleet.pr_loop.lifecycle.github_ops.merge_tree_against",
+            return_value=git_error_tree,
+        ),
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.close_pr") as mock_close,
+        patch("agent_fleet.pr_loop.lifecycle.github_ops.post_pr_comment") as mock_post_pr,
+    ):
+        mock_run.side_effect = [fetch_ok, ancestor_fail]
+        result = _call_detect_drift(tmp_path)
+
+    assert result is None
+    mock_close.assert_not_called()
+    mock_post_pr.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -290,9 +471,11 @@ def test_merge_tree_result_clean() -> None:
     r = MergeTreeResult(clean=True, conflict_files=())
     assert r.clean is True
     assert r.conflict_files == ()
+    assert r.git_error is False
 
 
 def test_merge_tree_result_conflict() -> None:
     r = MergeTreeResult(clean=False, conflict_files=("a.py", "b.py"))
     assert r.clean is False
     assert "a.py" in r.conflict_files
+    assert r.git_error is False

--- a/tests/test_pr_loop_drift.py
+++ b/tests/test_pr_loop_drift.py
@@ -186,9 +186,7 @@ def test_detect_drift_conflict_idempotent(tmp_path: Path) -> None:
     fetch_ok = _make_proc(0)
     ancestor_fail = _make_proc(1)
     recent_ts = datetime.now(tz=UTC).isoformat()
-    existing_drift_comment = [
-        {"body": f"old comment {_DRIFT_PR_MARKER}", "createdAt": recent_ts}
-    ]
+    existing_drift_comment = [{"body": f"old comment {_DRIFT_PR_MARKER}", "createdAt": recent_ts}]
     conflict_tree = MergeTreeResult(clean=False, conflict_files=("src/a.py",))
 
     with (
@@ -278,9 +276,7 @@ def test_pr_loop_config_drift_check_default() -> None:
 def test_pr_loop_config_drift_check_disabled() -> None:
     from agent_fleet.pr_loop.config import load_pr_loop_config
 
-    cfg = load_pr_loop_config(
-        Path("/tmp"), {"pr_loop": {"enabled": True, "drift_check": False}}
-    )
+    cfg = load_pr_loop_config(Path("/tmp"), {"pr_loop": {"enabled": True, "drift_check": False}})
     assert cfg is not None
     assert cfg.drift_check is False
 


### PR DESCRIPTION
## Summary

- Adds a non-destructive drift check at the top of `_run_pr_lifecycle_body` using `git merge-tree origin/main HEAD` to detect conflicts before doing any review/CI work.
- Three outcomes: (1) no drift → continue; (2) auto-mergeable drift → return `LifecycleResult(\"behind\", ...)` so the existing BEHIND path picks it up next poll; (3) unresolvable drift → comment + close the PR, reopen the source issue with a replan comment.
- Default-on; set `drift_check: false` in `pr_loop` config to disable.

## Motivation

silphcoanalytics PR #2010 wasted ~3 hours rebuilding against `id_confidence == Float64` after main's PR #2012 moved that field to `Utf8`. `pr_loop` only noticed at the merge gate when `mergeStateStatus` went `DIRTY`. The fix is to check drift at the **start** of each lifecycle, not the end.

## Algorithm

1. `git fetch origin main` (in the PR worktree).
2. `git merge-base --is-ancestor origin/main HEAD` → if true, no drift.
3. Else, `git merge-tree --write-tree --name-only origin/main HEAD`.
4. Exit-0 with no conflict files → auto-mergeable → return `LifecycleResult(\"behind\", ...)`.
5. Exit-1 or conflict files listed → unresolvable:
   - PR comment with conflict file list + marker `<!-- pr_loop:drift-detected -->`.
   - `gh pr close --delete-branch=false`.
   - Parse issue number from branch (`agent_fleet/<persona>/<n>` or `fleet/<persona>/<n>`).
   - `gh issue reopen <n>`; post issue comment with marker `<!-- pr_loop:replan -->`.
   - Return `LifecycleResult(\"drift\", ...)`.

## Idempotency

Both markers are de-duped against a 24h window via `_marker_within_window`. Re-entering on a still-broken PR is a no-op. `gh pr close` on a closed PR and `gh issue reopen` on an open issue are no-ops by design.

## Files

| File | Change |
|---|---|
| `agent_fleet/pr_loop/lifecycle.py` | Drift-check wired at body top; new `_detect_drift`, `_marker_within_window`, `_issue_number_from_branch` helpers; `LifecycleResult(\"drift\"/\"behind\", ...)` outcomes. |
| `agent_fleet/pr_loop/github_ops.py` | New `MergeTreeResult` dataclass and helpers: `merge_tree_against`, `close_pr`, `issue_comments`, `reopen_issue`, `post_issue_comment`. |
| `agent_fleet/pr_loop/config.py` | New `drift_check: bool = True`. |
| `tests/test_pr_loop_drift.py` | 17 new tests. |

## Plan reference

Final PR of the stable-autonomous track. Phase 1 = #38, Phase 2 = #39, Phase 3 = #40 (all open). Plan doc at `plans/stable-autonomous/phase-4-main-drift.md` (lives on the Phase 1 branch).

## Test plan

- [x] `uv run --no-sync pytest tests/test_pr_loop_drift.py -q` — 17 passed
- [x] `uv run --no-sync pytest -q` — 317 passed, 3 skipped (no regressions)
- [x] `uv run --no-sync ruff check agent_fleet tests` — clean
- [x] `uv run --no-sync pyright agent_fleet/pr_loop` — 0 errors
- [ ] Live: synthesize a small-scale drift scenario after merge and verify single-shot close+reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)