### PR TITLE
fix(silphco): bootstrap from agent-fleet, not silphco scripts

### DIFF
--- a/targets/silphcoanalytics.agent-fleet.yaml
+++ b/targets/silphcoanalytics.agent-fleet.yaml
@@ -8,13 +8,13 @@ default_branch: main
 use_worktree: true
 
 worktree_bootstrap_commands:
-  - bash scripts/fleet-worktree-bootstrap.sh
+  # Lives in agent-fleet repo — runs with cwd = target worktree (silphco checkout).
+  - bash /home/evan/Documents/agent-fleet/scripts/worktree-bootstrap.sh
 
 personas_dir: agents/personas
 worktree_base: ~/tmp/agent-worktrees
 
 verify_commands:
-  - bash scripts/fleet-worktree-bootstrap.sh
   - uv run --directory agents python agents/verify.py ..
   - uv run --directory api ruff check .
 


### PR DESCRIPTION
## Summary
- Use `agent-fleet/scripts/worktree-bootstrap.sh` for silphco worktree bootstrap (already existed; identical to silphco copy).
- Remove duplicate bootstrap from `verify_commands` — bootstrap runs once via `worktree_bootstrap_commands`.

Fixes verify exit 127 on fleet runs where silphco `main` has no `scripts/fleet-worktree-bootstrap.sh`.

## Test plan
- [ ] Redispatch #2025/#2026/#2027 passes VERIFY bootstrap step

Made with [Cursor](https://cursor.com)