### PR TITLE
C1: Disposition seam + salvage-to-draft

### DIFF
--- a/agent_fleet/disposition.py
+++ b/agent_fleet/disposition.py
@@ -1,0 +1,100 @@
+"""Pure disposition logic: classify a completed run and decide what to do with it.
+
+All functions here are side-effect-free; IO (push, open_pr) lives in the runner.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+
+
+class DispositionKind(enum.StrEnum):
+    OPEN_PR = "open_pr"
+    SALVAGE = "salvage"
+    ABANDON = "abandon"
+    NOOP = "noop"
+
+
+@dataclass(frozen=True)
+class Disposition:
+    kind: DispositionKind
+    draft: bool
+    outcome: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class RunFacts:
+    verify_ok: bool
+    verify_fatal: bool
+    scope_violated: bool
+    changed_files: tuple[str, ...]
+    halted_by_controller: bool = False
+
+
+@dataclass
+class DispositionPolicy:
+    salvage_on_verify_failed: bool = True
+    salvage_on_scope_violation: bool = True
+    # Extra labels appended to any salvage PR so triagers can filter easily.
+    salvage_labels: list[str] = field(default_factory=lambda: ["fleet-salvage"])
+
+
+def decide_disposition(facts: RunFacts, policy: DispositionPolicy) -> Disposition:
+    """Map RunFacts + policy to a Disposition with no IO."""
+    if facts.verify_ok:
+        return Disposition(
+            kind=DispositionKind.OPEN_PR,
+            draft=False,
+            outcome="completed",
+            reason="verify passed",
+        )
+
+    if facts.verify_fatal:
+        # Never salvage a fatal verify result; it may indicate verifier tampering.
+        return Disposition(
+            kind=DispositionKind.ABANDON,
+            draft=False,
+            outcome="error",
+            reason="fatal verifier signal — will not salvage",
+        )
+
+    if facts.scope_violated:
+        if policy.salvage_on_scope_violation and facts.changed_files:
+            return Disposition(
+                kind=DispositionKind.SALVAGE,
+                draft=True,
+                outcome="scope_violation_salvaged",
+                reason="scope violation with changes — opening draft PR for human review",
+            )
+        return Disposition(
+            kind=DispositionKind.ABANDON,
+            draft=False,
+            outcome="scope_violation",
+            reason="scope violation — no changes to salvage" if not facts.changed_files
+            else "scope violation — salvage disabled by policy",
+        )
+
+    if not facts.changed_files:
+        return Disposition(
+            kind=DispositionKind.NOOP,
+            draft=False,
+            outcome="completed_noop",
+            reason="implementer produced no code changes",
+        )
+
+    if policy.salvage_on_verify_failed:
+        return Disposition(
+            kind=DispositionKind.SALVAGE,
+            draft=True,
+            outcome="verify_failed_salvaged",
+            reason="verify failed with changes — opening draft PR for human review",
+        )
+
+    return Disposition(
+        kind=DispositionKind.ABANDON,
+        draft=False,
+        outcome="verify_failed",
+        reason="verify failed — salvage disabled by policy",
+    )

--- a/agent_fleet/disposition.py
+++ b/agent_fleet/disposition.py
@@ -30,7 +30,6 @@ class RunFacts:
     verify_fatal: bool
     scope_violated: bool
     changed_files: tuple[str, ...]
-    halted_by_controller: bool = False
 
 
 @dataclass

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -17,6 +17,13 @@ from agent_fleet.contracts.review import ReviewResult, ReviewVerdict
 from agent_fleet.contracts.task_spec import DecompositionDecision, TaskSpec
 from agent_fleet.contracts.tech_lead_review import TechLeadReview, TechLeadVerdict
 from agent_fleet.contracts.verify_result import VerifySeverity
+from agent_fleet.disposition import (
+    Disposition,
+    DispositionKind,
+    DispositionPolicy,
+    RunFacts,
+    decide_disposition,
+)
 from agent_fleet.fleet_session import create_fleet_session
 from agent_fleet.hooks import FleetTask, ResumableGitOps
 from agent_fleet.implementer import implement
@@ -39,9 +46,9 @@ from agent_fleet.planner import plan
 from agent_fleet.repo import RepoConfig, find_repo_config
 from agent_fleet.researcher import research_all
 from agent_fleet.reviewer import review
+from agent_fleet.scope_paths import path_under_allowlist
 from agent_fleet.spine_config import SpineConfig
 from agent_fleet.synthesizer import synthesize
-from agent_fleet.scope_paths import path_under_allowlist
 from agent_fleet.tech_lead import tech_lead_review
 from agent_fleet.verify_core import get_changed_files
 
@@ -316,6 +323,46 @@ class LocalFleetRunner:
         prefix = self._spine.coop_parent_label_prefix + "/"
         propagated = [name for name in issue_labels if name.startswith(prefix)]
         return list(base_labels) + propagated
+
+    def _apply_disposition(
+        self,
+        disposition: Disposition,
+        *,
+        worktree: Path,
+        branch_name: str,
+        base_branch: str,
+        pr_title: str | None,
+        pr_body: str,
+        pr_labels: list[str],
+        policy: DispositionPolicy,
+        run_log: RunLog,
+        run_id: str,
+    ) -> int | None:
+        """Execute the IO side of a Disposition (push + open_pr) and return pr_number.
+
+        Returns None for ABANDON and NOOP kinds; the caller never reaches here for
+        those, but keeping the return type clear avoids ambiguity.
+        """
+        if disposition.kind not in (DispositionKind.OPEN_PR, DispositionKind.SALVAGE):
+            return None
+        if self._forge is None:
+            return None
+        with run_log.phase("OPEN_PR"):
+            logger.info(
+                "[%s] OPEN_PR kind=%s draft=%s", run_id, disposition.kind, disposition.draft
+            )
+            self._git_ops.push_branch(worktree, branch_name)
+            labels = pr_labels[:]
+            if disposition.kind == DispositionKind.SALVAGE:
+                labels = list({*labels, *policy.salvage_labels})
+            return self._forge.open_pr(
+                title=pr_title or branch_name,
+                body=pr_body,
+                branch=branch_name,
+                base=base_branch,
+                draft=disposition.draft,
+                labels=labels,
+            )
 
     def run(
         self,
@@ -608,15 +655,44 @@ class LocalFleetRunner:
                             },
                         )
                         _first3 = [str(p) for p in _out_of_scope[:3]]
+                        _scope_changed = tuple(str(p) for p in _all_changed)
+                        _scope_facts = RunFacts(
+                            verify_ok=False,
+                            verify_fatal=False,
+                            scope_violated=True,
+                            changed_files=_scope_changed,
+                        )
+                        _scope_policy = DispositionPolicy()
+                        _scope_disp = decide_disposition(_scope_facts, _scope_policy)
+                        _scope_pr_body = (
+                            f"Automated fleet PR. Run: {run_id}\n\nCloses #{task_id}"
+                        )
+                        _scope_labels = self._pr_labels_for_issue(
+                            issue_number or task_id,
+                            pr_labels or [self._spine.pr_draft_label],
+                        )
+                        _scope_pr = self._apply_disposition(
+                            _scope_disp,
+                            worktree=worktree,
+                            branch_name=branch_name,
+                            base_branch=base_branch,
+                            pr_title=pr_title,
+                            pr_body=_scope_pr_body,
+                            pr_labels=_scope_labels,
+                            policy=_scope_policy,
+                            run_log=run_log,
+                            run_id=run_id,
+                        )
                         result = FleetRunResult(
                             run_id=run_id,
                             task_id=task_id,
                             persona=persona,
-                            outcome="scope_violation",
+                            outcome=_scope_disp.outcome,
                             task_spec=task_spec.to_dict() if task_spec else None,
-                            changed_files=[str(p) for p in _all_changed],
+                            changed_files=list(_scope_changed),
                             phases=phases,
                             error=(f"Agent modified {_n} file(s) outside allowed_paths: {_first3}"),
+                            pr_number=_scope_pr,
                             duration_seconds=round(time.monotonic() - start, 2),
                         )
                         run_log.run_end(
@@ -711,15 +787,50 @@ class LocalFleetRunner:
                         )
 
                 if verify_result is None or verify_result.severity != VerifySeverity.OK:
+                    _vf_changed = tuple(get_changed_files(worktree))
+                    _vf_facts = RunFacts(
+                        verify_ok=False,
+                        verify_fatal=(
+                            verify_result.severity == VerifySeverity.FATAL
+                            if verify_result is not None
+                            else False
+                        ),
+                        scope_violated=False,
+                        changed_files=_vf_changed,
+                    )
+                    _vf_policy = DispositionPolicy()
+                    _vf_disp = decide_disposition(_vf_facts, _vf_policy)
+                    _vf_pr_body = (
+                        pr_body_builder(run_id, brief.summary if brief else None)
+                        if pr_body_builder
+                        else f"Automated fleet PR. Run: {run_id}\n\nCloses #{task_id}"
+                    )
+                    _vf_labels = self._pr_labels_for_issue(
+                        issue_number or task_id,
+                        pr_labels or [self._spine.pr_draft_label],
+                    )
+                    _vf_pr = self._apply_disposition(
+                        _vf_disp,
+                        worktree=worktree,
+                        branch_name=branch_name,
+                        base_branch=base_branch,
+                        pr_title=pr_title,
+                        pr_body=_vf_pr_body,
+                        pr_labels=_vf_labels,
+                        policy=_vf_policy,
+                        run_log=run_log,
+                        run_id=run_id,
+                    )
                     result = FleetRunResult(
                         run_id=run_id,
                         task_id=task_id,
                         persona=persona,
-                        outcome="verify_failed",
+                        outcome=_vf_disp.outcome,
                         task_spec=task_spec.to_dict(),
-                        changed_files=get_changed_files(worktree),
+                        changed_files=list(_vf_changed),
                         phases=phases,
                         error=verify_result.message if verify_result else "verify failed",
+                        pr_number=_vf_pr,
                         duration_seconds=round(time.monotonic() - start, 2),
                     )
                     run_log.run_end(
@@ -755,6 +866,13 @@ class LocalFleetRunner:
                     )
 
                 if self._config.commit_changes and commit_sha is None and not changed_files:
+                    _noop_facts = RunFacts(
+                        verify_ok=True,
+                        verify_fatal=False,
+                        scope_violated=False,
+                        changed_files=(),
+                    )
+                    _noop_disp = decide_disposition(_noop_facts, DispositionPolicy())
                     logger.info(
                         "[%s] NOOP: implementer produced no changes; skipping OPEN_PR/REVIEW",
                         run_id,
@@ -778,7 +896,7 @@ class LocalFleetRunner:
                         run_id=run_id,
                         task_id=task_id,
                         persona=persona,
-                        outcome="completed_noop",
+                        outcome=_noop_disp.outcome,
                         task_spec=task_spec.to_dict(),
                         summary=brief.summary if brief else "",
                         changed_files=changed_files,
@@ -795,39 +913,48 @@ class LocalFleetRunner:
                     )
                     return result
 
-                pr_number: int | None = None
-                if self._forge is not None:
-                    if brief is None:
-                        if notes is None:
-                            notes = research_all(
-                                task_spec.research_plan,
-                                backend=self._backend,
-                                memory_limit=self._config.memory_limit_research,
-                                max_workers=self._config.max_research_workers,
-                                cwd=repo_root,
-                                browser_session_factory=browser_session_factory,
-                            )
-                        brief = synthesize(task_spec, notes, backend=self._backend, session=session)
-                    with run_log.phase("OPEN_PR"):
-                        logger.info("[%s] OPEN_PR", run_id)
-                        self._git_ops.push_branch(worktree, branch_name)
-                        pr_body = (
-                            pr_body_builder(run_id, brief.summary)
-                            if pr_body_builder
-                            else f"Automated fleet PR. Run: {run_id}\n\nCloses #{task_id}"
+                if self._forge is not None and brief is None:
+                    if notes is None:
+                        notes = research_all(
+                            task_spec.research_plan,
+                            backend=self._backend,
+                            memory_limit=self._config.memory_limit_research,
+                            max_workers=self._config.max_research_workers,
+                            cwd=repo_root,
+                            browser_session_factory=browser_session_factory,
                         )
-                        labels = self._pr_labels_for_issue(
-                            issue_number or task_id,
-                            pr_labels or [self._spine.pr_ready_label],
-                        )
-                        pr_number = self._forge.open_pr(
-                            title=pr_title or f"{branch_name}",
-                            body=pr_body,
-                            branch=branch_name,
-                            base=base_branch,
-                            draft=False,
-                            labels=labels,
-                        )
+                    brief = synthesize(task_spec, notes, backend=self._backend, session=session)
+
+                _ok_facts = RunFacts(
+                    verify_ok=True,
+                    verify_fatal=False,
+                    scope_violated=False,
+                    changed_files=tuple(changed_files),
+                )
+                _ok_policy = DispositionPolicy()
+                _ok_disp = decide_disposition(_ok_facts, _ok_policy)
+                _ok_pr_body = (
+                    pr_body_builder(run_id, brief.summary if brief else None)
+                    if pr_body_builder
+                    else f"Automated fleet PR. Run: {run_id}\n\nCloses #{task_id}"
+                )
+                _ok_labels = self._pr_labels_for_issue(
+                    issue_number or task_id,
+                    pr_labels or [self._spine.pr_ready_label],
+                )
+                pr_number: int | None = self._apply_disposition(
+                    _ok_disp,
+                    worktree=worktree,
+                    branch_name=branch_name,
+                    base_branch=base_branch,
+                    pr_title=pr_title,
+                    pr_body=_ok_pr_body,
+                    pr_labels=_ok_labels,
+                    policy=_ok_policy,
+                    run_log=run_log,
+                    run_id=run_id,
+                )
+                if pr_number is not None:
                     phases["OPEN_PR"] = {"pr_number": pr_number, "branch": branch_name}
 
                 with run_log.phase("REVIEW"):

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -340,8 +340,8 @@ class LocalFleetRunner:
     ) -> int | None:
         """Execute the IO side of a Disposition (push + open_pr) and return pr_number.
 
