### PR TITLE
fix: clear pre-existing CI debt so main goes green

### DIFF
--- a/agent_fleet/cli.py
+++ b/agent_fleet/cli.py
@@ -614,7 +614,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     try:
         config = load_fleet_config(args.config) if args.config else load_fleet_config()
         backend = config.default_backend
-    except (OSError, ValueError, yaml.YAMLError):
+    except OSError, ValueError, yaml.YAMLError:
         pass
     workspace = Path(args.workspace).resolve() if args.workspace else Path.cwd()
     repo_present = find_repo_config(workspace) is not None

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -40,10 +40,10 @@ from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.redispatch import dispatch_with_retry
 from agent_fleet.repo import RepoConfig, find_repo_config, merge_repo_into_fleet_config
 from agent_fleet.runner import run_full_pipeline
+from agent_fleet.scope_paths import path_under_allowlist
 from agent_fleet.telemetry import span as _telemetry_span
 from agent_fleet.verify_core import is_git_repo
 from agent_fleet.worktree import maybe_commit_recoverable_worktree, should_keep_task_worktree
-from agent_fleet.scope_paths import path_under_allowlist
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -730,15 +730,11 @@ class FleetDispatcher:
 
                 # --- allowed_paths enforcement (task-level, not persona-level) ---
                 if task.allowed_paths and changed_files:
-                    scope_root = (
-                        task_workspace.path if task_workspace is not None else workspace
-                    )
+                    scope_root = task_workspace.path if task_workspace is not None else workspace
                     _out_of_scope = [
                         p
                         for p in changed_files
-                        if not path_under_allowlist(
-                            p, task.allowed_paths, worktree=scope_root
-                        )
+                        if not path_under_allowlist(p, task.allowed_paths, worktree=scope_root)
                     ]
                     if _out_of_scope:
                         _n = len(_out_of_scope)

--- a/agent_fleet/disposition.py
+++ b/agent_fleet/disposition.py
@@ -72,7 +72,8 @@ def decide_disposition(facts: RunFacts, policy: DispositionPolicy) -> Dispositio
             kind=DispositionKind.ABANDON,
             draft=False,
             outcome="scope_violation",
-            reason="scope violation — no changes to salvage" if not facts.changed_files
+            reason="scope violation — no changes to salvage"
+            if not facts.changed_files
             else "scope violation — salvage disabled by policy",
         )
 

