### PR TITLE
fix(verifier): classify bootstrap failures as FATAL and propagate stderr

### DIFF
--- a/agent_fleet/integrations/command_verifier.py
+++ b/agent_fleet/integrations/command_verifier.py
@@ -15,6 +15,13 @@ if TYPE_CHECKING:
     from agent_fleet.repo import RepoConfig
 
 
+def _format_failure(headline: str, proc: subprocess.CompletedProcess[str]) -> str:
+    detail = (proc.stderr or proc.stdout or "")[-2000:].rstrip()
+    if not detail:
+        return f"{headline}\nexit={proc.returncode}"
+    return f"{headline}\nexit={proc.returncode}\n{detail}"
+
+
 class CommandVerifier:
     """Run configured shell commands as verification gates."""
 
@@ -37,6 +44,39 @@ class CommandVerifier:
             "ISSUE_NUMBER": str(task_id),
             "FLEET_PERSONA": persona,
         }
+        for cmd in self.repo.worktree_bootstrap_commands:
+            proc = subprocess.run(
+                cmd,
+                shell=True,
+                cwd=str(worktree),
+                capture_output=True,
+                text=True,
+                check=False,
+                env=verify_env,
+            )
+            checks.append(
+                {
+                    "name": f"bootstrap: {cmd}",
+                    "passed": proc.returncode == 0,
+                    "stdout_tail": proc.stdout[-2000:],
+                    "stderr_tail": proc.stderr[-2000:],
+                    "exit_code": proc.returncode,
+                }
+            )
+            if proc.returncode != 0:
+                # Bootstrap prepares the worktree. It is deterministic on
+                # rerun and not fixable by editing the code under task
+                # (lockfile drift, missing tools, network). Classify FATAL
+                # so the runner bails immediately instead of burning fix
+                # iterations on an environmental problem.
+                return VerifyResult(
+                    severity=VerifySeverity.FATAL,
+                    checks=checks,
+                    violating_paths=[],
+                    files_changed=rel_changed,
+                    message=_format_failure(f"Worktree bootstrap failed: {cmd}", proc),
+                )
+
         verify_commands_ran = bool(self.repo.verify_commands)
         for cmd in self.repo.verify_commands:
             proc = subprocess.run(
@@ -63,7 +103,7 @@ class CommandVerifier:
                     checks=checks,
                     violating_paths=[],
                     files_changed=rel_changed,
-                    message=f"Verification failed: {cmd}",
+                    message=_format_failure(f"Verification failed: {cmd}", proc),
                 )
 
         if not verify_commands_ran:

--- a/agent_fleet/repo.py
+++ b/agent_fleet/repo.py
@@ -45,6 +45,7 @@ class RepoConfig:
     use_worktree: bool = False
     worktree_base: Path | None = None
     verify_commands: list[str] = field(default_factory=list)
+    worktree_bootstrap_commands: list[str] = field(default_factory=list)
     commit_preflight_commands: list[str] = field(default_factory=list)
     test_command: str | None = None
     lint_command: str | None = None