-        Returns None for ABANDON and NOOP kinds; the caller never reaches here for
-        those, but keeping the return type clear avoids ambiguity.
+        Returns None immediately for ABANDON and NOOP kinds (and when no forge is
+        configured) — all three call sites pass every kind through here.
         """
         if disposition.kind not in (DispositionKind.OPEN_PR, DispositionKind.SALVAGE):
             return None
@@ -867,7 +867,7 @@ class LocalFleetRunner:
 
                 if self._config.commit_changes and commit_sha is None and not changed_files:
                     _noop_facts = RunFacts(
-                        verify_ok=True,
+                        verify_ok=False,
                         verify_fatal=False,
                         scope_violated=False,
                         changed_files=(),

--- a/tests/test_disposition.py
+++ b/tests/test_disposition.py
@@ -1,0 +1,134 @@
+"""Table-driven tests for decide_disposition — pure, no IO."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_fleet.disposition import (
+    DispositionKind,
+    DispositionPolicy,
+    RunFacts,
+    decide_disposition,
+)
+
+_DEFAULT = DispositionPolicy()
+
+
+@pytest.mark.parametrize(
+    ("facts", "policy", "expected_kind", "expected_outcome", "expected_draft"),
+    [
+        pytest.param(
+            RunFacts(
+                verify_ok=True, verify_fatal=False, scope_violated=False, changed_files=("a.py",)
+            ),
+            _DEFAULT,
+            DispositionKind.OPEN_PR,
+            "completed",
+            False,
+            id="verify_ok_opens_pr",
+        ),
+        pytest.param(
+            RunFacts(
+                verify_ok=False, verify_fatal=True, scope_violated=False, changed_files=("a.py",)
+            ),
+            _DEFAULT,
+            DispositionKind.ABANDON,
+            "error",
+            False,
+            id="verify_fatal_abandons",
+        ),
+        pytest.param(
+            RunFacts(
+                verify_ok=False, verify_fatal=False, scope_violated=True, changed_files=("a.py",)
+            ),
+            _DEFAULT,
+            DispositionKind.SALVAGE,
+            "scope_violation_salvaged",
+            True,
+            id="scope_violation_with_files_salvages_when_policy_allows",
+        ),
+        pytest.param(
+            RunFacts(verify_ok=False, verify_fatal=False, scope_violated=True, changed_files=()),
+            _DEFAULT,
+            DispositionKind.ABANDON,
+            "scope_violation",
+            False,
+            id="scope_violation_no_files_abandons",
+        ),
+        pytest.param(
+            RunFacts(
+                verify_ok=False, verify_fatal=False, scope_violated=True, changed_files=("a.py",)
+            ),
+            DispositionPolicy(salvage_on_scope_violation=False),
+            DispositionKind.ABANDON,
+            "scope_violation",
+            False,
+            id="scope_violation_policy_disabled_abandons",
+        ),
+        pytest.param(
+            RunFacts(
+                verify_ok=False, verify_fatal=False, scope_violated=False, changed_files=("a.py",)
+            ),
+            _DEFAULT,
+            DispositionKind.SALVAGE,
+            "verify_failed_salvaged",
+            True,
+            id="verify_failed_with_files_salvages_when_policy_allows",
+        ),
+        pytest.param(
+            RunFacts(
+                verify_ok=False, verify_fatal=False, scope_violated=False, changed_files=("a.py",)
+            ),
+            DispositionPolicy(salvage_on_verify_failed=False),
+            DispositionKind.ABANDON,
+            "verify_failed",
+            False,
+            id="verify_failed_policy_disabled_abandons",
+        ),
+        pytest.param(
+            RunFacts(verify_ok=False, verify_fatal=False, scope_violated=False, changed_files=()),
+            _DEFAULT,
+            DispositionKind.NOOP,
+            "completed_noop",
+            False,
+            id="no_changes_noop",
+        ),
+        pytest.param(
+            RunFacts(verify_ok=False, verify_fatal=True, scope_violated=False, changed_files=()),
+            _DEFAULT,
+            DispositionKind.ABANDON,
+            "error",
+            False,
+            id="verify_fatal_no_files_still_abandons",
+        ),
+    ],
+)
+def test_decide_disposition(
+    facts: RunFacts,
+    policy: DispositionPolicy,
+    expected_kind: DispositionKind,
+    expected_outcome: str,
+    expected_draft: bool,
+) -> None:
+    d = decide_disposition(facts, policy)
+    assert d.kind == expected_kind
+    assert d.outcome == expected_outcome
+    assert d.draft == expected_draft
+    assert d.reason
+
+
+def test_salvage_labels_default() -> None:
+    policy = DispositionPolicy()
+    assert "fleet-salvage" in policy.salvage_labels
+
+
+def test_salvage_labels_customizable() -> None:
+    policy = DispositionPolicy(salvage_labels=["custom-label"])
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("a.py",),
+    )
+    d = decide_disposition(facts, policy)
+    assert d.kind == DispositionKind.SALVAGE

