### PR TITLE
feat(complexity): enforce and surface token-ceiling breaches

### DIFF
--- a/agent_fleet/config.py
+++ b/agent_fleet/config.py
@@ -72,6 +72,7 @@ class FleetConfig:
     repo_config: RepoConfig | None = None
     mcp_servers: dict[str, McpServerSpec] = field(default_factory=dict)
     max_redispatches: int = 1
+    enforce_token_ceiling: bool = False
 
 
 def _expand_path(value: str) -> Path:
@@ -197,4 +198,5 @@ def load_fleet_config(
         default_workspace=default_workspace or data.get("default_workspace"),
         mcp_servers=mcp_catalog,
         max_redispatches=int(data.get("max_redispatches") or 1),
+        enforce_token_ceiling=bool(data.get("enforce_token_ceiling", False)),
     )

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -733,6 +733,7 @@ class FleetDispatcher:
                     max_retries=runtime.retries,
                     token_ceiling=runtime.token_ceiling,
                     declared_complexity=task.complexity,
+                    enforce_token_ceiling=task_config.enforce_token_ceiling,
                 )
                 phase_results.extend(pipeline_results)
 

--- a/agent_fleet/dispatcher_task.py
+++ b/agent_fleet/dispatcher_task.py
@@ -6,6 +6,7 @@ import time
 from typing import TYPE_CHECKING
 
 from agent_fleet.code_review import publish_fleet_branch, run_code_review_with_auto_fix
+from agent_fleet.complexity import observe_token_ceiling
 from agent_fleet.fleet_session import create_fleet_session
 from agent_fleet.handoff_context import apply_handoff_to_task
 from agent_fleet.observability.context import get_run_log
@@ -168,6 +169,7 @@ def run_configured_pipeline(
     max_retries: int | None = None,
     token_ceiling: int | None = None,
     declared_complexity: str | None = None,
+    enforce_token_ceiling: bool = False,
 ) -> tuple[list[dict[str, object]], str, int, list[str] | None]:
     effective_task = apply_handoff_to_task(task, handoff)
     pipeline_name = task.pipeline or task_config.default_pipeline
@@ -190,7 +192,7 @@ def run_configured_pipeline(
     )
     try:
         if use_auto_fix:
-            return run_code_review_with_auto_fix(
+            outcome = run_code_review_with_auto_fix(
                 backend=backend,
                 resolver=resolver,
                 task=effective_task,
@@ -204,22 +206,47 @@ def run_configured_pipeline(
                 token_ceiling=token_ceiling,
                 declared_complexity=declared_complexity,
             )
-        return run_pipeline(
-            backend=backend,
-            resolver=resolver,
-            task=task,
-            workspace=run_workspace,
-            timeout_s=task_config.timeout_seconds,
-            phases=phases,
-            repo=repo_config or git_repo,
-            session=session,
-            fleet_config=task_config,
-            token_ceiling=token_ceiling,
-            declared_complexity=declared_complexity,
-        )
+        else:
+            outcome = run_pipeline(
+                backend=backend,
+                resolver=resolver,
+                task=task,
+                workspace=run_workspace,
+                timeout_s=task_config.timeout_seconds,
+                phases=phases,
+                repo=repo_config or git_repo,
+                session=session,
+                fleet_config=task_config,
+                token_ceiling=token_ceiling,
+                declared_complexity=declared_complexity,
+            )
     finally:
         if session is not None:
             session.dispose()
+
+    # Enforcement is opt-in (enforce_token_ceiling=False by default).
+    # When enabled, a ceiling breach after the pipeline aborts the run instead
+    # of being a log-only metric.
+    if enforce_token_ceiling and token_ceiling is not None and declared_complexity is not None:
+        breach = observe_token_ceiling(
+            token_ceiling=token_ceiling,
+            declared_complexity=declared_complexity,
+        )
+        if breach is not None:
+            phase_results, _summary, _exit_code, changed_files = outcome
+            abort_phase: dict[str, object] = {
+                "phase": "ceiling_abort",
+                "enforced": True,
+                **breach.to_dict(),
+            }
+            return (
+                [*phase_results, abort_phase],
+                f"Token ceiling enforced: {breach.observed_total_tokens} > {breach.ceiling}",
+                1,
+                changed_files,
+            )
+
+    return outcome
 
 
 def build_task_result(

--- a/tests/test_token_ceiling_enforce.py
+++ b/tests/test_token_ceiling_enforce.py
@@ -1,0 +1,177 @@
+"""Regression: token-ceiling enforcement in run_configured_pipeline.
+
+Verifies that:
+- With enforce_token_ceiling=True, a breach returns exit_code=1 and a
+  ceiling_abort phase (not log-only).
+- With enforce_token_ceiling=False (default), a breach is log-only: exit_code
+  is unchanged and no ceiling_abort phase is added.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from agent_fleet.observability.context import bind_run
+from agent_fleet.observability.events import RunContext
+from agent_fleet.observability.log import RunLog
+
+
+def _make_run_log(run_id: str = "test-run") -> RunLog:
+    ctx = RunContext(run_id=run_id)
+    return RunLog(run_id=run_id, context=ctx, sinks=[])
+
+
+def _fake_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.run.return_value = MagicMock(
+        stdout="done", stderr="", exit_code=0, duration_s=0.1, agent_id=None
+    )
+    return backend
+
+
+def _fake_resolver() -> MagicMock:
+    resolver = MagicMock()
+    resolver.load.return_value = MagicMock(
+        name="coder",
+        allowed_tools=[],
+        body="be a coder",
+        extra_instructions="",
+        allowed_paths=(),
+        model="model",
+        mode="agent",
+    )
+    return resolver
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_enforce_ceiling_aborts_when_breached() -> None:
+    """With enforce_token_ceiling=True and a breach, exit_code=1 and a ceiling_abort phase."""
+    from agent_fleet.config import load_fleet_config
+    from agent_fleet.dispatcher_task import run_configured_pipeline
+    from agent_fleet.hooks import FleetTask
+
+    run_log = _make_run_log()
+    # Record usage that exceeds a 1_000_000 ceiling
+    run_log.llm_usage(
+        phase="execute",
+        model="test",
+        duration_s=0.1,
+        input_tokens=600_000,
+        output_tokens=500_000,
+    )
+
+    task = FleetTask(goal="test task", complexity="LOW")
+    task_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task_config.enforce_token_ceiling = True  # opt-in enforcement
+
+    with bind_run(run_log, run_log.context):
+        phase_results, summary, exit_code, _changed = run_configured_pipeline(
+            backend=_fake_backend(),
+            resolver=_fake_resolver(),
+            task=task,
+            run_workspace=Path("/tmp"),
+            task_config=task_config,
+            phases=["execute"],
+            repo_config=None,
+            git_repo=None,
+            handoff=None,
+            token_ceiling=1_000_000,
+            declared_complexity="LOW",
+            enforce_token_ceiling=True,
+        )
+
+    assert exit_code == 1
+    abort_phases = [p for p in phase_results if p.get("phase") == "ceiling_abort"]
+    assert len(abort_phases) == 1
+    assert abort_phases[0]["enforced"] is True
+    observed = abort_phases[0]["observed_total_tokens"]
+    assert isinstance(observed, int) and observed > 1_000_000
+    assert "ceiling enforced" in summary.lower()
+
+
+def test_default_no_enforcement_log_only_when_breached() -> None:
+    """With enforce_token_ceiling=False (default), a breach is log-only: no abort."""
+    from agent_fleet.config import load_fleet_config
+    from agent_fleet.dispatcher_task import run_configured_pipeline
+    from agent_fleet.hooks import FleetTask
+
+    run_log = _make_run_log()
+    run_log.llm_usage(
+        phase="execute",
+        model="test",
+        duration_s=0.1,
+        input_tokens=600_000,
+        output_tokens=500_000,
+    )
+
+    task = FleetTask(goal="test task", complexity="LOW")
+    task_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    # enforce_token_ceiling defaults to False — current log-only behavior
+
+    with bind_run(run_log, run_log.context):
+        phase_results, _summary, exit_code, _changed = run_configured_pipeline(
+            backend=_fake_backend(),
+            resolver=_fake_resolver(),
+            task=task,
+            run_workspace=Path("/tmp"),
+            task_config=task_config,
+            phases=["execute"],
+            repo_config=None,
+            git_repo=None,
+            handoff=None,
+            token_ceiling=1_000_000,
+            declared_complexity="LOW",
+            # enforce_token_ceiling defaults to False
+        )
+
+    # Behavior unchanged: no abort, exit_code from the actual pipeline (0)
+    assert exit_code == 0
+    abort_phases = [p for p in phase_results if p.get("phase") == "ceiling_abort"]
+    assert len(abort_phases) == 0
+    # The log-only metric phase is still present
+    metric_phases = [p for p in phase_results if p.get("phase") == "complexity"]
+    assert len(metric_phases) == 1
+    assert metric_phases[0]["metric_only"] is True
+
+
+def test_enforce_ceiling_no_breach_passes_through() -> None:
+    """With enforce_token_ceiling=True but no breach, outcome is unchanged."""
+    from agent_fleet.config import load_fleet_config
+    from agent_fleet.dispatcher_task import run_configured_pipeline
+    from agent_fleet.hooks import FleetTask
+
+    run_log = _make_run_log()
+    run_log.llm_usage(
+        phase="execute",
+        model="test",
+        duration_s=0.1,
+        input_tokens=100,
+        output_tokens=100,  # well under 1_000_000
+    )
+
+    task = FleetTask(goal="test task", complexity="LOW")
+    task_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    task_config.enforce_token_ceiling = True
+
+    with bind_run(run_log, run_log.context):
+        phase_results, _summary, exit_code, _changed = run_configured_pipeline(
+            backend=_fake_backend(),
+            resolver=_fake_resolver(),
+            task=task,
+            run_workspace=Path("/tmp"),
+            task_config=task_config,
+            phases=["execute"],
+            repo_config=None,
+            git_repo=None,
+            handoff=None,
+            token_ceiling=1_000_000,
+            declared_complexity="LOW",
+            enforce_token_ceiling=True,
+        )
+
+    assert exit_code == 0
+    abort_phases = [p for p in phase_results if p.get("phase") == "ceiling_abort"]
+    assert len(abort_phases) == 0


### PR DESCRIPTION
## Summary

- Adds `enforce_token_ceiling: bool = False` to `FleetConfig` — opt-in flag, defaults to current log-only behavior so no existing runs are affected.
- Threads the flag from `_execute_task` in `dispatcher.py` through `run_configured_pipeline` in `dispatcher_task.py`.
- When `enforce_token_ceiling=True` and `observe_token_ceiling` detects a breach after the pipeline completes, `run_configured_pipeline` returns `exit_code=1` with a `ceiling_abort` phase dict containing the breach details (declared_complexity, observed_total_tokens, ceiling, over_by, efficiency_ratio). Without the flag the existing `complexity.ceiling_metric` log-only path is unchanged.

## Data shape

`enforce_token_ceiling: bool` on `FleetConfig` is the explicit enforcement decision. The abort outcome is surfaced as a `ceiling_abort` phase entry in `phase_results`, making it a first-class result visible to `build_task_result` and the experience recorder.

## Tests

`tests/test_token_ceiling_enforce.py` adds three focused regressions:
- `test_enforce_ceiling_aborts_when_breached` — with enforcement on and usage over ceiling, exit_code=1 and a `ceiling_abort` phase is present.
- `test_default_no_enforcement_log_only_when_breached` — with enforcement off (default), exit_code=0 and only the existing `complexity` metric phase appears.
- `test_enforce_ceiling_no_breach_passes_through` — with enforcement on but no breach, outcome is unchanged (exit_code=0, no abort phase).

Generated with Claude Code (https://claude.com/claude-code)