### PR TITLE
feat(dispatch): dynamic persona routing

### DIFF
--- a/agent_fleet/config.py
+++ b/agent_fleet/config.py
@@ -17,6 +17,7 @@ from agent_fleet.fleet_paths import (
     default_runs_dir,
     user_skill_dir,
 )
+from agent_fleet.persona_router import PersonaRoutingConfig, parse_persona_routing
 from agent_fleet.skills_lib import bundled_skill_dirs, merge_skill_dirs
 
 if TYPE_CHECKING:
@@ -73,6 +74,7 @@ class FleetConfig:
     mcp_servers: dict[str, McpServerSpec] = field(default_factory=dict)
     max_redispatches: int = 1
     enforce_token_ceiling: bool = False
+    persona_routing: PersonaRoutingConfig | None = None
 
 
 def _expand_path(value: str) -> Path:
@@ -199,4 +201,5 @@ def load_fleet_config(
         mcp_servers=mcp_catalog,
         max_redispatches=int(data.get("max_redispatches") or 1),
         enforce_token_ceiling=bool(data.get("enforce_token_ceiling", False)),
+        persona_routing=parse_persona_routing(data.get("persona_routing")),
     )

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -67,6 +67,7 @@ def _resolve_persona(
     *,
     router: PersonaRouter | None,
     fallback: str,
+    scope: str = "",
 ) -> str:
     """Return the persona to use for a task.
 
@@ -75,7 +76,7 @@ def _resolve_persona(
     if explicit:
         return explicit
     if router is not None:
-        return router.route(goal)
+        return router.route(goal, scope)
     return fallback
 
 
@@ -109,11 +110,13 @@ def _normalize_tasks(
             if entry_complexity is None:
                 entry_complexity = classify_complexity(task_goal)
             entry_explicit_persona = _optional_entry_str(entry.get("persona"), caller_persona)
+            entry_scope = str(entry.get("scope") or "")
             resolved_persona = _resolve_persona(
                 entry_explicit_persona,
                 task_goal,
                 router=router,
                 fallback=default_persona,
+                scope=entry_scope,
             )
             normalized.append(
                 FleetTask(

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -35,6 +35,7 @@ from agent_fleet.observability.context import get_run_log
 from agent_fleet.observability.efficiency import changed_lines as _changed_lines
 from agent_fleet.observability.fleet_logger import FleetLogger
 from agent_fleet.observability.run_metrics import build_run_metrics
+from agent_fleet.persona_router import PersonaRouter, PersonaRoutingConfig
 from agent_fleet.personas import YamlPersonaResolver
 from agent_fleet.redispatch import RetryPolicy, dispatch_with_retry
 from agent_fleet.repo import RepoConfig, find_repo_config, merge_repo_into_fleet_config
@@ -60,6 +61,24 @@ def _optional_entry_str(value: object | None, fallback: str | None) -> str | Non
     return str(value)
 
 
+def _resolve_persona(
+    explicit: str | None,
+    goal: str,
+    *,
+    router: PersonaRouter | None,
+    fallback: str,
+) -> str:
+    """Return the persona to use for a task.
+
+    Priority: explicit task persona > routing table > fallback.
+    """
+    if explicit:
+        return explicit
+    if router is not None:
+        return router.route(goal)
+    return fallback
+
+
 def _normalize_tasks(
     *,
     goal: str | None,
@@ -69,7 +88,12 @@ def _normalize_tasks(
     pipeline: str | None,
     tasks: list[dict[str, object]] | None,
     complexity: str | None = None,
+    routing: PersonaRoutingConfig | None = None,
+    default_persona: str = "coder",
 ) -> tuple[list[FleetTask], list[str | None]]:
+    router = PersonaRouter(routing, fallback=default_persona) if routing is not None else None
+    # caller-supplied persona is the fleet-level default; tasks may override per entry
+    caller_persona = persona  # explicit fleet-level persona (may be None)
     base_branches: list[str | None] = []
     if tasks:
         normalized: list[FleetTask] = []
@@ -84,11 +108,18 @@ def _normalize_tasks(
             # Auto-classify when no explicit complexity was declared by the caller.
             if entry_complexity is None:
                 entry_complexity = classify_complexity(task_goal)
+            entry_explicit_persona = _optional_entry_str(entry.get("persona"), caller_persona)
+            resolved_persona = _resolve_persona(
+                entry_explicit_persona,
+                task_goal,
+                router=router,
+                fallback=default_persona,
+            )
             normalized.append(
                 FleetTask(
                     goal=task_goal,
                     context=str(entry.get("context") or ""),
-                    persona=str(entry.get("persona") or persona or "coder"),
+                    persona=resolved_persona,
                     workspace=_optional_entry_str(entry.get("workspace"), workspace),
                     pipeline=_optional_entry_str(entry.get("pipeline"), pipeline),
                     complexity=entry_complexity,
@@ -100,11 +131,17 @@ def _normalize_tasks(
         effective_complexity = (
             complexity if complexity is not None else classify_complexity(goal.strip())
         )
+        resolved_persona = _resolve_persona(
+            caller_persona,
+            goal.strip(),
+            router=router,
+            fallback=default_persona,
+        )
         return [
             FleetTask(
                 goal=goal.strip(),
                 context=str(context or ""),
-                persona=str(persona or "coder"),
+                persona=resolved_persona,
                 workspace=workspace,
                 pipeline=pipeline,
                 complexity=effective_complexity,
@@ -888,6 +925,8 @@ class FleetDispatcher:
             pipeline=pipeline,
             tasks=tasks,
             complexity=complexity,
+            routing=self.config.persona_routing,
+            default_persona=self.config.default_persona,
         )
         if len(normalized) > self.config.max_parallel:
             raise ValueError(

--- a/agent_fleet/persona_router.py
+++ b/agent_fleet/persona_router.py
@@ -1,0 +1,93 @@
+"""Config-driven persona routing.
+
+When a task carries no explicit persona, PersonaRouter selects one from a
+routing table keyed on goal text and/or changed-file scope.  An explicit
+task persona always wins; the router is only consulted on the fallback path.
+
+Config shape (in fleet.yaml or .agent-fleet.yaml under ``persona_routing``):
+
+    persona_routing:
+      rules:
+        - goal_pattern: "(?i)front.?end|css|react"
+          persona: frontend
+        - scope_prefix: "packages/data"
+          persona: data-eng
+        - goal_pattern: "(?i)docs?"
+          scope_prefix: "docs/"
+          persona: tech-writer
+      default_persona: coder   # optional — overrides config.default_persona
+
+A rule matches when ALL specified matchers match:
+- ``goal_pattern`` — Python regex searched against the goal string.
+- ``scope_prefix`` — the scope string starts with this prefix.
+
+Rules are evaluated in order; the first match wins.  When no rule matches the
+router falls back to ``rules.default_persona``, then ``config.default_persona``,
+then the hard-coded sentinel ``"coder"``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RoutingRule:
+    persona: str
+    goal_pattern: str | None = None  # compiled at route() time; None means skip
+    scope_prefix: str | None = None  # None means skip
+
+
+@dataclass
+class PersonaRoutingConfig:
+    rules: list[RoutingRule] = field(default_factory=list)
+    default_persona: str | None = None  # None → defer to FleetConfig.default_persona
+
+
+def parse_persona_routing(raw: dict[str, Any] | None) -> PersonaRoutingConfig | None:
+    """Parse the ``persona_routing`` block from fleet or repo config YAML."""
+    if not raw:
+        return None
+    rules_raw = raw.get("rules") or []
+    rules: list[RoutingRule] = []
+    for entry in rules_raw:
+        if not isinstance(entry, dict):
+            continue
+        persona = str(entry.get("persona") or "").strip()
+        if not persona:
+            continue
+        rules.append(
+            RoutingRule(
+                persona=persona,
+                goal_pattern=str(entry["goal_pattern"]) if entry.get("goal_pattern") else None,
+                scope_prefix=str(entry["scope_prefix"]) if entry.get("scope_prefix") else None,
+            )
+        )
+    default_persona_raw = raw.get("default_persona")
+    return PersonaRoutingConfig(
+        rules=rules,
+        default_persona=str(default_persona_raw) if default_persona_raw else None,
+    )
+
+
+class PersonaRouter:
+    """Selects a persona for a task using a config-driven routing table."""
+
+    def __init__(self, routing: PersonaRoutingConfig, fallback: str = "coder") -> None:
+        self._routing = routing
+        self._fallback = fallback
+
+    def route(self, goal: str, scope: str = "") -> str:
+        """Return the best persona for *goal* and optional *scope*.
+
+        Evaluates rules in declaration order; first match wins.  When no rule
+        matches, returns ``routing.default_persona`` or the constructor fallback.
+        """
+        for rule in self._routing.rules:
+            goal_ok = rule.goal_pattern is None or bool(re.search(rule.goal_pattern, goal))
+            scope_ok = rule.scope_prefix is None or scope.startswith(rule.scope_prefix)
+            if goal_ok and scope_ok:
+                return rule.persona
+        return self._routing.default_persona or self._fallback

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -1,0 +1,238 @@
+"""Regression tests for PersonaRouter and its integration into _normalize_tasks.
+
+Tests that FAIL without the PersonaRouter change and pass with it:
+- A routing rule selects the expected persona.
+- An explicit task persona overrides routing.
+- Absent routing config preserves the current default ('coder').
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.dispatcher import _normalize_tasks
+from agent_fleet.persona_router import (
+    PersonaRouter,
+    PersonaRoutingConfig,
+    RoutingRule,
+    parse_persona_routing,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# PersonaRouter unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_routing_rule_matches_goal_pattern() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="frontend", goal_pattern="(?i)react|css")]
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    assert router.route("Fix the React button styles") == "frontend"
+
+
+def test_routing_rule_no_match_returns_fallback() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="frontend", goal_pattern="(?i)react|css")]
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    assert router.route("Add a new database migration") == "coder"
+
+
+def test_routing_rule_default_persona_overrides_fallback() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="frontend", goal_pattern="(?i)react")],
+        default_persona="data-eng",
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    # goal doesn't match the rule → falls back to routing.default_persona
+    assert router.route("Fix the SQL query") == "data-eng"
+
+
+def test_routing_rules_first_match_wins() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[
+            RoutingRule(persona="frontend", goal_pattern="(?i)css"),
+            RoutingRule(persona="data-eng", goal_pattern="(?i)css|sql"),
+        ]
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    assert router.route("Update the CSS") == "frontend"
+
+
+def test_scope_prefix_rule_matches() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="data-eng", scope_prefix="packages/data")]
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    assert router.route("any goal", scope="packages/data/pipeline.py") == "data-eng"
+
+
+def test_scope_prefix_rule_no_match() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="data-eng", scope_prefix="packages/data")]
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    assert router.route("any goal", scope="packages/ui/button.tsx") == "coder"
+
+
+def test_combined_rule_requires_both_matchers() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[
+            RoutingRule(
+                persona="docs-writer",
+                goal_pattern="(?i)docs?",
+                scope_prefix="docs/",
+            )
+        ]
+    )
+    router = PersonaRouter(routing, fallback="coder")
+    # goal matches but scope doesn't → no match
+    assert router.route("Update docs", scope="src/main.py") == "coder"
+    # both match → rule fires
+    assert router.route("Update docs", scope="docs/guide.md") == "docs-writer"
+
+
+# ---------------------------------------------------------------------------
+# parse_persona_routing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_persona_routing_none() -> None:
+    assert parse_persona_routing(None) is None
+
+
+def test_parse_persona_routing_empty_dict() -> None:
+    assert parse_persona_routing({}) is None
+
+
+def test_parse_persona_routing_full() -> None:
+    raw = {
+        "rules": [
+            {"goal_pattern": "(?i)react", "persona": "frontend"},
+            {"scope_prefix": "data/", "persona": "data-eng"},
+        ],
+        "default_persona": "researcher",
+    }
+    cfg = parse_persona_routing(raw)
+    assert cfg is not None
+    assert len(cfg.rules) == 2
+    assert cfg.rules[0].persona == "frontend"
+    assert cfg.rules[1].scope_prefix == "data/"
+    assert cfg.default_persona == "researcher"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_tasks integration
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_routing_selects_persona() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="frontend", goal_pattern="(?i)react|css")]
+    )
+    tasks, _ = _normalize_tasks(
+        goal="Fix the React button",
+        context="",
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=None,
+        routing=routing,
+        default_persona="coder",
+    )
+    assert tasks[0].persona == "frontend"
+
+
+def test_normalize_explicit_persona_overrides_routing() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="frontend", goal_pattern="(?i)react|css")]
+    )
+    tasks, _ = _normalize_tasks(
+        goal="Fix the React button",
+        context="",
+        persona="reviewer",  # explicit caller persona wins
+        workspace=None,
+        pipeline=None,
+        tasks=None,
+        routing=routing,
+        default_persona="coder",
+    )
+    assert tasks[0].persona == "reviewer"
+
+
+def test_normalize_task_level_persona_overrides_routing() -> None:
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="frontend", goal_pattern="(?i)react")]
+    )
+    tasks, _ = _normalize_tasks(
+        goal=None,
+        context=None,
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=[{"goal": "Fix the React button", "persona": "specialist"}],
+        routing=routing,
+        default_persona="coder",
+    )
+    assert tasks[0].persona == "specialist"
+
+
+def test_normalize_absent_routing_preserves_default() -> None:
+    """When no routing config is present behavior is unchanged (falls back to default_persona)."""
+    tasks, _ = _normalize_tasks(
+        goal="Do something",
+        context="",
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=None,
+        routing=None,
+        default_persona="coder",
+    )
+    assert tasks[0].persona == "coder"
+
+
+def test_normalize_absent_routing_no_persona_uses_coder() -> None:
+    """Mirrors the pre-router behavior: no routing, no persona → 'coder'."""
+    tasks, _ = _normalize_tasks(
+        goal="Fix a bug",
+        context="",
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=None,
+    )
+    assert tasks[0].persona == "coder"
+
+
+# ---------------------------------------------------------------------------
+# Load from config
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_config_persona_routing_none_by_default() -> None:
+    """fleet.example.yaml has no persona_routing — field should be None."""
+    config = load_fleet_config(ROOT / "fleet.example.yaml")
+    assert config.persona_routing is None
+
+
+def test_fleet_config_persona_routing_parsed(tmp_path: Path) -> None:
+    yaml_text = """\
+default_persona: coder
+persona_routing:
+  rules:
+    - goal_pattern: "(?i)frontend"
+      persona: frontend
+  default_persona: researcher
+"""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(yaml_text)
+    config = load_fleet_config(cfg_file)
+    assert config.persona_routing is not None
+    assert len(config.persona_routing.rules) == 1
+    assert config.persona_routing.default_persona == "researcher"

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -210,6 +210,42 @@ def test_normalize_absent_routing_no_persona_uses_coder() -> None:
     assert tasks[0].persona == "coder"
 
 
+def test_normalize_scope_prefix_routing_threaded_through_batch() -> None:
+    """scope_prefix rule must fire when a batch task entry carries a scope field."""
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="data-eng", scope_prefix="packages/data")]
+    )
+    tasks, _ = _normalize_tasks(
+        goal=None,
+        context=None,
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=[{"goal": "Fix the pipeline", "scope": "packages/data/etl.py"}],
+        routing=routing,
+        default_persona="coder",
+    )
+    assert tasks[0].persona == "data-eng"
+
+
+def test_normalize_scope_prefix_routing_no_match_uses_fallback() -> None:
+    """scope_prefix rule must NOT fire when the task scope does not match."""
+    routing = PersonaRoutingConfig(
+        rules=[RoutingRule(persona="data-eng", scope_prefix="packages/data")]
+    )
+    tasks, _ = _normalize_tasks(
+        goal=None,
+        context=None,
+        persona=None,
+        workspace=None,
+        pipeline=None,
+        tasks=[{"goal": "Fix the UI button", "scope": "packages/ui/button.tsx"}],
+        routing=routing,
+        default_persona="coder",
+    )
+    assert tasks[0].persona == "coder"
+
+
 # ---------------------------------------------------------------------------
 # Load from config
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `PersonaRouter` in `agent_fleet/persona_router.py` — a pure `route(goal, scope)` function backed by an ordered list of `RoutingRule`s (each rule matches on `goal_pattern` regex and/or `scope_prefix`; first match wins).
- Add `PersonaRoutingConfig` and `parse_persona_routing()` to parse the new `persona_routing:` YAML key in fleet or repo config.
- Extend `FleetConfig` with a `persona_routing: PersonaRoutingConfig | None` field (default `None` — no change to existing behavior).
- Integrate routing into `_normalize_tasks` via `_resolve_persona()`: explicit task persona > routing table > `config.default_persona` > `'coder'`.
- `FleetDispatcher.dispatch()` forwards `config.persona_routing` and `config.default_persona` to `_normalize_tasks`.

## Data shape

```yaml
persona_routing:
  rules:
    - goal_pattern: "(?i)front.?end|css|react"
      persona: frontend
    - scope_prefix: "packages/data"
      persona: data-eng
    - goal_pattern: "(?i)docs?"
      scope_prefix: "docs/"
      persona: tech-writer
  default_persona: coder   # optional
```

A rule matches when ALL specified matchers match. Rules are evaluated in order; the first match wins.

## Tests (`tests/test_persona_router.py`)

- A routing rule selects the expected persona (goal pattern, scope prefix, combined).
- First-match semantics when multiple rules could apply.
- An explicit task persona overrides routing.
- Absent routing config preserves `'coder'` — current default behavior is unchanged.
- `parse_persona_routing` round-trips the YAML shape correctly.
- `FleetConfig` loaded from `fleet.example.yaml` has `persona_routing=None` (backward-compat guard).

Generated with Claude Code (https://claude.com/claude-code)