--- a/agent_fleet/repo.py
+++ b/agent_fleet/repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -10,6 +11,8 @@ import yaml
 
 from agent_fleet.level_up.config import LevelUpConfig, load_level_up_config
 from agent_fleet.pr_review.config import PrReviewConfig, load_pr_review_config
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from agent_fleet.capacity.config import FleetCapacity
@@ -181,6 +184,12 @@ def load_repo_config(
         for entry in raw.get("targets") or []:
             if isinstance(entry, dict) and entry.get("config"):
                 target_path = (config_root / str(entry["config"])).resolve()
+                if not target_path.exists():
+                    # Per-target configs are kept local and gitignored, so a
+                    # fresh checkout legitimately has none. Skip the missing
+                    # ones instead of failing the whole controller load.
+                    logger.warning("target config not found, skipping: %s", target_path)
+                    continue
                 target_configs.append(load_repo_config(target_path, controller_root=config_root))
 
     return RepoConfig(

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -82,7 +82,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-
 def _task_spec_with_browser_research(task_spec: TaskSpec) -> TaskSpec:
     if not task_spec.research_plan:
         return task_spec
@@ -630,9 +629,7 @@ class LocalFleetRunner:
                                 cwd=repo_root,
                                 browser_session_factory=browser_session_factory,
                             )
-                            ctx.phases.setdefault(
-                                "RESEARCH", [n.to_dict() for n in ctx.notes]
-                            )
+                            ctx.phases.setdefault("RESEARCH", [n.to_dict() for n in ctx.notes])
                         _fix_changed = deps.git_ops.changed_files(worktree)
                         _fix_diff = deps.git_ops.diff_summary(worktree)
                         _fix_mem = FixMemory(
@@ -810,9 +807,7 @@ class LocalFleetRunner:
                             cwd=repo_root,
                             browser_session_factory=browser_session_factory,
                         )
-                    ctx.brief = synthesize(
-                        ts, ctx.notes, backend=deps.backend, session=ctx.session
-                    )
+                    ctx.brief = synthesize(ts, ctx.notes, backend=deps.backend, session=ctx.session)
 
                 _ok_facts = RunFacts(
                     verify_ok=True,

--- a/agent_fleet/workstreams/scope.py
+++ b/agent_fleet/workstreams/scope.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/tests/test_fix_attempt.py
+++ b/tests/test_fix_attempt.py
@@ -268,9 +268,7 @@ class TestWarmContinuationStrategy:
         existing_session = MagicMock()
 
         with (
-            patch(
-                "agent_fleet.fix_attempt.create_fleet_session"
-            ) as mock_create,
+            patch("agent_fleet.fix_attempt.create_fleet_session") as mock_create,
             patch("agent_fleet.fix_attempt.synthesize", return_value=mock_brief),
             patch("agent_fleet.fix_attempt.implement"),
         ):

--- a/tests/test_fleet_context.py
+++ b/tests/test_fleet_context.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _opts(
     workspace_arg: str | None = None,
     config_arg: str | None = None,
@@ -183,9 +184,7 @@ def test_personas_dir_from_repo_true_applies_repo_personas_dir(tmp_path: Path) -
     repo_yaml = tmp_path / ".agent-fleet.yaml"
     repo_yaml.write_text(f"personas_dir: {personas}\n", encoding="utf-8")
 
-    ctx, err = build_fleet_context(
-        _opts(workspace_arg=str(tmp_path), personas_dir_from_repo=True)
-    )
+    ctx, err = build_fleet_context(_opts(workspace_arg=str(tmp_path), personas_dir_from_repo=True))
     assert err is None
     assert ctx is not None
     assert ctx.config.personas_dir == personas
@@ -203,9 +202,7 @@ def test_personas_dir_from_repo_false_does_not_apply(tmp_path: Path) -> None:
 
     fleet_personas = _lfc().personas_dir
 
-    ctx, err = build_fleet_context(
-        _opts(workspace_arg=str(tmp_path), personas_dir_from_repo=False)
-    )
+    ctx, err = build_fleet_context(_opts(workspace_arg=str(tmp_path), personas_dir_from_repo=False))
     assert err is None
     assert ctx is not None
     assert ctx.config.personas_dir == fleet_personas
@@ -231,9 +228,7 @@ def test_use_env_target_config_false_ignores_env(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    ctx, err = build_fleet_context(
-        _opts(workspace_arg=str(workspace), use_env_target_config=False)
-    )
+    ctx, err = build_fleet_context(_opts(workspace_arg=str(workspace), use_env_target_config=False))
     assert err is None
     assert ctx is not None
     # repo must be None (no .agent-fleet.yaml in workspace) — env var ignored
@@ -254,9 +249,7 @@ def test_use_env_target_config_true_honours_env(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    ctx, err = build_fleet_context(
-        _opts(workspace_arg=str(workspace), use_env_target_config=True)
-    )
+    ctx, err = build_fleet_context(_opts(workspace_arg=str(workspace), use_env_target_config=True))
     assert err is None
     assert ctx is not None
     assert ctx.repo is not None

--- a/tests/test_init_installed.py
+++ b/tests/test_init_installed.py
@@ -61,9 +61,7 @@ def test_cmd_init_does_not_depend_on_toplevel_examples(tmp_path: Path) -> None:
     with patch.object(Path, "read_text", _patched_read_text):
         rc = cmd_init(init_args)
 
-    assert rc == 0, (
-        f"cmd_init failed (rc={rc}) — it still depends on the un-packaged examples/ dir"
-    )
+    assert rc == 0, f"cmd_init failed (rc={rc}) — it still depends on the un-packaged examples/ dir"
     assert dest.exists(), ".agent-fleet.yaml was not created"
     content = dest.read_text(encoding="utf-8")
     assert "name:" in content, "generated config missing 'name:' field"

--- a/tests/test_p3_entry_points.py
+++ b/tests/test_p3_entry_points.py
@@ -64,9 +64,7 @@ def test_fleet_console_script_in_pyproject() -> None:
     assert "fleet" in content
     # Verify fleet points to the cli module (not some other target)
     lines = [
-        ln.strip()
-        for ln in content.splitlines()
-        if "fleet" in ln and "agent_fleet.cli:main" in ln
+        ln.strip() for ln in content.splitlines() if "fleet" in ln and "agent_fleet.cli:main" in ln
     ]
     assert lines, "No pyproject.toml line matches 'fleet ... agent_fleet.cli:main'"
 
@@ -233,17 +231,14 @@ def test_schedule_shim_and_fleet_schedule_same_output(tmp_path: Path) -> None:
 
     # Standalone adapter: --workspace precedes the subcommand
     standalone = subprocess.run(
-        [sys.executable, "-m", "agent_fleet.schedule.cli",
-         "--workspace", str(tmp_path), "list"],
+        [sys.executable, "-m", "agent_fleet.schedule.cli", "--workspace", str(tmp_path), "list"],
         env=env,
         capture_output=True,
         text=True,
         check=False,
     )
     # Unified CLI: workspace comes after the schedule subcommand
-    unified = _run_fleet(
-        ["schedule", "list", "--workspace", str(tmp_path)], env
-    )
+    unified = _run_fleet(["schedule", "list", "--workspace", str(tmp_path)], env)
 
     assert standalone.returncode == unified.returncode, (
         f"standalone rc={standalone.returncode}, unified rc={unified.returncode}\n"
@@ -251,6 +246,5 @@ def test_schedule_shim_and_fleet_schedule_same_output(tmp_path: Path) -> None:
         f"unified stderr: {unified.stderr!r}"
     )
     assert standalone.stdout.strip() == unified.stdout.strip(), (
-        f"standalone: {standalone.stdout!r}\n"
-        f"unified:    {unified.stdout!r}"
+        f"standalone: {standalone.stdout!r}\nunified:    {unified.stdout!r}"
     )

--- a/tests/test_p6_docs_version.py
+++ b/tests/test_p6_docs_version.py
@@ -98,13 +98,9 @@ def test_readme_no_agent_fleet_run_command() -> None:
     # Allow agent-fleet as a package reference (e.g. git+https://...agent-fleet.git)
     # but not as a CLI invocation: 'agent-fleet run', 'agent-fleet doctor', etc.
     _cmds = r"(run|doctor|personas|review|loop|watch|schedule|dispatch|summon|init)"
-    bad_cli_pattern = re.compile(
-        rf"^\s*(uv run )?agent-fleet {_cmds}\b", re.MULTILINE
-    )
+    bad_cli_pattern = re.compile(rf"^\s*(uv run )?agent-fleet {_cmds}\b", re.MULTILINE)
     matches = bad_cli_pattern.findall(readme)
-    assert not matches, (
-        f"README still contains old 'agent-fleet <cmd>' CLI invocations: {matches}"
-    )
+    assert not matches, f"README still contains old 'agent-fleet <cmd>' CLI invocations: {matches}"
 
 
 # ---------------------------------------------------------------------------
@@ -237,14 +233,17 @@ def test_personas_uses_fleet_personas() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("doc", [
-    "README.md",
-    "docs/QUICKSTART.md",
-    "docs/NEW-REPO.md",
-    "docs/FLEET-CONFIG.md",
-    "docs/PERSONAS.md",
-    "docs/SCHEDULES.md",
-])
+@pytest.mark.parametrize(
+    "doc",
+    [
+        "README.md",
+        "docs/QUICKSTART.md",
+        "docs/NEW-REPO.md",
+        "docs/FLEET-CONFIG.md",
+        "docs/PERSONAS.md",
+        "docs/SCHEDULES.md",
+    ],
+)
 def test_no_migration_table(doc: str) -> None:
     """Docs must not contain old→new migration tables (per locked decision)."""
     content = (ROOT / doc).read_text(encoding="utf-8")
@@ -256,9 +255,7 @@ def test_no_migration_table(doc: str) -> None:
         re.IGNORECASE | re.MULTILINE,
     )
     matches = bad_pattern.findall(content)
-    assert not matches, (
-        f"{doc} appears to contain a migration table: {matches[:3]}"
-    )
+    assert not matches, f"{doc} appears to contain a migration table: {matches[:3]}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_controller.py
+++ b/tests/test_run_controller.py
@@ -42,6 +42,7 @@ from agent_fleet.runner import LocalFleetRunner
 # Helper: build a usage_rollup dict that matches the RunLog snapshot shape
 # ---------------------------------------------------------------------------
 
+
 def _usage_rollup(
     *,
     total_tokens: int,
@@ -195,6 +196,7 @@ def test_threshold_controller(
 # _build_run_metrics helper
 # ---------------------------------------------------------------------------
 
+
 def test_build_run_metrics_computes_ratio() -> None:
     rollup = _usage_rollup(total_tokens=1000, fix_tokens=700)
     m = _build_run_metrics(rollup, verify_attempts=3)
@@ -262,7 +264,6 @@ class _FakeForge:
     def get_labels(self, issue_or_pr: int) -> list[str]:
         del issue_or_pr
         return []
-
 
 
 class _ImmediateHaltController:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -18,9 +18,7 @@ def test_version_flag_exits_0(capsys: pytest.CaptureFixture[str]) -> None:
 
     with pytest.raises(SystemExit) as exc:
         main(["--version"])
-    assert exc.value.code == 0, (
-        f"expected exit code 0 for --version, got {exc.value.code!r}"
-    )
+    assert exc.value.code == 0, f"expected exit code 0 for --version, got {exc.value.code!r}"
     out = capsys.readouterr().out
     assert agent_fleet.__version__ in out, (
         f"version string {agent_fleet.__version__!r} not found in stdout: {out!r}"
@@ -36,9 +34,7 @@ def test_version_flag_includes_program_name(capsys: pytest.CaptureFixture[str]) 
     assert exc.value.code == 0
     out = capsys.readouterr().out
     # Accept either "fleet" or "agent-fleet" as the program prefix.
-    assert "fleet" in out.lower(), (
-        f"expected 'fleet' in --version output, got: {out!r}"
-    )
+    assert "fleet" in out.lower(), f"expected 'fleet' in --version output, got: {out!r}"
 
 
 def test_normalize_argv_version_flag_passthrough() -> None:


### PR DESCRIPTION
## Why

Main CI has been red on two pre-existing jobs since #56, neither caused by feature work. Latest main run: `lint` failure, `test` failure, `ci-gate` failure (typecheck was already green). This clears all three.

## Root causes and fixes

**Lint (11 format-debt files + 2 `ruff check` errors).** The lint job gates on both `ruff format --check` and `ruff check`. Eleven files carried format debt; `ruff check` separately flagged un-sorted imports in `dispatcher.py` and an unused `pathlib.Path` in `workstreams/scope.py`. Applied `ruff format` and `ruff check --fix`. All mechanical.

**Test (4 FileNotFoundError failures).** `test_fleet_context.py::test_config_arg_path_is_used` and three `test_cli_observability.py` tests raised `FileNotFoundError` loading `targets/silphcoanalytics.agent-fleet.yaml`. Commit 9a13308 made per-target configs local and gitignored but left a committed reference to one in `.agent-fleet.yaml`, so a fresh checkout (CI) has no such file while the loader hard-failed on its absence. `load_repo_config` now skips a target whose config file is absent and logs a warning, matching the local-and-optional design contract rather than papering over the symptom. The committed `.agent-fleet.yaml` reference is intentionally left intact so a local controller with the file present still wires it up.

## Verification

Reproduced the CI failure locally by hiding the local untracked target, then verified the exact CI surface with it still hidden:

- `ruff format --check agent_fleet tests integrations` clean
- `ruff check agent_fleet tests integrations` clean
- `ty check agent_fleet tests integrations` clean
- full `pytest` 901 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)