### PR TITLE
feat(pr_review): repo overlay + deslop + logfire span

### DIFF
--- a/.agent-fleet.yaml
+++ b/.agent-fleet.yaml
@@ -14,6 +14,24 @@ lint_command: bash -c "git diff --name-only main HEAD -- '*.py' | xargs -r uv ru
 capacity:
   max_dispatches: 8
 
+pr_review:
+  enabled: true
+  use_in_code_review: true
+  overlay: agents/pr_review_overlay.md
+  comment_title: Composer PR Analysis
+  oversized_threshold: 60
+  area_prefixes:
+    backend:
+      - agent_fleet/
+      - tests/
+      - integrations/
+      - scripts/
+  quality_review:
+    enabled: true
+    skills:
+      - thermo-nuclear-code-quality-review
+      - deslop
+
 code_review:
   auto_fix: true
   max_fix_attempts: 2

--- a/agent_fleet/pr_review/analyzer.py
+++ b/agent_fleet/pr_review/analyzer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 from datetime import UTC, datetime
@@ -10,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from agent_fleet.fleet_paths import agent_fleet_home
 from agent_fleet.pr_review.git import classify_files, is_deletion_only_pr
 from agent_fleet.pr_review.prompts import build_prompt
+from agent_fleet.telemetry import span as _telemetry_span
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -176,48 +178,75 @@ def _run_pass(
     skill_dirs: list | None = None,
 ) -> dict[str, Any] | None:
     prompt = build_prompt(diff, files, mode, config, skill_dirs=skill_dirs or [])
-    result = backend.run(
-        prompt,
-        max_tokens=8192,
-        timeout_s=timeout_s,
-        cwd=workspace,
-        model=model,
-        mode="plan",
-        allowed_tools=allowed_tools or ["Read", "Grep"],
-    )
-    if result.exit_code != 0:
-        _log_analysis(
-            config,
-            pr_number=pr_number,
-            mode=f"{mode}_error",
-            prompt=prompt,
-            raw_output=result.stdout,
-            parsed=None,
-            error=result.stderr or f"exit {result.exit_code}",
-        )
-        return None
-    try:
-        parsed = _extract_json(result.stdout)
-    except (ValueError, json.JSONDecodeError) as exc:
-        _log_analysis(
-            config,
-            pr_number=pr_number,
-            mode=f"{mode}_parse_error",
-            prompt=prompt,
-            raw_output=result.stdout,
-            parsed=None,
-            error=str(exc),
-        )
-        return None
-    _log_analysis(
-        config,
+    with _telemetry_span(
+        "pr_review.pass",
         pr_number=pr_number,
         mode=mode,
-        prompt=prompt,
-        raw_output=result.stdout,
-        parsed=parsed,
-    )
-    return parsed
+        model=model,
+        prompt_chars=len(prompt),
+        files=len(files),
+    ) as pass_span:
+        result = backend.run(
+            prompt,
+            max_tokens=8192,
+            timeout_s=timeout_s,
+            cwd=workspace,
+            model=model,
+            mode="plan",
+            allowed_tools=allowed_tools or ["Read", "Grep"],
+        )
+        if result.exit_code != 0:
+            _log_analysis(
+                config,
+                pr_number=pr_number,
+                mode=f"{mode}_error",
+                prompt=prompt,
+                raw_output=result.stdout,
+                parsed=None,
+                error=result.stderr or f"exit {result.exit_code}",
+            )
+            _set_span_attrs(pass_span, status="backend_error", exit_code=result.exit_code)
+            return None
+        try:
+            parsed = _extract_json(result.stdout)
+        except (ValueError, json.JSONDecodeError) as exc:
+            _log_analysis(
+                config,
+                pr_number=pr_number,
+                mode=f"{mode}_parse_error",
+                prompt=prompt,
+                raw_output=result.stdout,
+                parsed=None,
+                error=str(exc),
+            )
+            _set_span_attrs(pass_span, status="parse_error")
+            return None
+        _log_analysis(
+            config,
+            pr_number=pr_number,
+            mode=mode,
+            prompt=prompt,
+            raw_output=result.stdout,
+            parsed=parsed,
+        )
+        _set_span_attrs(
+            pass_span,
+            status="ok",
+            risk_level=str(parsed.get("risk_level") or "unknown"),
+            findings_count=len(parsed.get("findings") or []),
+            suggestions_count=len(parsed.get("suggestions") or []),
+        )
+        return parsed
+
+
+def _set_span_attrs(span: object, **attrs: object) -> None:
+    """Best-effort attribute setting; no-ops when telemetry is disabled."""
+    set_attr = getattr(span, "set_attribute", None)
+    if set_attr is None:
+        return
+    for key, value in attrs.items():
+        with contextlib.suppress(Exception):
+            set_attr(key, value)
 
 
 def passes_for_files(files: list[str], config: PrReviewConfig) -> list[str]:

--- a/agent_fleet/pr_review/config.py
+++ b/agent_fleet/pr_review/config.py
@@ -30,6 +30,12 @@ DEFAULT_AREA_PREFIXES: dict[str, tuple[str, ...]] = {
 }
 
 
+DEFAULT_QUALITY_REVIEW_SKILLS: tuple[str, ...] = (
+    "thermo-nuclear-code-quality-review",
+    "deslop",
+)
+
+
 @dataclass(frozen=True)
 class PrReviewConfig:
     enabled: bool = True
@@ -48,7 +54,7 @@ class PrReviewConfig:
     fanout_threshold: int = 20
     log_dir: Path | None = None
     quality_review_enabled: bool = True
-    quality_review_skill: str = "thermo-nuclear-code-quality-review"
+    quality_review_skills: tuple[str, ...] = DEFAULT_QUALITY_REVIEW_SKILLS
 
 
 def _tuple_paths(value: object) -> tuple[str, ...]:
@@ -90,12 +96,18 @@ def load_pr_review_config(repo_root: Path, raw: dict[str, Any] | None) -> PrRevi
 
     quality_raw = section.get("quality_review")
     quality_enabled = True
-    quality_skill = "thermo-nuclear-code-quality-review"
+    quality_skills: tuple[str, ...] = DEFAULT_QUALITY_REVIEW_SKILLS
     if quality_raw is False:
         quality_enabled = False
     elif isinstance(quality_raw, dict):
         quality_enabled = bool(quality_raw.get("enabled", True))
-        quality_skill = str(quality_raw.get("skill") or "thermo-nuclear-code-quality-review")
+        skills_raw = quality_raw.get("skills")
+        if isinstance(skills_raw, list) and skills_raw:
+            quality_skills = tuple(str(s) for s in skills_raw if s)
+        elif "skill" in quality_raw:
+            single = str(quality_raw.get("skill") or "").strip()
+            if single:
+                quality_skills = (single,)
 
     return PrReviewConfig(
         enabled=bool(section.get("enabled", True)),
@@ -112,7 +124,7 @@ def load_pr_review_config(repo_root: Path, raw: dict[str, Any] | None) -> PrRevi
         fanout_threshold=int(section.get("fanout_threshold") or 20),
         log_dir=log_dir,
         quality_review_enabled=quality_enabled,
-        quality_review_skill=quality_skill,
+        quality_review_skills=quality_skills,
     )
 
 

--- a/agent_fleet/pr_review/prompts.py
+++ b/agent_fleet/pr_review/prompts.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import textwrap
 
-from agent_fleet.pr_review.config import PrReviewConfig, load_overlay_text
+from agent_fleet.pr_review.config import (
+    DEFAULT_QUALITY_REVIEW_SKILLS,
+    PrReviewConfig,
+    load_overlay_text,
+)
 from agent_fleet.pr_review.git import classify_files, diff_for_files, truncate_diff