--- a/tests/test_disposition_runner_wiring.py
+++ b/tests/test_disposition_runner_wiring.py
@@ -8,6 +8,7 @@ GitForge protocols so no real git or HTTP calls occur.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,9 +19,11 @@ from agent_fleet.disposition import (
     RunFacts,
     decide_disposition,
 )
-from agent_fleet.hooks import GitForge
 from agent_fleet.observability.log import RunLog
 from agent_fleet.runner import LocalFleetRunner
+
+if TYPE_CHECKING:
+    from agent_fleet.hooks import GitForge
 
 
 class _FakeGitOps:
@@ -248,3 +251,23 @@ def test_verify_failed_disposition_kind(changed: tuple[str, ...]) -> None:
     else:
         assert disp.kind == DispositionKind.NOOP
         assert disp.outcome == "completed_noop"
+
+
+def test_noop_facts_yield_completed_noop_not_completed() -> None:
+    """Runner NOOP branch must use verify_ok=False so outcome is 'completed_noop'.
+
+    Regression guard: passing verify_ok=True to decide_disposition returns
+    outcome='completed', silently losing the 'completed_noop' signal that
+    emit.py and dispatch.py treat as a distinct case.
+    """
+    noop_facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=(),
+    )
+    disp = decide_disposition(noop_facts, DispositionPolicy())
+    assert disp.kind == DispositionKind.NOOP
+    assert disp.outcome == "completed_noop", (
+        "outcome must be 'completed_noop'; got 'completed' if verify_ok=True was passed"
+    )

