### PR TITLE
verify: attribute pre-existing failures and honor persona scope in CommandVerifier

### DIFF
--- a/agent_fleet/integrations/command_verifier.py
+++ b/agent_fleet/integrations/command_verifier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import time
 from typing import TYPE_CHECKING
@@ -22,6 +23,26 @@ def _format_failure(headline: str, proc: subprocess.CompletedProcess[str]) -> st
     if not detail:
         return f"{headline}\nexit={proc.returncode}"
     return f"{headline}\nexit={proc.returncode}\n{detail}"
+
+
+_FAILED_RE = re.compile(r"^(?:FAILED|ERROR)\s+(\S+)", re.MULTILINE)
+
+
+def _parse_failed_ids(stdout: str, stderr: str, returncode: int) -> frozenset[str] | None:
+    """Parse pytest failing node-ids from a command's output.
+
+    Returns an empty set when the command passed, the set of failing node-ids
+    when the pytest summary can be parsed, or ``None`` for an opaque failure
+    (non-zero exit with no parseable node-ids, e.g. a lint error or a collection
+    crash). Tokens without a ``.py`` segment are dropped so generic ``ERROR``
+    log lines are not mistaken for tests.
+    """
+    if returncode == 0:
+        return frozenset()
+    ids = frozenset(
+        tok for m in _FAILED_RE.finditer(f"{stdout}\n{stderr}") if ".py" in (tok := m.group(1))
+    )
+    return ids or None
 
 
 class CommandVerifier:
@@ -99,8 +120,9 @@ class CommandVerifier:
                 ),
             )
 
-        verify_commands_ran = bool(self.repo.verify_commands)
-        for cmd in self.repo.verify_commands:
+        commands = self.repo.verify_commands_for(persona)
+        verify_commands_ran = bool(commands)
+        for cmd in commands:
             proc = subprocess.run(
                 cmd,
                 shell=True,
@@ -179,12 +201,28 @@ class CommandVerifier:
                     if rerun_proc.returncode == 0:
                         continue
                     proc = rerun_proc
+                preexisting, new_ids = self._preexisting_only(worktree, cmd, verify_env, proc)
+                if preexisting:
+                    checks[-1]["passed"] = True
+                    checks[-1]["attributed_preexisting"] = True
+                    emit_fleet_event(
+                        "verify.preexisting_skipped",
+                        data={"command": cmd, "exit_code": proc.returncode},
+                    )
+                    continue
+                headline = f"Verification failed: {cmd}"
+                if new_ids:
+                    shown = ", ".join(sorted(new_ids)[:20])
+                    headline = (
+                        f"Verification failed: {cmd}\n"
+                        f"New failures introduced by this change ({len(new_ids)}): {shown}"
+                    )
                 return VerifyResult(
                     severity=VerifySeverity.RETRY,
                     checks=checks,
                     violating_paths=[],
                     files_changed=rel_changed,
-                    message=_format_failure(f"Verification failed: {cmd}", proc),
+                    message=_format_failure(headline, proc),
                 )
 
         if not verify_commands_ran:
@@ -202,7 +240,7 @@ class CommandVerifier:
                     message=f"Modified protected paths: {', '.join(blocked)}",
                 )
 
-        if not self.repo.verify_commands and not rel_changed:
+        if not commands and not rel_changed:
             return VerifyResult(
                 severity=VerifySeverity.OK,
                 checks=checks,
@@ -218,3 +256,68 @@ class CommandVerifier:
             files_changed=rel_changed,
             message="All verification checks passed",
         )
