### PR TITLE
feat(complexity): auto-classify task complexity before dispatch

### DIFF
--- a/agent_fleet/complexity.py
+++ b/agent_fleet/complexity.py
@@ -110,6 +110,84 @@ _RUNTIME_MAP: dict[str, RuntimeConfig] = {
 }
 
 
+_SCOPE_HIGH: frozenset[str] = frozenset(
+    {
+        "refactor",
+        "migrate",
+        "migration",
+        "rewrite",
+        "architect",
+        "architecture",
+        "redesign",
+        "overhaul",
+        "restructure",
+        "cross-cutting",
+        "cross cutting",
+        "system-wide",
+        "system wide",
+        "entire codebase",
+        "multiple services",
+    }
+)
+
+_SCOPE_LOW: frozenset[str] = frozenset(
+    {
+        "fix typo",
+        "rename",
+        "update comment",
+        "update docs",
+        "add comment",
+        "bump version",
+        "format",
+        "lint",
+        "one-liner",
+        "single line",
+        "small fix",
+        "minor fix",
+        "trivial",
+    }
+)
+
+_WORDS_HIGH = 60  # goal word count threshold → at least MED
+_WORDS_VERY_HIGH = 120  # goal word count threshold → HIGH
+_FILES_MED = 3  # changed_files count thresholds
+_FILES_HIGH = 8
+
+
+def classify_complexity(
+    goal: str,
+    changed_files: list[str] | None = None,
+) -> Complexity:
+    """Derive a Complexity tier from *goal* text and optional scope hints.
+
+    Rules applied in order (first match wins):
+    1. Any HIGH scope keyword in goal → HIGH.
+    2. File count >= _FILES_HIGH or goal word count >= _WORDS_VERY_HIGH → HIGH.
+    3. Any LOW scope keyword in goal AND file count <= 1 AND word count < _WORDS_HIGH → LOW.
+    4. File count >= _FILES_MED or word count >= _WORDS_HIGH → MED.
+    5. Default → LOW.
+    """
+    goal_lower = goal.lower()
+    words = len(goal.split())
+    n_files = len(changed_files) if changed_files else 0
+
+    for kw in _SCOPE_HIGH:
+        if kw in goal_lower:
+            return "HIGH"
+
+    if n_files >= _FILES_HIGH or words >= _WORDS_VERY_HIGH:
+        return "HIGH"
+
+    for kw in _SCOPE_LOW:
+        if kw in goal_lower and n_files <= 1 and words < _WORDS_HIGH:
+            return "LOW"
+
+    if n_files >= _FILES_MED or words >= _WORDS_HIGH:
+        return "MED"
+
+    return "LOW"
+
+
 def coerce_complexity(value: str | None) -> Complexity:
     """Validate and normalise a raw complexity string; default to 'MED'.
 

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -18,7 +18,7 @@ from agent_fleet.admission import (
     ResourceTier,
 )
 from agent_fleet.backends import make_backend
-from agent_fleet.complexity import derive_runtime
+from agent_fleet.complexity import classify_complexity, derive_runtime
 from agent_fleet.config import FleetConfig, load_fleet_config
 from agent_fleet.dispatcher_task import (
     build_task_result,
@@ -81,6 +81,9 @@ def _normalize_tasks(
                 continue
             base_branches.append(_optional_entry_str(entry.get("base_branch"), None))
             entry_complexity = _optional_entry_str(entry.get("complexity"), complexity)
+            # Auto-classify when no explicit complexity was declared by the caller.
+            if entry_complexity is None:
+                entry_complexity = classify_complexity(task_goal)
             normalized.append(
                 FleetTask(
                     goal=task_goal,
@@ -94,6 +97,9 @@ def _normalize_tasks(
         if normalized:
             return normalized, base_branches
     if goal and goal.strip():
+        effective_complexity = (
+            complexity if complexity is not None else classify_complexity(goal.strip())
+        )
         return [
             FleetTask(
                 goal=goal.strip(),
@@ -101,7 +107,7 @@ def _normalize_tasks(
                 persona=str(persona or "coder"),
                 workspace=workspace,
                 pipeline=pipeline,
-                complexity=complexity,
+                complexity=effective_complexity,
             )
         ], [None]
     raise ValueError("Provide either 'goal' (single task) or 'tasks' (batch).")

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -9,6 +9,7 @@ import pytest
 
 from agent_fleet.complexity import (
     RuntimeConfig,
+    classify_complexity,
     coerce_complexity,
     derive_runtime,
     is_actionable_stderr,
@@ -380,3 +381,111 @@ def test_build_task_result_no_complexity_task() -> None:
     )
 
     assert result.declared_complexity is None
+
+
+# ---------------------------------------------------------------------------
+# classify_complexity — deterministic tier derivation
+# ---------------------------------------------------------------------------
+
+
+def test_classify_complexity_short_simple_goal_is_low() -> None:
+    assert classify_complexity("fix typo in README") == "LOW"
+
+
+def test_classify_complexity_rename_is_low() -> None:
+    assert classify_complexity("rename the variable foo to bar") == "LOW"
+
+
+def test_classify_complexity_moderate_goal_is_low_by_default() -> None:
+    # Short goal, no keywords, no files → LOW
+    assert classify_complexity("add a unit test for the login endpoint") == "LOW"
+
+
+def test_classify_complexity_scope_keyword_refactor_is_high() -> None:
+    assert classify_complexity("refactor the authentication module") == "HIGH"
+
+
+def test_classify_complexity_scope_keyword_migrate_is_high() -> None:
+    assert classify_complexity("migrate the database schema to Postgres") == "HIGH"
+
+
+def test_classify_complexity_scope_keyword_architecture_is_high() -> None:
+    assert classify_complexity("redesign the service architecture for multi-tenancy") == "HIGH"
+
+
+def test_classify_complexity_many_files_is_high() -> None:
+    files = [f"src/module_{i}.py" for i in range(10)]
+    assert classify_complexity("update all modules", changed_files=files) == "HIGH"
+
+
+def test_classify_complexity_few_files_promotes_to_med() -> None:
+    files = ["src/a.py", "src/b.py", "src/c.py"]
+    assert classify_complexity("update imports in these files", changed_files=files) == "MED"
+
+
+def test_classify_complexity_long_goal_is_med() -> None:
+    # 65 words → MED (above _WORDS_HIGH=60, below _WORDS_VERY_HIGH=120)
+    long_goal = " ".join(["word"] * 65)
+    assert classify_complexity(long_goal) == "MED"
+
+
+def test_classify_complexity_very_long_goal_is_high() -> None:
+    # 125 words → HIGH
+    very_long_goal = " ".join(["word"] * 125)
+    assert classify_complexity(very_long_goal) == "HIGH"
+
+
+def test_classify_complexity_no_files_arg_same_as_empty() -> None:
+    assert classify_complexity("add logging") == classify_complexity(
+        "add logging", changed_files=[]
+    )
+
+
+def test_classify_complexity_explicit_complexity_overrides_classifier() -> None:
+    """An explicit caller-supplied complexity on FleetTask always wins."""
+    from agent_fleet.dispatcher import _normalize_tasks
+
+    # A "refactor" goal would be classified HIGH, but caller says LOW.
+    tasks, _ = _normalize_tasks(
+        goal=None,
+        context=None,
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=[{"goal": "refactor the entire authentication system", "complexity": "LOW"}],
+        complexity=None,
+    )
+    assert tasks[0].complexity == "LOW"
+
+
+def test_classify_complexity_auto_fills_when_no_explicit_complexity() -> None:
+    """When no explicit complexity, _normalize_tasks fills it via classifier."""
+    from agent_fleet.dispatcher import _normalize_tasks
+
+    tasks, _ = _normalize_tasks(
+        goal="refactor the entire authentication system",
+        context=None,
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=None,
+        complexity=None,
+    )
+    # "refactor" triggers HIGH
+    assert tasks[0].complexity == "HIGH"
+
+
+def test_classify_complexity_explicit_single_goal_overrides() -> None:
+    """An explicit complexity on single-goal dispatch wins over classifier."""
+    from agent_fleet.dispatcher import _normalize_tasks
+
+    tasks, _ = _normalize_tasks(
+        goal="refactor the entire system",
+        context=None,
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=None,
+        complexity="LOW",
+    )
+    assert tasks[0].complexity == "LOW"


### PR DESCRIPTION
## Summary

- Adds `classify_complexity(goal, changed_files=None) -> Complexity` to `agent_fleet/complexity.py`: a pure, deterministic function with no LLM call or new dependency. It derives LOW/MED/HIGH from scope keywords (e.g. "refactor", "migrate", "architecture" → HIGH; "fix typo", "rename" → LOW), goal word count (≥60→MED, ≥120→HIGH), and file count (≥3→MED, ≥8→HIGH).
- Wires the classifier into `_normalize_tasks` in `agent_fleet/dispatcher.py`: tasks with no explicit complexity are auto-classified; an explicit caller-supplied complexity always wins as an override. Default behavior for tasks that do specify complexity is unchanged.
- Adds focused regression tests to `tests/test_complexity.py` covering representative goal → tier mappings, file-count promotion, word-count promotion, and the explicit-overrides-classifier invariant. All 927 tests pass.

## Test plan

- [ ] `classify_complexity("fix typo in README")` → LOW
- [ ] `classify_complexity("refactor the authentication module")` → HIGH
- [ ] `classify_complexity(goal, changed_files=[...10 files...])` → HIGH
- [ ] `classify_complexity(goal, changed_files=[...3 files...])` → MED
- [ ] Explicit `"complexity": "LOW"` on a refactor goal → LOW (classifier bypassed)
- [ ] No explicit complexity on a refactor goal → HIGH (classifier fires)
- [ ] `uv run pytest -q` — 927 passed, 4 skipped

Generated with Claude Code (https://claude.com/claude-code)