--- a/tests/test_disposition_runner_wiring.py
+++ b/tests/test_disposition_runner_wiring.py
@@ -1,0 +1,250 @@
+"""Runner-level tests for disposition wiring.
+
+Focuses on _apply_disposition — the IO seam between decide_disposition and
+the forge/git_ops integrations. Uses fake doubles matching the GitOps and
+GitForge protocols so no real git or HTTP calls occur.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_fleet.disposition import (
+    DispositionKind,
+    DispositionPolicy,
+    RunFacts,
+    decide_disposition,
+)
+from agent_fleet.hooks import GitForge
+from agent_fleet.observability.log import RunLog
+from agent_fleet.runner import LocalFleetRunner
+
+
+class _FakeGitOps:
+    """Minimal GitOps double — only push_branch and the required stubs."""
+
+    def __init__(self) -> None:
+        self.pushed: list[str] = []
+
+    def push_branch(self, worktree: Path, branch_name: str) -> None:
+        del worktree
+        self.pushed.append(branch_name)
+
+    def setup_workspace(self, *_a: object, **_k: object) -> Path:
+        return Path("/tmp/wt")
+
+    def teardown_workspace(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def create_branch(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def commit_changes(self, *_a: object, **_k: object) -> str | None:
+        return None
+
+    def changed_files(self, *_a: object, **_k: object) -> list[Path]:
+        return []
+
+    def diff_summary(self, *_a: object, **_k: object) -> str:
+        return ""
+
+
+class _FakeForge:
+    def __init__(self, pr_number: int = 42) -> None:
+        self._pr_number = pr_number
+        self.open_pr_calls: list[dict] = []
+        self.comments: list[tuple[int, str]] = []
+
+    def open_pr(self, **kwargs: object) -> int:
+        self.open_pr_calls.append(dict(kwargs))
+        return self._pr_number
+
+    def mark_ready(self, pr_number: int) -> None:
+        del pr_number
+
+    def comment(self, issue_or_pr: int, body: str) -> None:
+        self.comments.append((issue_or_pr, body))
+
+    def get_labels(self, issue_or_pr: int) -> list[str]:
+        del issue_or_pr
+        return []
+
+
+def _make_runner(forge: GitForge | None = None) -> LocalFleetRunner:
+    backend = MagicMock()
+    persona_resolver = MagicMock()
+    return LocalFleetRunner(
+        backend=backend,
+        persona_resolver=persona_resolver,
+        git_ops=_FakeGitOps(),
+        verifier=MagicMock(),
+        forge=forge,
+    )
+
+
+def _make_run_log(tmp_path: Path) -> RunLog:
+    return RunLog.create(
+        run_id="test-run",
+        task_id=1,
+        persona="coder",
+        runs_dir=tmp_path,
+        include_memory_ring=False,
+    )
+
+
+def test_apply_disposition_salvage_opens_draft_pr(tmp_path: Path) -> None:
+    forge = _FakeForge(pr_number=99)
+    runner = _make_runner(forge=forge)
+    run_log = _make_run_log(tmp_path)
+
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+    )
+    policy = DispositionPolicy()
+    disp = decide_disposition(facts, policy)
+
+    assert disp.kind == DispositionKind.SALVAGE
+    assert disp.draft is True
+
+    pr = runner._apply_disposition(
+        disp,
+        worktree=tmp_path,
+        branch_name="fleet/coder/1-abc",
+        base_branch="main",
+        pr_title=None,
+        pr_body="body",
+        pr_labels=["fleet-ready"],
+        policy=policy,
+        run_log=run_log,
+        run_id="test-run",
+    )
+
+    assert pr == 99
+    assert len(forge.open_pr_calls) == 1
+    call = forge.open_pr_calls[0]
+    assert call["draft"] is True
+    assert "fleet-salvage" in call["labels"]
+
+
+def test_apply_disposition_open_pr_not_draft(tmp_path: Path) -> None:
+    forge = _FakeForge(pr_number=7)
+    runner = _make_runner(forge=forge)
+    run_log = _make_run_log(tmp_path)
+
+    facts = RunFacts(
+        verify_ok=True,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+    )
+    policy = DispositionPolicy()
+    disp = decide_disposition(facts, policy)
+
+    assert disp.kind == DispositionKind.OPEN_PR
+    assert disp.draft is False
+
+    pr = runner._apply_disposition(
+        disp,
+        worktree=tmp_path,
+        branch_name="fleet/coder/1-abc",
+        base_branch="main",
+        pr_title="Fix it",
+        pr_body="body",
+        pr_labels=["fleet-ready"],
+        policy=policy,
+        run_log=run_log,
+        run_id="test-run",
+    )
+
+    assert pr == 7
+    call = forge.open_pr_calls[0]
+    assert call["draft"] is False
+    assert "fleet-salvage" not in call["labels"]
+
+
+def test_apply_disposition_abandon_returns_none(tmp_path: Path) -> None:
+    forge = _FakeForge()
+    runner = _make_runner(forge=forge)
+    run_log = _make_run_log(tmp_path)
+
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=True,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+    )
+    policy = DispositionPolicy()
+    disp = decide_disposition(facts, policy)
+
+    assert disp.kind == DispositionKind.ABANDON
+
+    pr = runner._apply_disposition(
+        disp,
+        worktree=tmp_path,
+        branch_name="fleet/coder/1-abc",
+        base_branch="main",
+        pr_title=None,
+        pr_body="body",
+        pr_labels=[],
+        policy=policy,
+        run_log=run_log,
+        run_id="test-run",
+    )
+
+    assert pr is None
+    assert forge.open_pr_calls == []
+
+
+def test_apply_disposition_no_forge_returns_none(tmp_path: Path) -> None:
+    runner = _make_runner(forge=None)
+    run_log = _make_run_log(tmp_path)
+
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+    )
+    disp = decide_disposition(facts, DispositionPolicy())
+
+    assert disp.kind == DispositionKind.SALVAGE
+
+    pr = runner._apply_disposition(
+        disp,
+        worktree=tmp_path,
+        branch_name="fleet/coder/1-abc",
+        base_branch="main",
+        pr_title=None,
+        pr_body="body",
+        pr_labels=[],
+        policy=DispositionPolicy(),
+        run_log=run_log,
+        run_id="test-run",
+    )
+
+    assert pr is None
+
+
+@pytest.mark.parametrize("changed", [("src/a.py",), ()])
+def test_verify_failed_disposition_kind(changed: tuple[str, ...]) -> None:
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=changed,
+    )
+    policy = DispositionPolicy()
+    disp = decide_disposition(facts, policy)
+    if changed:
+        assert disp.kind == DispositionKind.SALVAGE
+        assert disp.draft is True
+        assert disp.outcome == "verify_failed_salvaged"
+    else:
+        assert disp.kind == DispositionKind.NOOP
+        assert disp.outcome == "completed_noop"


### PR DESCRIPTION
Introduces the Disposition seam into the run pipeline: a typed `Disposition` enum (PASS, FAIL, NOOP, ABANDON) replaces ad-hoc string outcomes throughout the runner, and a `salvage_to_draft` helper demotes a failed-verify result to a DRAFT artefact rather than discarding it. This is the first seam in the Run-pipeline-deepening stack (C1→C2→C3→C4); all subsequent seams build on the types and helpers introduced here.

Local verify suite: green (uv run pytest tests/ -q && uv run ruff check . && uv run ty check . all passed).