-from agent_fleet.skills_lib import DEFAULT_QUALITY_REVIEW_SKILL, load_skill_text
+from agent_fleet.skills_lib import load_skill_text
 
 JSON_OUTPUT_SPEC = textwrap.dedent("""\
     Return your complete assessment as **strict JSON**:
@@ -180,13 +184,17 @@ def build_prompt(
 
     elif mode == "quality":
         full_diff = truncate_diff(diff, config.max_diff_chars)
-        skill_name = config.quality_review_skill or DEFAULT_QUALITY_REVIEW_SKILL
-        quality_body = ""
+        skill_names = config.quality_review_skills or DEFAULT_QUALITY_REVIEW_SKILLS
+        skill_bodies: list[str] = []
         if config.quality_review_enabled and skill_dirs:
-            try:
-                quality_body = load_skill_text(skill_name, skill_dirs)
-            except FileNotFoundError:
-                quality_body = ""
+            for skill_name in skill_names:
+                try:
+                    body = load_skill_text(skill_name, skill_dirs)
+                except FileNotFoundError:
+                    continue
+                if body:
+                    skill_bodies.append(f"### Skill: {skill_name}\n\n{body}")
+        quality_body = "\n\n".join(skill_bodies)
         sections.append(
             textwrap.dedent(f"""\
             ## Thermo-nuclear code quality review (mandatory)

--- a/agents/pr_review_overlay.md
+++ b/agents/pr_review_overlay.md
@@ -1,0 +1,84 @@
+# Two-pass PR analyzer — agent-fleet domain invariants
+
+agent-fleet is the orchestration runtime. It spawns Cursor agents on issues,
+runs a PR review/fix/merge loop, and shares one state file. Concurrency and
+idempotency invariants are load-bearing. Flag any diff that violates them.
+
+## Sole-writer rules (concurrency-critical)
+
+- `agent_fleet/issue_loop/watcher.py` is the **sole writer** of
+  `.agent-fleet-state.json` `in_flight` keys. `backlog_dispatcher.py` and
+  scheduled jobs must NOT mutate `in_flight`; they only post `/agent` comments
+  and let the watcher comment-trigger path admit the dispatch.
+- A new module writing to `in_flight` is a HIGH finding. Look for
+  `state["in_flight"]` or `set_state(...)` calls outside `watcher.py` and
+  `in_flight.py`.
+
+## FleetCapacityGate is the single admission point
+
+- `agent_fleet/capacity/gate.py:FleetCapacityGate.try_admit` enforces:
+  `already_in_flight` (same issue + persona), `issue_at_capacity` (count of
+  runs for the issue ≥ `per_issue_limit`, default 3), `fleet_at_capacity`,
+  `insufficient_ram`, plus visual-audit variants.
+- `in_flight[issue_number]` is a LIST of `{pid, persona, visual_audit}` dicts.
+  Multi-persona-per-issue (up to `per_issue_limit`) is intentional. A cheap
+  pre-filter elsewhere that skips on "issue is in in_flight" is a HIGH
+  finding — it makes gate semantics unreachable and contradicts watcher
+  behavior.
+
+## RETRYABLE_ADMISSION_REASONS vs continue-able reasons
+
+- `RETRYABLE_ADMISSION_REASONS = {fleet_at_capacity, visual_audit_at_capacity,
+  insufficient_ram, visual_audit_ram_reserved}` → `break` the dispatch loop
+  (system-wide resource pressure; try again on the next tick).
+- Any other refusal reason (`already_in_flight`, `issue_at_capacity`,
+  `mutex_label`, `open_pr`, etc.) → `continue` to the next issue (issue-local
+  problem; other issues may still admit).
+- Flipping a `break` and `continue` for these is a HIGH finding — wrong
+  retry semantics either starve the fleet or busy-loop.
+
+## Background-task pid check rules
+
+- `agent_fleet/in_flight.py:pid_is_dispatch(pid)` verifies a PID is a real
+  dispatch process by inspecting `/proc/<pid>/cmdline` for
+  `agent_fleet.issue_loop.dispatch` or `agent_fleet.schedule.task_dispatch`.
+- `reap_in_flight(state)` filters entries to those whose pid passes
+  `pid_is_dispatch`. Bypassing this filter (e.g. trusting `os.kill(pid, 0)`)
+  is a HIGH finding — it leaves reaped/recycled-PID ghosts in `in_flight`.
+
+## PR loop drift idempotency
+
+- `agent_fleet/pr_loop/lifecycle.py` close+reopen+replan must require BOTH
+  `pr_already_closed` AND `issue_already_replanned` to short-circuit.
+  Skipping on `pr_already_closed` alone leaves the source issue stuck open
+  with no replan marker.
+- `post_pr_comment(_DRIFT_PR_MARKER)` must only fire AFTER a successful
+  `reopen_issue`. Posting the marker before reopen succeeds creates a
+  permanently stuck PR (marker present, issue still closed).
+
+## /agent comment trigger semantics
+
+- `/agent --persona <name>` on an issue is the ONLY dispatch trigger.
+  `agent-running/<N>` labels are mutex locks applied by the dispatcher; they
+  are NOT triggers.
+- `backlog_dispatcher` posts `/agent` comments and relies on
+  `issue_dispatch.enabled` on the same target. If `issue_dispatch.enabled`
+  is false but `backlog_dispatcher.enabled` is true, comments are dead-lettered
+  to GitHub with no consumer — a HIGH finding.
+
+## Configuration and protected paths
+
+- `agent_fleet/cursor_backend.py`, `agent_fleet/runner.py`,
+  `agent_fleet/dispatcher.py`, `agent_fleet/phases.py`, `agent_fleet/hooks.py`,
+  `agent_fleet/cli.py`, `.github/workflows/`, `pyproject.toml`, `uv.lock` are
+  critical-path; structural changes need explicit justification.
+- Do not silently catch exceptions in backend `send()` paths and return
+  empty stdout — the planner depends on stderr/exit_code surfacing.
+
+## Tests / verification
+
+- Repo test command: `uv run --no-sync pytest -q`.
+- Lint: `uv run --no-sync ruff check .`. Typecheck: `uv run --no-sync pyright`.
+- New concurrency code MUST include a test that exercises both the admit and
+  refuse paths through `FleetCapacityGate.try_admit` (see
+  `tests/test_backlog_dispatcher.py` for the shape).

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -46,4 +46,4 @@ def test_load_pr_review_quality_from_yaml() -> None:
     )
     assert cfg is not None
     assert cfg.quality_review_enabled is True
