### PR TITLE
fix(silphco): queue path + worktree base for chat fleet runs

### DIFF
--- a/targets/silphcoanalytics.agent-fleet.yaml
+++ b/targets/silphcoanalytics.agent-fleet.yaml
@@ -11,7 +11,7 @@ worktree_bootstrap_commands:
   - bash scripts/fleet-worktree-bootstrap.sh
 
 personas_dir: agents/personas
-worktree_base: /tmp/agent-worktrees
+worktree_base: ~/tmp/agent-worktrees
 
 verify_commands:
   - bash scripts/fleet-worktree-bootstrap.sh
@@ -65,7 +65,7 @@ critical_path_prefixes:
 
 spine:
   branch_prefix: fleet
-  worktree_base: /tmp/agent-worktrees
+  worktree_base: ~/tmp/agent-worktrees
   pr_ready_label: fleet-ready
 
 issue_dispatch:
@@ -75,7 +75,7 @@ issue_dispatch:
   running_label_prefix: fleet-running
   queue:
     enabled: true
-    file: targets/silphcoanalytics.queue.yaml
+    file: silphcoanalytics.queue.yaml
     advance: dispatch
 
 pr_review:

--- a/targets/silphcoanalytics.queue.yaml
+++ b/targets/silphcoanalytics.queue.yaml
@@ -1,9 +1,15 @@
 # FIFO dispatch queue for silphcoanalytics — managed from agent_fleet repo.
-# Issues already dispatched by comment-trigger are not listed here (the
-# trigger label takes precedence; the queue is the "next when capacity
-# frees" list). Curated to avoid known-bad: #1734 (TC violations even
-# with safe-fix), #1704 (RUF043 metacharacter regression).
+# advance=dispatch in target YAML allows parallel parents when personas differ.
 queue:
+  - issue: 2025
+    persona: backend
+    note: "C1-backend: persist full chat turns (widgets + steps) in conversations API. Blocks #2026."
+  - issue: 2027
+    persona: frontend
+    note: "C2: extract ChatSurface config from ChatPage (parallel with #2025)."
+  - issue: 2026
+    persona: frontend
+    note: "C1-frontend: wire useConversations/useChatSession to metadata API (#2025)."
   - issue: 1737
     persona: backend
     note: "Remove backend GraphQL + agent + decouple MPP (#1692 child)"


### PR DESCRIPTION
## Summary
- Fix silphco queue file resolution (`silphcoanalytics.queue.yaml` vs double `targets/` prefix that yielded an empty FIFO).
- Move worktree base to `~/tmp/agent-worktrees` (user-writable; `/tmp/agent-worktrees` was root-owned on the dispatch host).
- Queue chat architecture issues #2025–#2027 for silphcoanalytics fleet dispatch.

## Test plan
- [x] `agent-fleet-watch --queue-status` shows 4 pending items at correct path
- [x] Queue dispatch succeeded for #2025/#2027/#2026 after local fix

Made with [Cursor](https://cursor.com)