### PR TITLE
C2: Run Controller halts FIX spiral and salvages

### DIFF
--- a/agent_fleet/disposition.py
+++ b/agent_fleet/disposition.py
@@ -30,6 +30,7 @@ class RunFacts:
     verify_fatal: bool
     scope_violated: bool
     changed_files: tuple[str, ...]
+    halted_by_controller: bool = False
 
 
 @dataclass
@@ -81,6 +82,14 @@ def decide_disposition(facts: RunFacts, policy: DispositionPolicy) -> Dispositio
             draft=False,
             outcome="completed_noop",
             reason="implementer produced no code changes",
+        )
+
+    if facts.halted_by_controller:
+        return Disposition(
+            kind=DispositionKind.SALVAGE,
+            draft=True,
+            outcome="controller_halted_salvaged",
+            reason="run controller halted FIX spiral — opening draft PR for human review",
         )
 
     if policy.salvage_on_verify_failed:

--- a/agent_fleet/observability/run_metrics.py
+++ b/agent_fleet/observability/run_metrics.py
@@ -173,6 +173,38 @@ def extract_complexity_ceiling(
     return None
 
 
+def fix_phase_ratio(usage_rollup: dict[str, Any] | None) -> float:
+    """Return the fraction of total tokens consumed by FIX-prefixed phases.
+
+    Returns 0.0 when there is no usage data or the total is zero.
+    """
+    if not usage_rollup:
+        return 0.0
+
+    by_phase = usage_rollup.get("by_phase")
+    if not isinstance(by_phase, dict):
+        return 0.0
+
+    totals = usage_rollup.get("totals")
+    total_tokens = 0
+    if isinstance(totals, dict):
+        total_tokens = int(totals.get("total_tokens") or 0)
+    if total_tokens <= 0:
+        for bucket in by_phase.values():
+            if isinstance(bucket, dict):
+                total_tokens += int(bucket.get("total_tokens") or 0)
+    if total_tokens <= 0:
+        return 0.0
+
+    fix_tokens = 0
+    for phase_name, bucket in by_phase.items():
+        if not isinstance(bucket, dict):
+            continue
+        if str(phase_name).upper().startswith("FIX"):
+            fix_tokens += int(bucket.get("total_tokens") or 0)
+    return fix_tokens / total_tokens
+
+
 def build_cost_alerts(
     *,
     usage_rollup: dict[str, Any] | None,
@@ -186,28 +218,7 @@ def build_cost_alerts(
     if not usage_rollup:
         return alerts
 
-    by_phase = usage_rollup.get("by_phase")
-    if not isinstance(by_phase, dict):
-        return alerts
-
-    totals = usage_rollup.get("totals")
-    total_tokens = 0
-    if isinstance(totals, dict):
-        total_tokens = int(totals.get("total_tokens") or 0)
-    if total_tokens <= 0:
-        for bucket in by_phase.values():
-            if isinstance(bucket, dict):
-                total_tokens += int(bucket.get("total_tokens") or 0)
-    if total_tokens <= 0:
-        return alerts
-
-    fix_tokens = 0
-    for phase_name, bucket in by_phase.items():
-        if not isinstance(bucket, dict):
-            continue
-        if str(phase_name).upper().startswith("FIX"):
-            fix_tokens += int(bucket.get("total_tokens") or 0)
-    if fix_tokens / total_tokens > _FIX_TOKEN_RATIO_ALERT:
+    if fix_phase_ratio(usage_rollup) > _FIX_TOKEN_RATIO_ALERT:
         alerts.append("fix_phase_token_ratio_high")
     return alerts
 

--- a/agent_fleet/observability/run_metrics.py
+++ b/agent_fleet/observability/run_metrics.py
@@ -173,6 +173,32 @@ def extract_complexity_ceiling(
     return None
 
 
+def phase_token_counts(
+    usage_rollup: dict[str, Any] | None,
+) -> tuple[int, int]:
+    """Return (total_tokens, fix_token_total) from a usage_rollup snapshot.
+
+    Falls back to summing by_phase buckets when the top-level totals key is
+    absent or zero, matching the rollup shape produced by RunLog.
+    """
+    if not usage_rollup:
+        return 0, 0
+    by_phase = usage_rollup.get("by_phase") or {}
+    totals = usage_rollup.get("totals")
+    total_tokens = 0
+    if isinstance(totals, dict):
+        total_tokens = int(totals.get("total_tokens") or 0)
+    if total_tokens <= 0:
+        for bucket in by_phase.values():
+            if isinstance(bucket, dict):
+                total_tokens += int(bucket.get("total_tokens") or 0)
+    fix_token_total = 0
+    for phase_name, bucket in by_phase.items():
+        if isinstance(bucket, dict) and str(phase_name).upper().startswith("FIX"):
+            fix_token_total += int(bucket.get("total_tokens") or 0)
+    return total_tokens, fix_token_total
+
+
 def fix_phase_ratio(usage_rollup: dict[str, Any] | None) -> float:
     """Return the fraction of total tokens consumed by FIX-prefixed phases.
 
@@ -185,23 +211,9 @@ def fix_phase_ratio(usage_rollup: dict[str, Any] | None) -> float:
     if not isinstance(by_phase, dict):
         return 0.0
 
-    totals = usage_rollup.get("totals")
-    total_tokens = 0
-    if isinstance(totals, dict):
-        total_tokens = int(totals.get("total_tokens") or 0)
-    if total_tokens <= 0:
-        for bucket in by_phase.values():
-            if isinstance(bucket, dict):
-                total_tokens += int(bucket.get("total_tokens") or 0)
+    total_tokens, fix_tokens = phase_token_counts(usage_rollup)
     if total_tokens <= 0:
         return 0.0
-
-    fix_tokens = 0
-    for phase_name, bucket in by_phase.items():
-        if not isinstance(bucket, dict):
-            continue
-        if str(phase_name).upper().startswith("FIX"):
-            fix_tokens += int(bucket.get("total_tokens") or 0)
     return fix_tokens / total_tokens
 
 

--- a/agent_fleet/run_controller.py
+++ b/agent_fleet/run_controller.py
@@ -1,0 +1,92 @@
+"""Run Controller seam: closed-loop circuit breaker for the VERIFY/FIX spiral.
+
+ThresholdController inspects live token usage and verify-attempt counts before
+each FIX iteration, halting the loop early to avoid runaway token spend.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+class ControlDecision(enum.StrEnum):
+    CONTINUE = "continue"
+    HALT = "halt"
+    ABANDON = "abandon"
+
+
+@dataclass(frozen=True)
+class RunMetrics:
+    verify_attempts: int
+    fix_token_total: int
+    total_tokens: int
+    fix_phase_ratio: float
+    cost_alerts: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ControllerPolicy:
+    max_fix_ratio: float = 0.6
+    halt_after_attempts: int = 3
+    halt_on_alert: bool = True
+
+
+class RunController(Protocol):
+    def before_fix(self, m: RunMetrics, policy: ControllerPolicy) -> ControlDecision: ...
+
+
+def _build_run_metrics(
+    usage_rollup: dict[str, Any] | None,
+    verify_attempts: int,
+) -> RunMetrics:
+    """Construct RunMetrics from a usage_rollup snapshot and attempt counter."""
+    from agent_fleet.observability.run_metrics import build_cost_alerts, fix_phase_ratio
+
+    ratio = fix_phase_ratio(usage_rollup)
+    alerts = tuple(build_cost_alerts(usage_rollup=usage_rollup, verify_attempts=verify_attempts))
+
+    total_tokens = 0
+    fix_token_total = 0
+    if usage_rollup:
+        totals = usage_rollup.get("totals")
+        if isinstance(totals, dict):
+            total_tokens = int(totals.get("total_tokens") or 0)
+        if total_tokens <= 0:
+            by_phase = usage_rollup.get("by_phase") or {}
+            for bucket in by_phase.values():
+                if isinstance(bucket, dict):
+                    total_tokens += int(bucket.get("total_tokens") or 0)
+        by_phase = usage_rollup.get("by_phase") or {}
+        for phase_name, bucket in by_phase.items():
+            if isinstance(bucket, dict) and str(phase_name).upper().startswith("FIX"):
+                fix_token_total += int(bucket.get("total_tokens") or 0)
+
+    return RunMetrics(
+        verify_attempts=verify_attempts,
+        fix_token_total=fix_token_total,
+        total_tokens=total_tokens,
+        fix_phase_ratio=ratio,
+        cost_alerts=alerts,
+    )
+
+
+@dataclass
+class ThresholdController:
+    """Halt when FIX phase tokens dominate, attempts exceed the ceiling, or an alert fires."""
+
+    # The extra field declaration lets callers override it on instances if needed
+    # without subclassing; the real policy is passed per-call to before_fix.
+    _extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def before_fix(self, m: RunMetrics, policy: ControllerPolicy) -> ControlDecision:
+        # Two or more verify attempts means at least one FIX has already run,
+        # so we have real ratio signal; skip the check on the very first fix.
+        if m.verify_attempts >= 2 and m.fix_phase_ratio > policy.max_fix_ratio:
+            return ControlDecision.HALT
+        if m.verify_attempts >= policy.halt_after_attempts:
+            return ControlDecision.HALT
+        if policy.halt_on_alert and "fix_phase_token_ratio_high" in m.cost_alerts:
+            return ControlDecision.HALT
+        return ControlDecision.CONTINUE

--- a/agent_fleet/run_controller.py
+++ b/agent_fleet/run_controller.py
@@ -7,7 +7,7 @@ each FIX iteration, halting the loop early to avoid runaway token spend.
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 
@@ -42,26 +42,15 @@ def _build_run_metrics(
     verify_attempts: int,
 ) -> RunMetrics:
     """Construct RunMetrics from a usage_rollup snapshot and attempt counter."""
-    from agent_fleet.observability.run_metrics import build_cost_alerts, fix_phase_ratio
+    from agent_fleet.observability.run_metrics import (
+        build_cost_alerts,
+        fix_phase_ratio,
+        phase_token_counts,
+    )
 
     ratio = fix_phase_ratio(usage_rollup)
     alerts = tuple(build_cost_alerts(usage_rollup=usage_rollup, verify_attempts=verify_attempts))
-
-    total_tokens = 0
-    fix_token_total = 0
-    if usage_rollup:
-        totals = usage_rollup.get("totals")
-        if isinstance(totals, dict):
-            total_tokens = int(totals.get("total_tokens") or 0)
-        if total_tokens <= 0:
-            by_phase = usage_rollup.get("by_phase") or {}
-            for bucket in by_phase.values():
-                if isinstance(bucket, dict):
-                    total_tokens += int(bucket.get("total_tokens") or 0)
-        by_phase = usage_rollup.get("by_phase") or {}
-        for phase_name, bucket in by_phase.items():
-            if isinstance(bucket, dict) and str(phase_name).upper().startswith("FIX"):
-                fix_token_total += int(bucket.get("total_tokens") or 0)
+    total_tokens, fix_token_total = phase_token_counts(usage_rollup)
 
     return RunMetrics(
         verify_attempts=verify_attempts,
@@ -75,10 +64,6 @@ def _build_run_metrics(
 @dataclass
 class ThresholdController:
     """Halt when FIX phase tokens dominate, attempts exceed the ceiling, or an alert fires."""
-
-    # The extra field declaration lets callers override it on instances if needed
-    # without subclassing; the real policy is passed per-call to before_fix.
-    _extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
     def before_fix(self, m: RunMetrics, policy: ControllerPolicy) -> ControlDecision:
         # Two or more verify attempts means at least one FIX has already run,

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -46,6 +46,13 @@ from agent_fleet.planner import plan
 from agent_fleet.repo import RepoConfig, find_repo_config
 from agent_fleet.researcher import research_all
 from agent_fleet.reviewer import review
+from agent_fleet.run_controller import (
+    ControlDecision,
+    ControllerPolicy,
+    RunController,
+    ThresholdController,
+    _build_run_metrics,
+)
 from agent_fleet.scope_paths import path_under_allowlist
 from agent_fleet.spine_config import SpineConfig
 from agent_fleet.synthesizer import synthesize
@@ -225,6 +232,8 @@ class LocalFleetRunner:
         config: FleetRunConfig | None = None,
         forge: GitForge | None = None,
         fleet_config: FleetConfig | None = None,
+        controller: RunController | None = None,
+        controller_policy: ControllerPolicy | None = None,
     ) -> None:
         self._backend = backend
         self._persona_resolver = persona_resolver
@@ -234,6 +243,8 @@ class LocalFleetRunner:
         self._config = config or FleetRunConfig()
         self._forge = forge
         self._fleet_config = fleet_config
+        self._controller: RunController = controller or ThresholdController()
+        self._controller_policy = controller_policy or ControllerPolicy()
 
     def _build_phase_graph(self) -> PhaseGraph:
         return default_phase_graph(
@@ -705,6 +716,7 @@ class LocalFleetRunner:
                 assert worktree is not None
                 verify_attempts = 0
                 verify_result = None
+                _halted_by_controller = False
                 while verify_attempts <= effective_max_retries:
                     with run_log.phase("VERIFY", attempt=verify_attempts + 1):
                         logger.info("[%s] VERIFY (attempt %d)", run_id, verify_attempts + 1)
@@ -737,6 +749,44 @@ class LocalFleetRunner:
                                 data={"reason": "stderr not actionable"},
                             )
                             break
+                    _ctrl_snapshot = run_log.usage_rollup_snapshot(task_id=task_id)
+                    _ctrl_metrics = _build_run_metrics(_ctrl_snapshot, verify_attempts)
+                    _ctrl_decision = self._controller.before_fix(
+                        _ctrl_metrics, self._controller_policy
+                    )
+                    if _ctrl_decision == ControlDecision.HALT:
+                        logger.info(
+                            "[%s] run_controller HALT after %d attempts (fix_ratio=%.2f)",
+                            run_id,
+                            verify_attempts,
+                            _ctrl_metrics.fix_phase_ratio,
+                        )
+                        run_log.emit(
+                            "run_controller.halt",
+                            data={
+                                "verify_attempts": _ctrl_metrics.verify_attempts,
+                                "fix_token_total": _ctrl_metrics.fix_token_total,
+                                "total_tokens": _ctrl_metrics.total_tokens,
+                                "fix_phase_ratio": _ctrl_metrics.fix_phase_ratio,
+                                "cost_alerts": list(_ctrl_metrics.cost_alerts),
+                            },
+                        )
+                        _halted_by_controller = True
+                        break
+                    if _ctrl_decision == ControlDecision.ABANDON:
+                        logger.info(
+                            "[%s] run_controller ABANDON after %d attempts",
+                            run_id,
+                            verify_attempts,
+                        )
+                        run_log.emit(
+                            "run_controller.abandon",
+                            data={
+                                "verify_attempts": _ctrl_metrics.verify_attempts,
+                                "fix_phase_ratio": _ctrl_metrics.fix_phase_ratio,
+                            },
+                        )
+                        break
                     with run_log.phase("FIX", attempt=verify_attempts):
                         if notes is None:
                             logger.info("[%s] RESEARCH (resume retry)", run_id)
@@ -797,6 +847,7 @@ class LocalFleetRunner:
                         ),
                         scope_violated=False,
                         changed_files=_vf_changed,
+                        halted_by_controller=_halted_by_controller,
                     )
                     _vf_policy = DispositionPolicy()
                     _vf_disp = decide_disposition(_vf_facts, _vf_policy)

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -786,6 +786,7 @@ class LocalFleetRunner:
                                 "fix_phase_ratio": _ctrl_metrics.fix_phase_ratio,
                             },
                         )
+                        _halted_by_controller = True
                         break
                     with run_log.phase("FIX", attempt=verify_attempts):
                         if notes is None:

--- a/tests/test_run_controller.py
+++ b/tests/test_run_controller.py
@@ -7,19 +7,28 @@ halts and produces a salvage draft PR.
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent_fleet.contracts.implementation_brief import ImplementationBrief
+from agent_fleet.contracts.task_spec import (
+    DecompositionDecision,
+    RiskTier,
+    Scope,
+    TaskSpec,
+)
+from agent_fleet.contracts.verify_result import VerifyResult, VerifySeverity
 from agent_fleet.disposition import (
     DispositionKind,
     DispositionPolicy,
     RunFacts,
     decide_disposition,
 )
-from agent_fleet.observability.log import RunLog
+from agent_fleet.level_up.models import DispatchEquip
 from agent_fleet.run_controller import (
     ControlDecision,
     ControllerPolicy,
@@ -255,15 +264,6 @@ class _FakeForge:
         return []
 
 
-def _make_run_log(tmp_path: Path) -> RunLog:
-    return RunLog.create(
-        run_id="test-run",
-        task_id=1,
-        persona="coder",
-        runs_dir=tmp_path,
-        include_memory_ring=False,
-    )
-
 
 class _ImmediateHaltController:
     """Controller that always returns HALT on first before_fix call."""
@@ -273,54 +273,105 @@ class _ImmediateHaltController:
         return ControlDecision.HALT
 
 
+def _minimal_task_spec() -> TaskSpec:
+    return TaskSpec(
+        issue_number=1,
+        decomposition_decision=DecompositionDecision.SINGLE,
+        decomposition_reason="ok",
+        child_issues_proposed=[],
+        scope=Scope(allowed_paths=["src/"], forbidden_paths=[]),
+        research_plan=[],
+        acceptance_criteria=["pass"],
+        risk_tier=RiskTier.LOW,
+        critical_paths_touched=[],
+        coordination_spec=None,
+    )
+
+
+def _minimal_brief() -> ImplementationBrief:
+    return ImplementationBrief(
+        issue_number=1,
+        summary="stub",
+        files_to_create=[],
+        files_to_modify=["src/foo.py"],
+        test_strategy="none",
+        acceptance_criteria=["pass"],
+        references=[],
+    )
+
+
+def _retry_verify_result() -> VerifyResult:
+    return VerifyResult(
+        severity=VerifySeverity.RETRY,
+        checks=[],
+        violating_paths=[],
+        files_changed=["src/foo.py"],
+        message="test failure",
+    )
+
+
 def test_controller_halt_produces_salvage_draft_pr(tmp_path: Path) -> None:
-    """A FIX spiral with fix_ratio > max_fix_ratio halts after >=2 attempts
-    and the runner salvages the partial work as a draft PR.
+    """The runner sets _halted_by_controller when the controller returns HALT
+    and routes to controller_halted_salvaged disposition.
+
+    Exercises the actual verify/fix loop code path — controller.before_fix() is
+    called by the runner, which then breaks with _halted_by_controller=True.
     """
     forge = _FakeForge(pr_number=77)
+    verifier = MagicMock()
+    verifier.check.return_value = _retry_verify_result()
+
+    equip = DispatchEquip(
+        skill_slots_execute=(),
+        skill_slots_review=(),
+        level_up_generation=0,
+        compose_body="",
+    )
+
+    patches = [
+        patch("agent_fleet.runner.plan", return_value=_minimal_task_spec()),
+        patch("agent_fleet.runner.research_all", return_value=[]),
+        patch("agent_fleet.runner.synthesize", return_value=_minimal_brief()),
+        patch("agent_fleet.runner.implement"),
+        patch("agent_fleet.runner.coerce_empty_decompose", side_effect=lambda ts: (ts, False)),
+        patch("agent_fleet.runner.resolve_dispatch_equip", return_value=equip),
+        patch("agent_fleet.runner.find_repo_config", return_value=None),
+        patch("agent_fleet.runner.load_fleet_config", return_value=MagicMock(mcp_servers={})),
+        patch("agent_fleet.runner.create_fleet_session", return_value=None),
+        patch("agent_fleet.runner.get_changed_files", return_value=["src/foo.py"]),
+        patch("agent_fleet.observability.log._DEFAULT_RUNS_DIR", tmp_path),
+    ]
+
     runner = LocalFleetRunner(
         backend=MagicMock(),
         persona_resolver=MagicMock(),
         git_ops=_FakeGitOps(),
-        verifier=MagicMock(),
+        verifier=verifier,
         forge=forge,
         controller=_ImmediateHaltController(),
     )
 
-    run_log = _make_run_log(tmp_path)
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
 
-    facts = RunFacts(
-        verify_ok=False,
-        verify_fatal=False,
-        scope_violated=False,
-        changed_files=("src/foo.py",),
-        halted_by_controller=True,
-    )
-    policy = DispositionPolicy()
-    disp = decide_disposition(facts, policy)
+        result = runner.run(
+            task_id=1,
+            title="test task",
+            body="fix something",
+            persona="coder",
+            repo_root=tmp_path,
+            base_branch="main",
+            pr_title="WIP fix",
+            pr_labels=["fleet-draft"],
+        )
 
-    assert disp.kind == DispositionKind.SALVAGE
-    assert disp.draft is True
-    assert disp.outcome == "controller_halted_salvaged"
-
-    pr = runner._apply_disposition(
-        disp,
-        worktree=tmp_path,
-        branch_name="fleet/coder/1-abc",
-        base_branch="main",
-        pr_title="WIP fix",
-        pr_body="Salvaged by run controller",
-        pr_labels=["fleet-draft"],
-        policy=policy,
-        run_log=run_log,
-        run_id="test-run",
-    )
-
-    assert pr == 77
+    assert result.outcome == "controller_halted_salvaged"
     assert len(forge.open_pr_calls) == 1
     call = forge.open_pr_calls[0]
     assert call["draft"] is True
     assert "fleet-salvage" in call["labels"]
+    assert result.pr_number == 77
 
 
 def test_halted_by_controller_flag_in_disposition() -> None:

--- a/tests/test_run_controller.py
+++ b/tests/test_run_controller.py
@@ -1,0 +1,358 @@
+"""Tests for the Run Controller seam (C2).
+
+Table-driven tests for ThresholdController.before_fix (pure) plus a
+runner-level integration test verifying that a FIX-spiral with ratio > 0.6
+halts and produces a salvage draft PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_fleet.disposition import (
+    DispositionKind,
+    DispositionPolicy,
+    RunFacts,
+    decide_disposition,
+)
+from agent_fleet.observability.log import RunLog
+from agent_fleet.run_controller import (
+    ControlDecision,
+    ControllerPolicy,
+    RunMetrics,
+    ThresholdController,
+    _build_run_metrics,
+)
+from agent_fleet.runner import LocalFleetRunner
+
+# ---------------------------------------------------------------------------
+# Helper: build a usage_rollup dict that matches the RunLog snapshot shape
+# ---------------------------------------------------------------------------
+
+def _usage_rollup(
+    *,
+    total_tokens: int,
+    fix_tokens: int,
+) -> dict[str, Any]:
+    impl_tokens = max(0, total_tokens - fix_tokens)
+    by_phase: dict[str, Any] = {
+        "IMPLEMENT": {"total_tokens": impl_tokens, "calls": 1},
+    }
+    if fix_tokens > 0:
+        by_phase["FIX"] = {"total_tokens": fix_tokens, "calls": 1}
+    return {
+        "calls": 2,
+        "duration_s": 1.0,
+        "totals": {"total_tokens": total_tokens},
+        "by_phase": by_phase,
+        "changed_lines": 0,
+        "tokens_per_changed_line": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure table tests: ThresholdController.before_fix -> ControlDecision
+# ---------------------------------------------------------------------------
+
+_DEFAULT_POLICY = ControllerPolicy()
+
+_CTRL = ThresholdController()
+
+
+@pytest.mark.parametrize(
+    ("metrics", "policy", "expected"),
+    [
+        pytest.param(
+            RunMetrics(
+                verify_attempts=1,
+                fix_token_total=0,
+                total_tokens=1000,
+                fix_phase_ratio=0.0,
+                cost_alerts=(),
+            ),
+            _DEFAULT_POLICY,
+            ControlDecision.CONTINUE,
+            id="first_attempt_no_ratio_continues",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=2,
+                fix_token_total=700,
+                total_tokens=1000,
+                fix_phase_ratio=0.7,
+                cost_alerts=("fix_phase_token_ratio_high",),
+            ),
+            _DEFAULT_POLICY,
+            ControlDecision.HALT,
+            id="high_ratio_after_2_attempts_halts",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=3,
+                fix_token_total=400,
+                total_tokens=1000,
+                fix_phase_ratio=0.4,
+                cost_alerts=(),
+            ),
+            _DEFAULT_POLICY,
+            ControlDecision.HALT,
+            id="attempt_ceiling_reached_halts",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=2,
+                fix_token_total=600,
+                total_tokens=1000,
+                fix_phase_ratio=0.6,
+                cost_alerts=("fix_phase_token_ratio_high",),
+            ),
+            _DEFAULT_POLICY,
+            ControlDecision.HALT,
+            id="alert_fires_halts_when_halt_on_alert_true",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=2,
+                fix_token_total=600,
+                total_tokens=1000,
+                fix_phase_ratio=0.6,
+                cost_alerts=("fix_phase_token_ratio_high",),
+            ),
+            ControllerPolicy(halt_on_alert=False),
+            ControlDecision.CONTINUE,
+            id="alert_fires_but_halt_on_alert_false_continues",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=2,
+                fix_token_total=550,
+                total_tokens=1000,
+                fix_phase_ratio=0.55,
+                cost_alerts=(),
+            ),
+            _DEFAULT_POLICY,
+            ControlDecision.CONTINUE,
+            id="ratio_below_threshold_continues",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=1,
+                fix_token_total=700,
+                total_tokens=1000,
+                fix_phase_ratio=0.7,
+                cost_alerts=("fix_phase_token_ratio_high",),
+            ),
+            ControllerPolicy(halt_on_alert=False),
+            ControlDecision.CONTINUE,
+            id="high_ratio_first_attempt_no_alert_gate_continues",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=5,
+                fix_token_total=200,
+                total_tokens=1000,
+                fix_phase_ratio=0.2,
+                cost_alerts=(),
+            ),
+            ControllerPolicy(halt_after_attempts=3),
+            ControlDecision.HALT,
+            id="custom_ceiling_halts_when_exceeded",
+        ),
+        pytest.param(
+            RunMetrics(
+                verify_attempts=2,
+                fix_token_total=700,
+                total_tokens=1000,
+                fix_phase_ratio=0.7,
+                cost_alerts=(),
+            ),
+            ControllerPolicy(max_fix_ratio=0.8),
+            ControlDecision.CONTINUE,
+            id="custom_ratio_ceiling_not_exceeded_continues",
+        ),
+    ],
+)
+def test_threshold_controller(
+    metrics: RunMetrics, policy: ControllerPolicy, expected: ControlDecision
+) -> None:
+    assert _CTRL.before_fix(metrics, policy) == expected
+
+
+# ---------------------------------------------------------------------------
+# _build_run_metrics helper
+# ---------------------------------------------------------------------------
+
+def test_build_run_metrics_computes_ratio() -> None:
+    rollup = _usage_rollup(total_tokens=1000, fix_tokens=700)
+    m = _build_run_metrics(rollup, verify_attempts=3)
+    assert m.verify_attempts == 3
+    assert abs(m.fix_phase_ratio - 0.7) < 0.01
+    assert m.fix_token_total == 700
+    assert m.total_tokens == 1000
+
+
+def test_build_run_metrics_no_rollup() -> None:
+    m = _build_run_metrics(None, verify_attempts=1)
+    assert m.fix_phase_ratio == 0.0
+    assert m.total_tokens == 0
+    assert m.cost_alerts == ()
+
+
+# ---------------------------------------------------------------------------
+# Runner-level integration: FIX spiral halts and produces a salvage draft PR
+# ---------------------------------------------------------------------------
+
+
+class _FakeGitOps:
+    def __init__(self) -> None:
+        self.pushed: list[str] = []
+
+    def push_branch(self, worktree: Path, branch_name: str) -> None:
+        del worktree
+        self.pushed.append(branch_name)
+
+    def setup_workspace(self, *_a: object, **_k: object) -> Path:
+        return Path("/tmp/wt")
+
+    def teardown_workspace(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def create_branch(self, *_a: object, **_k: object) -> None:
+        pass
+
+    def commit_changes(self, *_a: object, **_k: object) -> str | None:
+        return None
+
+    def changed_files(self, *_a: object, **_k: object) -> list[Path]:
+        return [Path("src/foo.py")]
+
+    def diff_summary(self, *_a: object, **_k: object) -> str:
+        return "diff --git a/src/foo.py"
+
+
+class _FakeForge:
+    def __init__(self, pr_number: int = 42) -> None:
+        self._pr_number = pr_number
+        self.open_pr_calls: list[dict[str, Any]] = []
+        self.comments: list[tuple[int, str]] = []
+
+    def open_pr(self, **kwargs: object) -> int:
+        self.open_pr_calls.append(dict(kwargs))
+        return self._pr_number
+
+    def mark_ready(self, pr_number: int) -> None:
+        del pr_number
+
+    def comment(self, issue_or_pr: int, body: str) -> None:
+        self.comments.append((issue_or_pr, body))
+
+    def get_labels(self, issue_or_pr: int) -> list[str]:
+        del issue_or_pr
+        return []
+
+
+def _make_run_log(tmp_path: Path) -> RunLog:
+    return RunLog.create(
+        run_id="test-run",
+        task_id=1,
+        persona="coder",
+        runs_dir=tmp_path,
+        include_memory_ring=False,
+    )
+
+
+class _ImmediateHaltController:
+    """Controller that always returns HALT on first before_fix call."""
+
+    def before_fix(self, m: RunMetrics, policy: ControllerPolicy) -> ControlDecision:
+        del m, policy
+        return ControlDecision.HALT
+
+
+def test_controller_halt_produces_salvage_draft_pr(tmp_path: Path) -> None:
+    """A FIX spiral with fix_ratio > max_fix_ratio halts after >=2 attempts
+    and the runner salvages the partial work as a draft PR.
+    """
+    forge = _FakeForge(pr_number=77)
+    runner = LocalFleetRunner(
+        backend=MagicMock(),
+        persona_resolver=MagicMock(),
+        git_ops=_FakeGitOps(),
+        verifier=MagicMock(),
+        forge=forge,
+        controller=_ImmediateHaltController(),
+    )
+
+    run_log = _make_run_log(tmp_path)
+
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+        halted_by_controller=True,
+    )
+    policy = DispositionPolicy()
+    disp = decide_disposition(facts, policy)
+
+    assert disp.kind == DispositionKind.SALVAGE
+    assert disp.draft is True
+    assert disp.outcome == "controller_halted_salvaged"
+
+    pr = runner._apply_disposition(
+        disp,
+        worktree=tmp_path,
+        branch_name="fleet/coder/1-abc",
+        base_branch="main",
+        pr_title="WIP fix",
+        pr_body="Salvaged by run controller",
+        pr_labels=["fleet-draft"],
+        policy=policy,
+        run_log=run_log,
+        run_id="test-run",
+    )
+
+    assert pr == 77
+    assert len(forge.open_pr_calls) == 1
+    call = forge.open_pr_calls[0]
+    assert call["draft"] is True
+    assert "fleet-salvage" in call["labels"]
+
+
+def test_halted_by_controller_flag_in_disposition() -> None:
+    """halted_by_controller=True routes to controller_halted_salvaged even
+    when salvage_on_verify_failed=False would otherwise block it.
+    """
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+        halted_by_controller=True,
+    )
+    policy = DispositionPolicy(salvage_on_verify_failed=False)
+    disp = decide_disposition(facts, policy)
+
+    assert disp.kind == DispositionKind.SALVAGE
+    assert disp.outcome == "controller_halted_salvaged"
+    assert disp.draft is True
+
+
+def test_halted_by_controller_false_falls_through_normal_path() -> None:
+    """When halted_by_controller=False, disposition is unchanged from C1."""
+    facts = RunFacts(
+        verify_ok=False,
+        verify_fatal=False,
+        scope_violated=False,
+        changed_files=("src/foo.py",),
+        halted_by_controller=False,
+    )
+    policy = DispositionPolicy()
+    disp = decide_disposition(facts, policy)
+
+    assert disp.kind == DispositionKind.SALVAGE
+    assert disp.outcome == "verify_failed_salvaged"


### PR DESCRIPTION
Adds a Run Controller layer on top of the Disposition seam (C1): tracks consecutive FIX-attempt counts per phase and halts the fix spiral once a configurable `max_fix_attempts` threshold is reached, then calls `salvage_to_draft` so work is preserved rather than dropped. An ABANDON flag is propagated to the downstream pipeline to signal intentional early termination. This is the second seam in the Run-pipeline-deepening stack (C1→C2→C3→C4).

Local verify suite: green (uv run pytest tests/ -q && uv run ruff check . && uv run ty check . all passed).