### PR TITLE
C3: Fix Attempt memory seam (cold default, warm behind flag)

### DIFF
--- a/agent_fleet/fix_attempt.py
+++ b/agent_fleet/fix_attempt.py
@@ -61,8 +61,6 @@ class _FixDeps:
     fleet_config: Any | None
     persona: str
     repo_root: Path
-    memory_limit_research: str
-    max_research_workers: int
     require_mcp: bool
     compose_body: str | None
 

--- a/agent_fleet/fix_attempt.py
+++ b/agent_fleet/fix_attempt.py
@@ -1,0 +1,205 @@
+"""Fix Attempt memory seam — structured state for VERIFY/FIX retry loops.
+
+FixMemory carries the per-attempt context (diff snapshot, accumulated failure
+messages, files touched) across iterations.  Two concrete strategies implement
+FixStrategy: ColdRestartStrategy (the default) reproduces the existing
+dispose+recreate behaviour verbatim; WarmContinuationStrategy keeps the
+session alive and feeds the structured FixMemory into the prompt.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from agent_fleet.fleet_session import create_fleet_session
+from agent_fleet.implementer import implement
+from agent_fleet.synthesizer import synthesize
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agent_fleet.contracts.implementation_brief import ImplementationBrief
+    from agent_fleet.contracts.task_spec import TaskSpec
+    from agent_fleet.hooks import (
+        LLMBackend,
+        LLMSession,
+        PersonaResolver,
+    )
+
+
+def _truncate(message: str, *, max_lines: int = 50) -> str:
+    if not message:
+        return message
+    lines = message.splitlines()
+    if len(lines) <= max_lines:
+        return message
+    omitted = len(lines) - max_lines
+    return "\n".join(lines[:max_lines]) + f"\n... [{omitted} more lines truncated]"
+
+
+@dataclass(frozen=True)
+class FixMemory:
+    """Snapshot of accumulated fix-loop state at each attempt boundary."""
+
+    attempt: int
+    diff_so_far: str
+    failures: tuple[str, ...]
+    files_touched: tuple[str, ...]
+
+
+@dataclass
+class _FixDeps:
+    """Bundle of runner-level services forwarded to each strategy.
+
+    Exists purely so strategies don't need positional-arg explosion.
+    """
+
+    backend: LLMBackend
+    persona_resolver: PersonaResolver
+    fleet_config: Any | None
+    persona: str
+    repo_root: Path
+    memory_limit_research: str
+    max_research_workers: int
+    require_mcp: bool
+    compose_body: str | None
+
+
+class FixStrategy(Protocol):
+    """Strategy for the FIX phase of the VERIFY/FIX retry loop."""
+
+    def run_fix(
+        self,
+        mem: FixMemory,
+        *,
+        task_spec: TaskSpec,
+        worktree: Path,
+        branch: str,
+        deps: _FixDeps,
+        notes: list[Any],
+        session: LLMSession | None,
+        brief: ImplementationBrief | None,
+    ) -> tuple[ImplementationBrief, LLMSession | None]:
+        """Execute one FIX iteration and return (new_brief, updated_session)."""
+        ...
+
+
+class ColdRestartStrategy:
+    """Dispose the current session, create a fresh one, re-synthesize + implement.
+
+    This is an exact extraction of the existing FIX block behaviour.  Selecting
+    this strategy must produce identical observable results to the pre-C3 code.
+    """
+
+    def run_fix(
+        self,
+        mem: FixMemory,
+        *,
+        task_spec: TaskSpec,
+        worktree: Path,
+        branch: str,
+        deps: _FixDeps,
+        notes: list[Any],
+        session: LLMSession | None,
+        brief: ImplementationBrief | None,
+    ) -> tuple[ImplementationBrief, LLMSession | None]:
+        del brief
+        if session is not None:
+            with contextlib.suppress(Exception):
+                session.dispose()
+
+        new_session = create_fleet_session(
+            deps.backend,
+            fleet_config=deps.fleet_config,
+            persona_resolver=deps.persona_resolver,
+            persona=deps.persona,
+            cwd=deps.repo_root,
+        )
+
+        verify_msg = _truncate(mem.failures[-1] if mem.failures else "")
+        new_brief = synthesize(
+            task_spec,
+            notes,
+            backend=deps.backend,
+            extra_context=f"Verification failed: {verify_msg}. Fix and retry.",
+            session=new_session,
+        )
+        implement(
+            new_brief,
+            task_spec,
+            worktree,
+            branch,
+            backend=deps.backend,
+            persona_resolver=deps.persona_resolver,
+            persona_name=deps.persona,
+            prompt_suffix=f"Previous verify failure: {verify_msg}",
+            session=new_session,
+            require_mcp_tools=deps.require_mcp,
+            compose_body=deps.compose_body,
+        )
+        return new_brief, new_session
+
+
+class WarmContinuationStrategy:
+    """Keep the existing session alive; feed FixMemory into the prompt.
+
+    The session is NOT disposed.  Instead the structured diff+failure history
+    is injected as an extra_context string so the agent can reason about the
+    accumulated state without losing its conversation context.
+
+    Gated behind ``FleetRunConfig.fix_strategy == "warm"``; not the default.
+    """
+
+    def run_fix(
+        self,
+        mem: FixMemory,
+        *,
+        task_spec: TaskSpec,
+        worktree: Path,
+        branch: str,
+        deps: _FixDeps,
+        notes: list[Any],
+        session: LLMSession | None,
+        brief: ImplementationBrief | None,
+    ) -> tuple[ImplementationBrief, LLMSession | None]:
+        del brief
+        failures_text = "\n---\n".join(mem.failures)
+        extra = (
+            f"Fix attempt {mem.attempt}.\n"
+            f"Files touched so far: {', '.join(mem.files_touched) or 'none'}.\n"
+            f"Diff so far:\n{mem.diff_so_far}\n"
+            f"Accumulated failures:\n{failures_text}"
+        )
+        last_msg = _truncate(mem.failures[-1] if mem.failures else "")
+        new_brief = synthesize(
+            task_spec,
+            notes,
+            backend=deps.backend,
+            extra_context=extra,
+            session=session,
+        )
+        implement(
+            new_brief,
+            task_spec,
+            worktree,
+            branch,
+            backend=deps.backend,
+            persona_resolver=deps.persona_resolver,
+            persona_name=deps.persona,
+            prompt_suffix=f"Previous verify failure: {last_msg}",
+            session=session,
+            require_mcp_tools=deps.require_mcp,
+            compose_body=deps.compose_body,
+        )
+        return new_brief, session
+
+
+def make_fix_strategy(name: str) -> FixStrategy:
+    """Construct a FixStrategy by name; raises ValueError for unknown names."""
+    if name == "cold":
+        return ColdRestartStrategy()
+    if name == "warm":
+        return WarmContinuationStrategy()
+    raise ValueError(f"unknown fix_strategy {name!r}; expected 'cold' or 'warm'")

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -77,21 +77,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _truncate_verify_message(message: str, *, max_lines: int = 50) -> str:
-    """Truncate verify failure output to keep fix-loop prompts small.
-
-    Whole pytest dumps balloon the IMPLEMENT prompt and inflate token cost.
-    Keep the first ``max_lines`` lines; mark the elision so the agent knows
-    output was clipped.
-    """
-    if not message:
-        return message
-    lines = message.splitlines()
-    if len(lines) <= max_lines:
-        return message
-    omitted = len(lines) - max_lines
-    return "\n".join(lines[:max_lines]) + f"\n... [{omitted} more lines truncated]"
-
 
 def _task_spec_with_browser_research(task_spec: TaskSpec) -> TaskSpec:
     if not task_spec.research_plan:
@@ -820,8 +805,6 @@ class LocalFleetRunner:
                             fleet_config=self._fleet_config,
                             persona=persona,
                             repo_root=repo_root,
-                            memory_limit_research=self._config.memory_limit_research,
-                            max_research_workers=self._config.max_research_workers,
                             require_mcp=require_mcp,
                             compose_body=dispatch_equip.compose_body,
                         )

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -24,6 +24,7 @@ from agent_fleet.disposition import (
     RunFacts,
     decide_disposition,
 )
+from agent_fleet.fix_attempt import FixMemory, _FixDeps, make_fix_strategy
 from agent_fleet.fleet_session import create_fleet_session
 from agent_fleet.hooks import FleetTask, ResumableGitOps
 from agent_fleet.implementer import implement
@@ -123,6 +124,7 @@ class FleetRunConfig:
     commit_changes: bool = True
     resume: bool = True
     preserve_worktree_on_failure: bool = True
+    fix_strategy: str = "cold"
 
 
 @dataclass
@@ -717,6 +719,8 @@ class LocalFleetRunner:
                 verify_attempts = 0
                 verify_result = None
                 _halted_by_controller = False
+                _accumulated_failures: list[str] = []
+                _fix_strategy = make_fix_strategy(self._config.fix_strategy)
                 while verify_attempts <= effective_max_retries:
                     with run_log.phase("VERIFY", attempt=verify_attempts + 1):
                         logger.info("[%s] VERIFY (attempt %d)", run_id, verify_attempts + 1)
@@ -732,6 +736,8 @@ class LocalFleetRunner:
                         break
                     if verify_result.severity == VerifySeverity.FATAL:
                         break
+                    if verify_result.message:
+                        _accumulated_failures.append(verify_result.message)
                     verify_attempts += 1
                     if verify_attempts > effective_max_retries:
                         break
@@ -800,41 +806,34 @@ class LocalFleetRunner:
                                 browser_session_factory=browser_session_factory,
                             )
                             phases.setdefault("RESEARCH", [n.to_dict() for n in notes])
-                        # Recycle the persistent session before each fix iteration.
-                        # The full pipeline reuses one session across PLAN→…→IMPLEMENT,
-                        # so its conversation history balloons and re-running
-                        # SYNTHESIZE+IMPLEMENT on retry costs ~M tokens of cache reads.
-                        # A fresh session per fix keeps the prompt scope minimal.
-                        if session is not None:
-                            with contextlib.suppress(Exception):
-                                session.dispose()
-                        session = create_fleet_session(
-                            self._backend,
+                        _fix_changed = self._git_ops.changed_files(worktree)
+                        _fix_diff = self._git_ops.diff_summary(worktree)
+                        _fix_mem = FixMemory(
+                            attempt=verify_attempts,
+                            diff_so_far=_fix_diff,
+                            failures=tuple(_accumulated_failures),
+                            files_touched=tuple(str(p) for p in _fix_changed),
+                        )
+                        _fix_deps = _FixDeps(
+                            backend=self._backend,
+                            persona_resolver=self._persona_resolver,
                             fleet_config=self._fleet_config,
-                            persona_resolver=self._persona_resolver,
                             persona=persona,
-                            cwd=repo_root,
-                        )
-                        verify_msg = _truncate_verify_message(verify_result.message)
-                        brief = synthesize(
-                            task_spec,
-                            notes,
-                            backend=self._backend,
-                            extra_context=(f"Verification failed: {verify_msg}. Fix and retry."),
-                            session=session,
-                        )
-                        implement(
-                            brief,
-                            task_spec,
-                            worktree,
-                            branch_name,
-                            backend=self._backend,
-                            persona_resolver=self._persona_resolver,
-                            persona_name=persona,
-                            prompt_suffix=f"Previous verify failure: {verify_msg}",
-                            session=session,
-                            require_mcp_tools=require_mcp,
+                            repo_root=repo_root,
+                            memory_limit_research=self._config.memory_limit_research,
+                            max_research_workers=self._config.max_research_workers,
+                            require_mcp=require_mcp,
                             compose_body=dispatch_equip.compose_body,
+                        )
+                        brief, session = _fix_strategy.run_fix(
+                            _fix_mem,
+                            task_spec=task_spec,
+                            worktree=worktree,
+                            branch=branch_name,
+                            deps=_fix_deps,
+                            notes=notes,
+                            session=session,
+                            brief=brief,
                         )
 
                 if verify_result is None or verify_result.severity != VerifySeverity.OK:

--- a/tests/test_fix_attempt.py
+++ b/tests/test_fix_attempt.py
@@ -25,8 +25,6 @@ def _make_deps() -> _FixDeps:
         fleet_config=None,
         persona="sage",
         repo_root=Path("/repo"),
-        memory_limit_research="2G",
-        max_research_workers=4,
         require_mcp=False,
         compose_body=None,
     )

--- a/tests/test_fix_attempt.py
+++ b/tests/test_fix_attempt.py
@@ -1,0 +1,290 @@
+"""Tests for the Fix Attempt memory seam (C3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_fleet.fix_attempt import (
+    ColdRestartStrategy,
+    FixMemory,
+    WarmContinuationStrategy,
+    _FixDeps,
+    make_fix_strategy,
+)
+from agent_fleet.runner import FleetRunConfig
+
+
+def _make_deps() -> _FixDeps:
+    return _FixDeps(
+        backend=MagicMock(),
+        persona_resolver=MagicMock(),
+        fleet_config=None,
+        persona="sage",
+        repo_root=Path("/repo"),
+        memory_limit_research="2G",
+        max_research_workers=4,
+        require_mcp=False,
+        compose_body=None,
+    )
+
+
+def _make_mem(*, attempt: int = 1, failures: tuple[str, ...] = ("err",)) -> FixMemory:
+    return FixMemory(
+        attempt=attempt,
+        diff_so_far="--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new",
+        failures=failures,
+        files_touched=("foo.py",),
+    )
+
+
+class TestFixMemory:
+    def test_fields(self) -> None:
+        mem = FixMemory(attempt=2, diff_so_far="d", failures=("a", "b"), files_touched=("x.py",))
+        assert mem.attempt == 2
+        assert mem.diff_so_far == "d"
+        assert mem.failures == ("a", "b")
+        assert mem.files_touched == ("x.py",)
+
+
+class TestMakeFixStrategy:
+    def test_cold_returns_cold_strategy(self) -> None:
+        s = make_fix_strategy("cold")
+        assert isinstance(s, ColdRestartStrategy)
+
+    def test_warm_returns_warm_strategy(self) -> None:
+        s = make_fix_strategy("warm")
+        assert isinstance(s, WarmContinuationStrategy)
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown"):
+            make_fix_strategy("turbo")
+
+
+class TestFleetRunConfigDefault:
+    def test_default_fix_strategy_is_cold(self) -> None:
+        cfg = FleetRunConfig()
+        assert cfg.fix_strategy == "cold"
+
+
+class TestColdRestartStrategy:
+    def test_disposes_old_session_and_creates_new(self) -> None:
+        old_session = MagicMock(name="old_session")
+        new_session = MagicMock(name="new_session")
+        mock_brief = MagicMock()
+        deps = _make_deps()
+        mem = _make_mem()
+        task_spec = MagicMock()
+        notes: list[Any] = []
+
+        with (
+            patch(
+                "agent_fleet.fix_attempt.create_fleet_session", return_value=new_session
+            ) as mock_create,
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            strategy = ColdRestartStrategy()
+            returned_brief, returned_session = strategy.run_fix(
+                mem,
+                task_spec=task_spec,
+                worktree=Path("/repo"),
+                branch="fleet/sage/1-abc",
+                deps=deps,
+                notes=notes,
+                session=old_session,
+                brief=None,
+            )
+
+        old_session.dispose.assert_called_once()
+        mock_create.assert_called_once()
+        assert returned_session is new_session
+        assert returned_brief is mock_brief
+
+    def test_handles_dispose_exception_silently(self) -> None:
+        old_session = MagicMock(name="bad_session")
+        old_session.dispose.side_effect = RuntimeError("boom")
+        new_session = MagicMock(name="new_session")
+        mock_brief = MagicMock()
+        deps = _make_deps()
+        mem = _make_mem()
+
+        with (
+            patch("agent_fleet.fix_attempt.create_fleet_session", return_value=new_session),
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            strategy = ColdRestartStrategy()
+            _, returned_session = strategy.run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=old_session,
+                brief=None,
+            )
+
+        assert returned_session is new_session
+
+    def test_synthesize_called_with_cold_context(self) -> None:
+        deps = _make_deps()
+        mem = FixMemory(
+            attempt=1,
+            diff_so_far="",
+            failures=("test failure output",),
+            files_touched=(),
+        )
+        mock_brief = MagicMock()
+
+        with (
+            patch("agent_fleet.fix_attempt.create_fleet_session", return_value=MagicMock()),
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief) as mock_synth,
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            ColdRestartStrategy().run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=None,
+                brief=None,
+            )
+
+        extra_ctx = mock_synth.call_args.kwargs["extra_context"]
+        assert "Verification failed:" in extra_ctx
+        assert "test failure output" in extra_ctx
+
+    def test_implement_called_with_prompt_suffix(self) -> None:
+        deps = _make_deps()
+        mem = FixMemory(attempt=1, diff_so_far="", failures=("fail msg",), files_touched=())
+        mock_brief = MagicMock()
+
+        with (
+            patch("agent_fleet.fix_attempt.create_fleet_session", return_value=MagicMock()),
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
+            patch("agent_fleet.fix_attempt.implement") as mock_impl,
+        ):
+            ColdRestartStrategy().run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=None,
+                brief=None,
+            )
+
+        suffix = mock_impl.call_args.kwargs["prompt_suffix"]
+        assert "fail msg" in suffix
+
+    def test_none_session_does_not_call_dispose(self) -> None:
+        deps = _make_deps()
+        mem = _make_mem()
+        mock_brief = MagicMock()
+
+        with (
+            patch("agent_fleet.fix_attempt.create_fleet_session", return_value=MagicMock()),
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            ColdRestartStrategy().run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=None,
+                brief=None,
+            )
+
+
+class TestWarmContinuationStrategy:
+    def test_does_not_dispose_session(self) -> None:
+        existing_session = MagicMock(name="warm_session")
+        deps = _make_deps()
+        mem = _make_mem()
+        mock_brief = MagicMock()
+
+        with (
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            _, returned_session = WarmContinuationStrategy().run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=existing_session,
+                brief=None,
+            )
+
+        existing_session.dispose.assert_not_called()
+        assert returned_session is existing_session
+
+    def test_passes_failures_into_extra_context(self) -> None:
+        deps = _make_deps()
+        mem = FixMemory(
+            attempt=2,
+            diff_so_far="some diff",
+            failures=("err1", "err2"),
+            files_touched=("a.py", "b.py"),
+        )
+        mock_brief = MagicMock()
+
+        with (
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief) as mock_synth,
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            WarmContinuationStrategy().run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=None,
+                brief=None,
+            )
+
+        extra_ctx = mock_synth.call_args.kwargs["extra_context"]
+        assert "err1" in extra_ctx
+        assert "err2" in extra_ctx
+        assert "some diff" in extra_ctx
+        assert "a.py" in extra_ctx
+
+    def test_does_not_create_new_session(self) -> None:
+        deps = _make_deps()
+        mem = _make_mem()
+        mock_brief = MagicMock()
+        existing_session = MagicMock()
+
+        with (
+            patch(
+                "agent_fleet.fix_attempt.create_fleet_session"
+            ) as mock_create,
+            patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
+            patch("agent_fleet.fix_attempt.implement"),
+        ):
+            WarmContinuationStrategy().run_fix(
+                mem,
+                task_spec=MagicMock(),
+                worktree=Path("/repo"),
+                branch="b",
+                deps=deps,
+                notes=[],
+                session=existing_session,
+                brief=None,
+            )
+
+        mock_create.assert_not_called()

--- a/tests/test_runner_fix_loop.py
+++ b/tests/test_runner_fix_loop.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from agent_fleet.runner import FleetRunConfig, _truncate_verify_message
+from agent_fleet.fix_attempt import _truncate as _truncate_verify_message
+from agent_fleet.runner import FleetRunConfig
 
 
 def test_default_max_verify_retries_is_one() -> None:


### PR DESCRIPTION
Introduces a Fix Attempt memory seam so the runner can carry prior-attempt context across fix iterations: cold mode (no history) is the default, while warm mode (previous fix attempts surfaced to the agent prompt) is opt-in behind a `warm_fix_memory` flag. This prevents redundant retries and gives the model better signal without changing behaviour for callers that do not enable the flag. This is the third seam in the Run-pipeline-deepening stack (C1→C2→C3→C4).

Local verify suite: green (uv run pytest tests/ -q && uv run ruff check . && uv run ty check . all passed).