@@ -118,6 +119,7 @@ def load_repo_config(
         state_root = repo_root
 
     verify_commands = list(raw.get("verify_commands") or [])
+    worktree_bootstrap_commands = list(raw.get("worktree_bootstrap_commands") or [])
     commit_preflight_commands = list(raw.get("commit_preflight_commands") or [])
     test_command = raw.get("test_command")
     lint_command = raw.get("lint_command")
@@ -179,6 +181,7 @@ def load_repo_config(
         use_worktree=bool(raw.get("use_worktree", False)),
         worktree_base=worktree_base,
         verify_commands=verify_commands,
+        worktree_bootstrap_commands=worktree_bootstrap_commands,
         commit_preflight_commands=commit_preflight_commands,
         test_command=test_command,
         lint_command=lint_command,

--- a/tests/test_command_verifier_failure_propagation.py
+++ b/tests/test_command_verifier_failure_propagation.py
@@ -11,7 +11,7 @@ an environmental failure (lockfile drift breaking ``npm ci``) because:
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -19,37 +19,34 @@ from agent_fleet.contracts.verify_result import VerifySeverity
 from agent_fleet.integrations.command_verifier import CommandVerifier
 from agent_fleet.repo import RepoConfig
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 @pytest.fixture
 def worktree(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _repo(worktree: Path, **kwargs: object) -> RepoConfig:
-    return RepoConfig(repo_root=worktree, state_root=worktree, **kwargs)  # type: ignore[arg-type]
-
-
 def test_bootstrap_failure_is_fatal(worktree: Path) -> None:
-    repo = _repo(
-        worktree,
+    repo = RepoConfig(
+        repo_root=worktree,
+        state_root=worktree,
         worktree_bootstrap_commands=["bash -c 'echo boot-stderr >&2; exit 7'"],
     )
-    result = CommandVerifier(repo).check(
-        worktree, persona="coder", changed_files=[], task_id=1
-    )
+    result = CommandVerifier(repo).check(worktree, persona="coder", changed_files=[], task_id=1)
     assert result.severity is VerifySeverity.FATAL
 
 
 def test_bootstrap_failure_message_includes_stderr_and_exit_code(
     worktree: Path,
 ) -> None:
-    repo = _repo(
-        worktree,
+    repo = RepoConfig(
+        repo_root=worktree,
+        state_root=worktree,
         worktree_bootstrap_commands=["bash -c 'echo boot-stderr >&2; exit 7'"],
     )
-    result = CommandVerifier(repo).check(
-        worktree, persona="coder", changed_files=[], task_id=1
-    )
+    result = CommandVerifier(repo).check(worktree, persona="coder", changed_files=[], task_id=1)
     assert "exit=7" in result.message
     assert "boot-stderr" in result.message
 
@@ -57,13 +54,12 @@ def test_bootstrap_failure_message_includes_stderr_and_exit_code(
 def test_verify_failure_message_includes_stderr_and_exit_code(
     worktree: Path,
 ) -> None:
-    repo = _repo(
-        worktree,
+    repo = RepoConfig(
+        repo_root=worktree,
+        state_root=worktree,
         verify_commands=["bash -c 'echo test-failed >&2; exit 3'"],
     )
-    result = CommandVerifier(repo).check(
-        worktree, persona="coder", changed_files=[], task_id=1
-    )
+    result = CommandVerifier(repo).check(worktree, persona="coder", changed_files=[], task_id=1)
     assert result.severity is VerifySeverity.RETRY
     assert "exit=3" in result.message
     assert "test-failed" in result.message

--- a/tests/test_command_verifier_failure_propagation.py
+++ b/tests/test_command_verifier_failure_propagation.py
@@ -1,0 +1,69 @@
+"""Bootstrap/verify failure classification + stderr propagation.
+
+Regression guard for a v0.8.3 dispatch where the fix loop burned 4 attempts on
+an environmental failure (lockfile drift breaking ``npm ci``) because:
+
+  * ``command_verifier`` returned ``VerifySeverity.RETRY`` for bootstrap
+    failures, so the runner kept replaying SYNTHESIZE+IMPLEMENT.
+  * The failure message contained only the command string, so the agent's
+    fix prompt could not see why the command exited non-zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_fleet.contracts.verify_result import VerifySeverity
+from agent_fleet.integrations.command_verifier import CommandVerifier
+from agent_fleet.repo import RepoConfig
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def _repo(worktree: Path, **kwargs: object) -> RepoConfig:
+    return RepoConfig(repo_root=worktree, state_root=worktree, **kwargs)  # type: ignore[arg-type]
+
+
+def test_bootstrap_failure_is_fatal(worktree: Path) -> None:
+    repo = _repo(
+        worktree,
+        worktree_bootstrap_commands=["bash -c 'echo boot-stderr >&2; exit 7'"],
+    )
+    result = CommandVerifier(repo).check(
+        worktree, persona="coder", changed_files=[], task_id=1
+    )
+    assert result.severity is VerifySeverity.FATAL
+
+
+def test_bootstrap_failure_message_includes_stderr_and_exit_code(
+    worktree: Path,
+) -> None:
+    repo = _repo(
+        worktree,
+        worktree_bootstrap_commands=["bash -c 'echo boot-stderr >&2; exit 7'"],
+    )
+    result = CommandVerifier(repo).check(
+        worktree, persona="coder", changed_files=[], task_id=1
+    )
+    assert "exit=7" in result.message
+    assert "boot-stderr" in result.message
+
+
+def test_verify_failure_message_includes_stderr_and_exit_code(
+    worktree: Path,
+) -> None:
+    repo = _repo(
+        worktree,
+        verify_commands=["bash -c 'echo test-failed >&2; exit 3'"],
+    )
+    result = CommandVerifier(repo).check(
+        worktree, persona="coder", changed_files=[], task_id=1
+    )
+    assert result.severity is VerifySeverity.RETRY
+    assert "exit=3" in result.message
+    assert "test-failed" in result.message


### PR DESCRIPTION
## Summary
- **Classify bootstrap failures as FATAL.** `worktree_bootstrap_commands` failures are environmental (lockfile drift, missing toolchain, network) and deterministic on rerun — the agent under task cannot fix them by editing code. Returning RETRY caused the runner to burn full SYNTHESIZE+IMPLEMENT replays on a broken precondition. Switching to FATAL short-circuits the loop on the first bootstrap failure.
- **Propagate exit code + stderr into the failure message.** Both bootstrap and verify-command failure messages now append `exit=<code>` and the last 2000 chars of stderr (falling back to stdout). Previously only the command string reached the agent's fix prompt — even on a legitimate RETRY the agent could not see *why* the command failed.
- **Formalize `worktree_bootstrap_commands` on `RepoConfig`.** Paired field load from `.agent-fleet.yaml`.

## Motivation
silphco dispatch `b1bd31fd` exhausted the fix loop on `npm ci` failing against a drifted `frontend/package-lock.json`. The fleet retried four times against an unfixable environmental error. The failure message reaching the agent's fix prompt was literally `Worktree bootstrap failed: bash scripts/fleet-worktree-bootstrap.sh` — no exit code, no npm output. Two design flaws in one incident:

1. `VerifySeverity` collapsed two axes (fixable-by-code vs. deterministic-on-retry).
2. Stderr was collected onto `checks[].stderr_tail` but never propagated to the agent.

## Test plan
- [x] `tests/test_command_verifier_failure_propagation.py` — three new tests:
  - bootstrap failure → `VerifySeverity.FATAL`
  - bootstrap failure message includes `exit=N` and stderr tail
  - verify-command failure message includes `exit=N` and stderr tail
- [x] Full suite green: `358 passed, 3 skipped`
- [x] ruff check, ruff format, ty check clean on changed files
- [ ] Re-dispatch silphco issue and confirm bootstrap failure now produces a single FATAL attempt with full npm output in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)