### PR TITLE
feat(phases): phase registry with load-time validation

### DIFF
--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -36,6 +36,22 @@ if TYPE_CHECKING:
     from agent_fleet.level_up.models import DispatchEquip
     from agent_fleet.repo import RepoConfig
 
+# Registry of phase names handled by run_pipeline.  Presence in the dict is
+# the source of truth; the value is unused (None) and exists only to give a
+# dict[str, None] type that callers can introspect.
+PHASE_REGISTRY: dict[str, None] = {"execute": None, "analyze": None, "review": None}
+
+
+def validate_phases(phases: list[str]) -> None:
+    """Raise ValueError if any phase name is not in PHASE_REGISTRY.
+
+    Call at pipeline-resolve time so unknown names fail before any agent runs.
+    """
+    unknown = [p for p in phases if p not in PHASE_REGISTRY]
+    if unknown:
+        known = sorted(PHASE_REGISTRY)
+        raise ValueError(f"Unknown phase(s) {unknown!r}; known phases are {known}")
+
 
 def _record_token_ceiling_metric(
     *,
@@ -747,6 +763,8 @@ def run_pipeline(
     phase, a ``complexity.ceiling_metric`` event is emitted and the pipeline
     continues (verify/review still run when configured).
     """
+    validate_phases(phases)
+
     results: list[dict[str, Any]] = []
     summary = ""
     exit_code = 0
@@ -890,9 +908,8 @@ def run_pipeline(
                     break
             continue
 
-        results.append({"phase": phase, "error": f"Unknown phase: {phase}"})
-        exit_code = 1
-        break
+        # validate_phases() above ensures this is unreachable.
+        raise AssertionError(f"unhandled phase {phase!r} slipped past validate_phases")
 
     return results, summary, exit_code, changed_files
 

--- a/tests/test_phase_registry.py
+++ b/tests/test_phase_registry.py
@@ -1,0 +1,95 @@
+"""Phase registry: validate_phases rejects unknown names at pipeline-resolve time."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.hooks import FleetTask
+from agent_fleet.personas import YamlPersonaResolver
+from agent_fleet.phases import PHASE_REGISTRY, run_pipeline, validate_phases
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# validate_phases unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_phases_accepts_known_phases() -> None:
+    # Should not raise for any registered phase name.
+    validate_phases(["execute"])
+    validate_phases(["analyze"])
+    validate_phases(["review"])
+    validate_phases(["execute", "review"])
+
+
+def test_validate_phases_rejects_unknown_single() -> None:
+    with pytest.raises(ValueError, match="unknown_phase"):
+        validate_phases(["unknown_phase"])
+
+
+def test_validate_phases_rejects_unknown_lists_known_phases() -> None:
+    with pytest.raises(ValueError, match="execute") as exc_info:
+        validate_phases(["bogus"])
+    # Error message names the known phases so users know what's valid.
+    assert "analyze" in str(exc_info.value)
+    assert "review" in str(exc_info.value)
+
+
+def test_validate_phases_rejects_multiple_unknown() -> None:
+    with pytest.raises(ValueError, match="foo") as exc_info:
+        validate_phases(["execute", "foo", "bar"])
+    assert "bar" in str(exc_info.value)
+
+
+def test_validate_phases_empty_list_ok() -> None:
+    validate_phases([])
+
+
+# ---------------------------------------------------------------------------
+# PHASE_REGISTRY shape
+# ---------------------------------------------------------------------------
+
+
+def test_phase_registry_contains_expected_keys() -> None:
+    assert "execute" in PHASE_REGISTRY
+    assert "analyze" in PHASE_REGISTRY
+    assert "review" in PHASE_REGISTRY
+
+
+# ---------------------------------------------------------------------------
+# run_pipeline rejects unknown phase at entry (before any agent call)
+# ---------------------------------------------------------------------------
+
+
+def test_run_pipeline_rejects_unknown_phase_before_running(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown phase name must fail early, not silently mid-run."""
+    fleet_config = load_fleet_config(ROOT / "fleet.example.yaml")
+    resolver = YamlPersonaResolver(fleet_config)
+    task = FleetTask(goal="do something", persona="coder")
+
+    # Patch the backend so it would error if any phase actually ran.
+    import agent_fleet.phases as _phases
+
+    monkeypatch.setattr(
+        _phases,
+        "run_execute_phase",
+        lambda **_kw: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+
+    with pytest.raises(ValueError, match="no_such_phase"):
+        run_pipeline(
+            backend=None,  # ty: ignore[invalid-argument-type]
+            resolver=resolver,
+            task=task,
+            workspace=tmp_path,
+            timeout_s=30,
+            phases=["no_such_phase"],
+        )


### PR DESCRIPTION
## Summary

- Adds `PHASE_REGISTRY: dict[str, None]` at module level in `agent_fleet/phases.py` as the canonical source of truth for valid phase names (`execute`, `analyze`, `review`).
- Adds `validate_phases(phases: list[str]) -> None` which raises `ValueError` naming the unknown phase(s) and listing known phases when any invalid name is supplied.
- Calls `validate_phases(phases)` at the entry of `run_pipeline`, so an unknown phase name fails immediately at pipeline-resolve time — before any agent work starts — rather than producing a silent runtime error mid-run.
- Replaces the unreachable fallthrough block at the end of the dispatch loop with an `AssertionError` that documents the now-enforced invariant.

## Data shape

```python
PHASE_REGISTRY: dict[str, None] = {"execute": None, "analyze": None, "review": None}
```

Presence in the dict is the source of truth; value is `None`. Callers can introspect `PHASE_REGISTRY` to enumerate valid phase names.

## Tests

`tests/test_phase_registry.py` adds 7 focused regressions:

- `validate_phases` accepts all known phase names without raising.
- `validate_phases` raises `ValueError` with the unknown name in the message.
- Error message names all known phases so users know what's valid.
- Multiple unknown names are all reported.
- Empty phase list is valid.
- `PHASE_REGISTRY` contains the three expected keys.
- `run_pipeline` rejects an unknown phase before calling any phase handler (i.e., load-time, not runtime).

Generated with Claude Code (https://claude.com/claude-code)