+
+    def _preexisting_only(
+        self,
+        worktree: Path,
+        cmd: str,
+        env: dict[str, str],
+        head_proc: subprocess.CompletedProcess[str],
+    ) -> tuple[bool, frozenset[str]]:
+        """Re-run a failed command against the base tree to attribute failures.
+
+        Stashes the agent's uncommitted edits, re-runs *cmd*, then restores them,
+        so failures already present without this change do not block. Returns
+        ``(is_preexisting_only, newly_introduced_ids)``. Falls back to a
+        conservative block (``False``) when no base can be established (a clean
+        tree, a stash failure, or any git error), preserving prior behavior.
+        """
+        try:
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=str(worktree),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if not status.stdout.strip():
+                return False, frozenset()
+            stash = subprocess.run(
+                ["git", "stash", "push", "--include-untracked", "--quiet"],
+                cwd=str(worktree),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if stash.returncode != 0:
+                return False, frozenset()
+            try:
+                base_proc = subprocess.run(
+                    cmd,
+                    shell=True,
+                    cwd=str(worktree),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env=env,
+                )
+            finally:
+                subprocess.run(
+                    ["git", "stash", "pop", "--quiet"],
+                    cwd=str(worktree),
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+        except Exception:
+            return False, frozenset()
+
+        head_ids = _parse_failed_ids(head_proc.stdout, head_proc.stderr, head_proc.returncode)
+        base_ids = _parse_failed_ids(base_proc.stdout, base_proc.stderr, base_proc.returncode)
+        if head_ids is not None and base_ids is not None:
+            new = head_ids - base_ids
+            return (not new), new
+        # No parseable node-ids (lint, a collection crash). Fall back to exit codes.
+        if base_proc.returncode == 0:
+            return False, frozenset()
+        return True, frozenset()

--- a/tests/test_command_verifier_baseline_attribution.py
+++ b/tests/test_command_verifier_baseline_attribution.py
@@ -1,0 +1,179 @@
+"""Baseline-diff failure attribution and persona scoping in CommandVerifier.
+
+The full-pipeline verify path (``CommandVerifier.check``) is the only gate that
+runs v0.11.2's checks, yet it used to grade an agent's change against the whole
+lane. A lane that was already red on clean main failed every scoped task that
+never touched the red files. These tests pin two fixes:
+
+  * ``check`` runs the persona-scoped command set, not the repo-wide one.
+  * A failing command is re-run against the base tree (the agent's uncommitted
+    edits stashed away). Failures already present without the change are
+    attributed as pre-existing and do not block; only newly introduced node-ids
+    fail the gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+from agent_fleet.contracts.verify_result import VerifyResult, VerifySeverity
+from agent_fleet.integrations.command_verifier import CommandVerifier, _parse_failed_ids
+from agent_fleet.repo import RepoConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A committed "test runner" whose verdict depends on the working tree, so a
+# stash-and-rerun genuinely changes its output between head and base.
+_RUNNER = (
+    "import pathlib, sys\n"
+    "names = pathlib.Path('marker.txt').read_text().split()\n"
+    "for n in names:\n"
+    "    print(f'FAILED tests/test_x.py::{n}')\n"
+    "sys.exit(1 if names else 0)\n"
+)
+
+
+def _git_init(tmpdir: Path) -> None:
+    subprocess.run(["git", "init"], cwd=str(tmpdir), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=str(tmpdir),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(tmpdir),
+        check=True,
+        capture_output=True,
+    )
+
+
+def _commit_all(tmpdir: Path, message: str) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=str(tmpdir), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", message], cwd=str(tmpdir), check=True, capture_output=True
+    )
+
+
+def _seed_runner_repo(tmpdir: Path, marker: str) -> RepoConfig:
+    _git_init(tmpdir)
+    (tmpdir / "fake_tests.py").write_text(_RUNNER, encoding="utf-8")
+    (tmpdir / "marker.txt").write_text(marker, encoding="utf-8")
+    _commit_all(tmpdir, "seed")
+    repo = RepoConfig(repo_root=tmpdir, state_root=tmpdir)
+    repo.verify_commands = [f"{sys.executable} fake_tests.py"]
+    repo.worktree_bootstrap_commands = []
+    repo.critical_path_prefixes = ()
+    return repo
+
+
+def _check(repo: RepoConfig, worktree: Path, persona: str = "coder") -> VerifyResult:
+    return CommandVerifier(repo).check(
+        worktree, persona=persona, changed_files=[], task_id=1
+    )
+
+
+def test_parse_failed_ids_passing_returns_empty() -> None:
+    assert _parse_failed_ids("everything green", "", 0) == frozenset()
+
+
+def test_parse_failed_ids_extracts_node_ids() -> None:
+    out = "FAILED tests/test_x.py::test_a\nFAILED tests/test_y.py::test_b - boom\n"
+    assert _parse_failed_ids(out, "", 1) == frozenset(
+        {"tests/test_x.py::test_a", "tests/test_y.py::test_b"}
+    )
+
+
+def test_parse_failed_ids_opaque_failure_returns_none() -> None:
+    assert _parse_failed_ids("ruff: 3 errors", "", 1) is None
+
+
+def test_parse_failed_ids_drops_non_python_error_lines() -> None:
+    # A bare ERROR log line is not a test node-id and must not be treated as one.
+    assert _parse_failed_ids("ERROR could not connect to db", "", 1) is None
+
+
+def test_preexisting_failure_is_attributed_not_blocked(tmp_path: Path) -> None:
+    repo = _seed_runner_repo(tmp_path, "test_a")
+    # Agent touches an unrelated file; the lane was already red on test_a.
+    (tmp_path / "feature.py").write_text("x = 1\n", encoding="utf-8")
+
+    result = _check(repo, tmp_path)
+
+    assert result.severity is VerifySeverity.OK
+    assert any(c.get("attributed_preexisting") for c in result.checks)
+
+
+def test_introduced_failure_blocks_with_new_node_id(tmp_path: Path) -> None:
+    repo = _seed_runner_repo(tmp_path, "test_a")
+    # Agent's change makes test_b fail on top of the pre-existing test_a.
+    (tmp_path / "marker.txt").write_text("test_a\ntest_b\n", encoding="utf-8")
+
+    result = _check(repo, tmp_path)
+
+    assert result.severity is VerifySeverity.RETRY
+    introduced = next(
+        ln for ln in result.message.splitlines() if "New failures introduced" in ln
+    )
+    # The introduced-failures line names only the new node-id, not the pre-existing one.
+    assert "tests/test_x.py::test_b" in introduced
+    assert "::test_a" not in introduced
+
+
+def test_opaque_failure_base_green_blocks(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "keep.txt").write_text("seed\n", encoding="utf-8")
+    _commit_all(tmp_path, "seed")
+    repo = RepoConfig(repo_root=tmp_path, state_root=tmp_path)
+    repo.verify_commands = ["bash -c 'test -f trigger && exit 1 || exit 0'"]
+    repo.worktree_bootstrap_commands = []
+    repo.critical_path_prefixes = ()
+    # Agent introduces the trigger; without it the base tree is green.
+    (tmp_path / "trigger").write_text("", encoding="utf-8")
+
+    result = _check(repo, tmp_path)
+
+    assert result.severity is VerifySeverity.RETRY
+
+
+def test_opaque_failure_base_red_is_attributed(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "keep.txt").write_text("seed\n", encoding="utf-8")
+    _commit_all(tmp_path, "seed")
+    repo = RepoConfig(repo_root=tmp_path, state_root=tmp_path)
+    repo.verify_commands = ["bash -c 'exit 1'"]
+    repo.worktree_bootstrap_commands = []
+    repo.critical_path_prefixes = ()
+    (tmp_path / "feature.py").write_text("x = 1\n", encoding="utf-8")
+
+    result = _check(repo, tmp_path)
+
+    assert result.severity is VerifySeverity.OK
+    assert any(c.get("attributed_preexisting") for c in result.checks)
+
+
+def test_clean_tree_failure_still_blocks(tmp_path: Path) -> None:
+    # No agent edits, so no base can be established; the failure must block.
+    repo = _seed_runner_repo(tmp_path, "test_a")
+
+    result = _check(repo, tmp_path)
+
+    assert result.severity is VerifySeverity.RETRY
+
+
+def test_persona_scoping_runs_lane_command(tmp_path: Path) -> None:
+    repo = RepoConfig(repo_root=tmp_path, state_root=tmp_path)
+    repo.verify_commands = ["bash -c 'exit 1'"]
+    repo.persona_verify_commands = {"lakestore": ("bash -c 'exit 0'",)}
+    repo.worktree_bootstrap_commands = []
+    repo.critical_path_prefixes = ()
+
+    scoped = _check(repo, tmp_path, persona="lakestore")
+    assert scoped.severity is VerifySeverity.OK
+
+    unscoped = _check(repo, tmp_path, persona="gold")
+    assert unscoped.severity is VerifySeverity.RETRY

--- a/tests/test_command_verifier_baseline_attribution.py
+++ b/tests/test_command_verifier_baseline_attribution.py
@@ -72,9 +72,7 @@ def _seed_runner_repo(tmpdir: Path, marker: str) -> RepoConfig:
 
 
 def _check(repo: RepoConfig, worktree: Path, persona: str = "coder") -> VerifyResult:
-    return CommandVerifier(repo).check(
-        worktree, persona=persona, changed_files=[], task_id=1
-    )
+    return CommandVerifier(repo).check(worktree, persona=persona, changed_files=[], task_id=1)
 
 
 def test_parse_failed_ids_passing_returns_empty() -> None:
@@ -116,9 +114,7 @@ def test_introduced_failure_blocks_with_new_node_id(tmp_path: Path) -> None:
     result = _check(repo, tmp_path)
 
     assert result.severity is VerifySeverity.RETRY
-    introduced = next(
-        ln for ln in result.message.splitlines() if "New failures introduced" in ln
-    )
+    introduced = next(ln for ln in result.message.splitlines() if "New failures introduced" in ln)
     # The introduced-failures line names only the new node-id, not the pre-existing one.
     assert "tests/test_x.py::test_b" in introduced
     assert "::test_a" not in introduced


### PR DESCRIPTION
## Why

`CommandVerifier.check` is the only verify gate that runs v0.11.2's checks (the `runner.run` full-pipeline path), but it had two scope leaks that the `run_verify_phases` path already avoids:

- It graded an agent's change against the **whole lane** instead of the change's own diff. A lane already red on clean `main` failed every scoped task that never touched the red files.
- It ran the **repo-wide** `verify_commands` and ignored per-persona scoping, so a monorepo could not point a persona at its own lane.

The net effect was correct agent work getting rejected against pre-existing debt outside its scope (the "broken oracle" pattern observed in autonomous dispatches where all lanes were red on clean main).

## What

**1. Persona scoping (Fix 2).** `check()` now runs `repo.verify_commands_for(persona)` instead of `repo.verify_commands`, matching the `run_verify_phases` path. Personas without a scoped set fall back to the repo-wide commands, so existing single-lane repos are unaffected.

**2. Baseline-diff failure attribution (Fix 1).** When a verify command fails, re-run it against the base tree by stashing the agent's uncommitted edits (`git stash push --include-untracked`), then restore them. 
- Pytest node-ids present on the base are attributed as pre-existing and do not block. The check is marked `attributed_preexisting` and a `verify.preexisting_skipped` event is emitted.
- Only newly introduced node-ids fail the gate, and the failure message names them (`New failures introduced by this change (N): ...`).
- Opaque failures with no parseable node-ids (lint errors, collection crashes) fall back to comparing exit codes: base green blocks, base red is attributed.
- When no base can be established (clean tree, stash failure, any git error) it conservatively blocks, preserving prior behavior. Lazy by design: the base re-run only happens when head already failed, so the green path is unchanged.

## Tests

New `tests/test_command_verifier_baseline_attribution.py` (10 cases): node-id parsing tri-state, pre-existing vs introduced failures, the opaque exit-code fallback in both directions, the clean-tree block, and persona routing. Full suite green (901 passed, 4 skipped). The single transient failure seen mid-run was a pre-existing stateful artifact in `~/.agent-fleet/fleet/runs/index.jsonl`, unrelated to this change (passes when run in isolation and on a re-run).

## Scope note

This does not touch the repo-side red-lane cleanup (the actual pre-existing failures in the target repo). That is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)