### PR TITLE
fix: _execute_task error path raised UnboundLocalError on early failures

### DIFF
--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -587,6 +587,8 @@ class FleetDispatcher:
 
             token = None
             task_workspace = None
+            run_workspace: Path | None = None
+            phase_results: list[dict[str, object]] = []
             try:
                 token = self._gate.acquire_token(depth=depth)
             except AdmissionDenied:
@@ -701,7 +703,6 @@ class FleetDispatcher:
                 )
                 task = replace(task, equip=equip)
 
-                phase_results: list[dict[str, object]] = []
                 if task_workspace is not None and task_workspace.isolated:
                     phase_results.append(
                         {

--- a/tests/test_dispatcher_except_unbound.py
+++ b/tests/test_dispatcher_except_unbound.py
@@ -1,0 +1,55 @@
+"""Regression: _execute_task's except handler must survive early failures.
+
+An exception thrown before run_workspace and phase_results are assigned used to
+make the except handler itself raise UnboundLocalError, masking the real error
+and skipping the clean status="error" return. Both names are now pre-initialized
+before the try, mirroring token and task_workspace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.dispatcher import FleetDispatcher
+from agent_fleet.hooks import FleetTask
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _dispatcher() -> FleetDispatcher:
+    return FleetDispatcher(config=load_fleet_config(ROOT / "fleet.example.yaml"))
+
+
+def _raise(exc: Exception) -> Callable[..., object]:
+    def _stub(*_args: object, **_kwargs: object) -> object:
+        raise exc
+
+    return _stub
+
+
+def test_early_resolve_failure_returns_clean_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(FleetDispatcher, "_resolve_workspace", _raise(RuntimeError("boom")))
+
+    result = _dispatcher()._execute_task(0, FleetTask(goal="x"))
+
+    assert result.status == "error"
+    assert "boom" in (result.error or "")
+
+
+def test_repo_config_failure_returns_clean_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(FleetDispatcher, "_resolve_workspace", lambda *_: ROOT)
+    monkeypatch.setattr(
+        "agent_fleet.dispatcher.find_repo_config", _raise(FileNotFoundError("missing target"))
+    )
+
+    result = _dispatcher()._execute_task(0, FleetTask(goal="x"))
+
+    assert result.status == "error"
+    assert "missing target" in (result.error or "")


### PR DESCRIPTION
## Bug

`FleetDispatcher._execute_task` wraps the task body in a `try` / `except Exception`. The handler calls `record_completed_task_experience(phase_results=phase_results, ..., workspace=run_workspace)`, but those two locals are only assigned partway through the `try`. The code pre-initializes `token` and `task_workspace` before the `try` for exactly this reason; `run_workspace` and `phase_results` were missed.

Any exception raised before their in-body assignment makes the handler itself raise `UnboundLocalError`. That masks the original error and skips the clean `status="error"` return, so the whole task crashes instead of reporting a failure. This is reachable. One concrete path is `find_repo_config` raising `FileNotFoundError` on a missing target config, the same condition fixed in #57.

## Reproduction

Driving `_execute_task` with `_resolve_workspace` patched to raise, on `main`:

```
UnboundLocalError: cannot access local variable 'phase_results' where it is not associated with a value
agent_fleet/dispatcher.py:842
```

## Fix

Pre-initialize `run_workspace: Path | None = None` and `phase_results: list[dict[str, object]] = []` before the `try`, mirroring `token` and `task_workspace`. `record_completed_task_experience` already accepts `workspace: Path | None`, so the early-failure path passes `None` cleanly. The now-redundant in-body re-declaration of `phase_results` is removed.

After the fix both reproductions return `status="error"` with the original error preserved (`"boom"`, `"missing target"`).

## How it surfaced

The CI typecheck gate is `ty`, which did not flag this. An ad-hoc `pyright` run during #57 reported `reportPossiblyUnbound` here, which is what surfaced it. We are staying ty-only; this PR just fixes the underlying bug pyright happened to point at. It also reduces pyright's findings on this file from 4 to 2.

## Verification

- New regression test `tests/test_dispatcher_except_unbound.py` (2 cases). Fails with `UnboundLocalError` on `main`, passes with the fix.
- `ruff format --check`, `ruff check`, `ty check` all clean.
- Full `pytest` 903 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)