-    assert cfg.quality_review_skill == "thermo-nuclear-code-quality-review"
+    assert cfg.quality_review_skills == ("thermo-nuclear-code-quality-review",)


### PR DESCRIPTION
## Summary
- Adds `agents/pr_review_overlay.md` encoding agent-fleet's invariants (watcher is sole `in_flight` writer, `FleetCapacityGate` is the single admission point, `RETRYABLE_ADMISSION_REASONS` semantics, `pid_is_dispatch` rules, PR drift marker is the last write, `/agent` comment is the only dispatch trigger) and wires it into `.agent-fleet.yaml` so the composer reviewer grounds findings in repo invariants.
- Quality pass now runs multiple skills. Default goes from a single `thermo-nuclear-code-quality-review` to `[thermo-nuclear-code-quality-review, deslop]`, with YAML accepting either `quality_review.skills: [...]` (new) or `quality_review.skill: ...` (legacy fallback).
- Wraps `_run_pass` in a `pr_review.pass` logfire span (attributes: `pr_number`, `mode`, `model`, `prompt_chars`, `files`, exit `status`, `risk_level`, `findings_count`, `suggestions_count`) so traces correlate PR review verdict → CI gate decision → merge in one query.

## Test plan
- [x] `uv run --no-sync pytest -q tests/test_skills_quality.py`
- [x] `uv run --no-sync ruff check agent_fleet/pr_review/ tests/test_skills_quality.py`
- [ ] Run composer review on this PR using the new overlay to confirm the invariants surface correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)