### PR TITLE
v0.8.2: add total_tokens + flush usage rollup from run.end

### DIFF
--- a/agent_fleet/__init__.py
+++ b/agent_fleet/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "run_full_pipeline",
 ]
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/agent_fleet/observability/log.py
+++ b/agent_fleet/observability/log.py
@@ -52,6 +52,7 @@ class RunLog:
         self._usage_calls: int = 0
         self._usage_duration_s: float = 0.0
         self._usage_by_phase: dict[str, dict[str, int]] = {}
+        self._usage_rollup_emitted: bool = False
 
     @classmethod
     def create(
@@ -122,6 +123,11 @@ class RunLog:
         self.emit("run.start", data=dict(data))
 
     def run_end(self, *, outcome: str, **data: object) -> None:
+        # Flush per-task token rollup before the run terminates so the
+        # consolidated log carries totals even for ad-hoc `agent-fleet run`
+        # paths that don't pass through the dispatcher.
+        if self._usage_calls > 0:
+            self.task_usage_rollup(task_id=self.context.task_id if self.context else None)
         payload = {"outcome": outcome, **data}
         self.emit("run.end", data=payload)
 
@@ -164,6 +170,7 @@ class RunLog:
             "cache_read_tokens": int(cache_read_tokens),
             "cache_write_tokens": int(cache_write_tokens),
         }
+        tokens["total_tokens"] = sum(tokens.values())
         data: dict[str, Any] = {
             "model": model,
             "agent_id": agent_id,
@@ -184,15 +191,24 @@ class RunLog:
         self.emit("llm.usage", phase=phase, data=data)
 
     def task_usage_rollup(self, *, task_id: int | None = None) -> dict[str, Any] | None:
-        """Emit a per-task usage summary; returns the totals payload (or None)."""
-        if self._usage_calls == 0:
+        """Emit a per-task usage summary; returns the totals payload (or None).
+        Idempotent: only emits once per RunLog lifetime."""
+        if self._usage_calls == 0 or self._usage_rollup_emitted:
             return None
+        self._usage_rollup_emitted = True
+        totals = dict(self._usage_totals)
+        totals["total_tokens"] = sum(totals.values())
+        by_phase: dict[str, dict[str, int]] = {}
+        for phase_key, bucket in self._usage_by_phase.items():
+            entry = dict(bucket)
+            entry["total_tokens"] = sum(entry[k] for k in self._USAGE_FIELDS)
+            by_phase[phase_key] = entry
         payload: dict[str, Any] = {
             "task_id": task_id,
             "calls": self._usage_calls,
             "duration_s": round(self._usage_duration_s, 3),
-            "totals": dict(self._usage_totals),
-            "by_phase": {p: dict(b) for p, b in self._usage_by_phase.items()},
+            "totals": totals,
+            "by_phase": by_phase,
         }
         self.emit("llm.usage.task_rollup", data=payload)
         return payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-fleet"
-version = "0.8.1"
+version = "0.8.2"
 description = "Multi-agent coding fleet — scoped personas, review pipelines, pluggable execution backends"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/tests/test_cursor_session.py
+++ b/tests/test_cursor_session.py
@@ -334,13 +334,23 @@ def test_runlog_llm_usage_accumulates_per_phase_then_rollup() -> None:
         "output_tokens": 25,
         "cache_read_tokens": 25,
         "cache_write_tokens": 1,
+        "total_tokens": 351,
     }
     assert rollup["by_phase"]["PLAN"]["calls"] == 1
+    assert rollup["by_phase"]["PLAN"]["total_tokens"] == 115
     assert rollup["by_phase"]["RESEARCH"]["input_tokens"] == 200
+    assert rollup["by_phase"]["RESEARCH"]["total_tokens"] == 236
 
     events = [e.event for e in sink.events]
     assert events.count("llm.usage") == 2
     assert events.count("llm.usage.task_rollup") == 1
+    # Second call is a no-op (idempotent).
+    assert log.task_usage_rollup(task_id=0) is None
+    assert [e.event for e in sink.events].count("llm.usage.task_rollup") == 1
+
+    usage_events = [e for e in sink.events if e.event == "llm.usage"]
+    assert usage_events[0].data["total_tokens"] == 115
+    assert usage_events[1].data["total_tokens"] == 236
 
 
 def test_session_send_hard_fails_when_mcp_required_but_unused(

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "agent-fleet"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary
- Per-call \`llm.usage\` events and the \`llm.usage.task_rollup\` payload now carry a derived \`total_tokens\` field (sum of input + output + cache_read + cache_write) so log consumers don't re-derive it themselves.
- \`RunLog.run_end\` now flushes \`task_usage_rollup\` before emitting \`run.end\`, so direct \`agent-fleet run\` invocations (LocalFleetRunner path) get the consolidated rollup that previously only fired through \`FleetDispatcher\`.
- Added \`_usage_rollup_emitted\` idempotence guard so the dispatcher's explicit \`task_usage_rollup\` and the new \`run_end\` flush can't double-emit.

## Test plan
- [x] \`pytest -q\` — 354 passed, 3 skipped
- [x] \`ty check\` — clean
- [x] \`ruff check\` — clean
- [x] Live \`agent-fleet run --pipeline full\` dispatch produced \`llm.usage\` events with \`total_tokens\` per call (PLAN 157,883; SYNTHESIZE 35,189; IMPLEMENT 146,750) and one \`llm.usage.task_rollup\` with grand \`total_tokens: 339,822\` plus per-phase \`total_tokens\` breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)