### PR TITLE
feat(backends): registry for pluggable model backends

### DIFF
--- a/agent_fleet/backends.py
+++ b/agent_fleet/backends.py
@@ -1,4 +1,4 @@
-"""Backend factory — Cursor SDK (default) or Kimi Code CLI (optional)."""
+"""Backend factory — registry-driven; Cursor SDK (default) and Kimi Code CLI built-in."""
 
 from __future__ import annotations
 
@@ -10,26 +10,48 @@ from agent_fleet.cursor_backend import CursorBackend
 from agent_fleet.kimi_backend import KimiBackend
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from agent_fleet.config import FleetConfig
     from agent_fleet.hooks import LLMBackend
 
+# name → factory(config) callable; mutate to register new backends at import time.
+_REGISTRY: dict[str, Callable[[FleetConfig], LLMBackend]] = {}
 
-def make_backend(config: FleetConfig) -> LLMBackend:
-    """Return the configured LLM backend."""
-    name = (getattr(config, "default_backend", None) or "cursor").lower()
-    if name == "kimi":
-        model = config.default_model
-        if model == "composer-2.5":
-            model = "kimi-for-coding"
-        return KimiBackend(
-            model=model,
-            kimi_bin=getattr(config, "kimi_bin", None),
-        )
-    if name != "cursor":
-        raise ValueError(f"Unknown default_backend {name!r}. Use 'cursor' or 'kimi'.")
+
+def register(name: str, factory: Callable[[FleetConfig], LLMBackend]) -> None:
+    """Register a backend factory under *name* (lower-cased)."""
+    _REGISTRY[name.lower()] = factory
+
+
+def _make_cursor(config: FleetConfig) -> LLMBackend:
     if not os.environ.get("CURSOR_API_KEY"):
         pass  # CursorBackend returns a clear error at run time
     return CursorBackend(
         default_model=config.default_model,
         default_mode=coerce_agent_mode(config.default_mode),
     )
+
+
+def _make_kimi(config: FleetConfig) -> LLMBackend:
+    model = config.default_model
+    if model == "composer-2.5":
+        model = "kimi-for-coding"
+    return KimiBackend(
+        model=model,
+        kimi_bin=getattr(config, "kimi_bin", None),
+    )
+
+
+register("cursor", _make_cursor)
+register("kimi", _make_kimi)
+
+
+def make_backend(config: FleetConfig) -> LLMBackend:
+    """Return the configured LLM backend."""
+    name = (getattr(config, "default_backend", None) or "cursor").lower()
+    factory = _REGISTRY.get(name)
+    if factory is None:
+        known = ", ".join(sorted(_REGISTRY))
+        raise ValueError(f"Unknown default_backend {name!r}. Known backends: {known}.")
+    return factory(config)

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -1,0 +1,69 @@
+"""Regression: backend registry resolves built-ins, accepts new entries, rejects unknown."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from agent_fleet.config import load_fleet_config
+
+if TYPE_CHECKING:
+    from agent_fleet.config import FleetConfig
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _config() -> FleetConfig:
+    return load_fleet_config(ROOT / "fleet.example.yaml")
+
+
+def test_cursor_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_fleet.backends import make_backend
+    from agent_fleet.cursor_backend import CursorBackend
+
+    cfg = _config()
+    monkeypatch.setattr(cfg, "default_backend", "cursor", raising=False)
+    backend = make_backend(cfg)
+    assert isinstance(backend, CursorBackend)
+
+
+def test_kimi_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_fleet.backends import make_backend
+    from agent_fleet.kimi_backend import KimiBackend
+
+    cfg = _config()
+    monkeypatch.setattr(cfg, "default_backend", "kimi", raising=False)
+    backend = make_backend(cfg)
+    assert isinstance(backend, KimiBackend)
+
+
+def test_registered_backend_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_fleet import backends
+
+    class _FakeBackend:
+        def run(self, *_args: object, **_kwargs: object) -> object:
+            raise NotImplementedError
+
+    cfg = _config()
+    monkeypatch.setattr(cfg, "default_backend", "fake", raising=False)
+    # Register a new backend without touching make_backend's body.
+    backends.register("fake", lambda _cfg: _FakeBackend())  # ty: ignore[invalid-argument-type]
+    try:
+        backend = backends.make_backend(cfg)
+        assert isinstance(backend, _FakeBackend)
+    finally:
+        backends._REGISTRY.pop("fake", None)
+
+
+def test_unknown_backend_raises_helpful_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_fleet.backends import make_backend
+
+    cfg = _config()
+    monkeypatch.setattr(cfg, "default_backend", "nonexistent", raising=False)
+    with pytest.raises(ValueError, match="nonexistent") as exc_info:
+        make_backend(cfg)
+    # Error message must list known backends so the user knows what to use.
+    assert "cursor" in str(exc_info.value)
+    assert "kimi" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `if/elif` switch in `make_backend` with a `_REGISTRY` dict (`dict[str, Callable[[FleetConfig], LLMBackend]]`) keyed by backend name.
- Adds a `register(name, factory)` function so new backends can be wired in at import time without touching the factory body.
- `cursor` and `kimi` are pre-registered with identical behavior to before.
- An unknown name raises `ValueError` listing all known backend names (e.g. `"cursor, kimi"`).

## Data shape

```python
_REGISTRY: dict[str, Callable[[FleetConfig], LLMBackend]] = {}
```

## Tests (`tests/test_backend_registry.py`)

- `test_cursor_resolves` — `default_backend="cursor"` returns a `CursorBackend`
- `test_kimi_resolves` — `default_backend="kimi"` returns a `KimiBackend`
- `test_registered_backend_resolves` — a dynamically registered backend resolves without modifying `make_backend`
- `test_unknown_backend_raises_helpful_error` — unknown name raises `ValueError` containing the name and all known backends

All 966 existing tests remain green.

Generated with Claude Code (https://claude.com/claude-code)