### PR TITLE
feat(config): per-repo complexity tiers and skill sets

### DIFF
--- a/agent_fleet/complexity.py
+++ b/agent_fleet/complexity.py
@@ -201,14 +201,33 @@ def coerce_complexity(value: str | None) -> Complexity:
     return cast("Complexity", upper)
 
 
-def derive_runtime(complexity: Complexity | str | None) -> RuntimeConfig:
+def derive_runtime(
+    complexity: Complexity | str | None,
+    *,
+    tier_overrides: dict[str, dict[str, Any]] | None = None,
+) -> RuntimeConfig:
     """Return the ``RuntimeConfig`` for *complexity*.
 
     Accepts ``None`` (treated as ``'MED'``) or any casing of the three valid
     levels.  Raises ``ValueError`` for other inputs.
+
+    *tier_overrides* may supply per-tier field overrides from fleet/repo config
+    (e.g. ``{"LOW": {"token_ceiling": 2_000_000}}``).  Only the keys present in
+    the override are changed; the Python defaults fill the rest.
     """
     level = coerce_complexity(complexity)
-    return _RUNTIME_MAP[level]
+    base = _RUNTIME_MAP[level]
+    if tier_overrides and level in tier_overrides:
+        raw = tier_overrides[level]
+        base = RuntimeConfig(
+            pipeline=str(raw["pipeline"]) if "pipeline" in raw else base.pipeline,
+            retries=int(raw["retries"]) if "retries" in raw else base.retries,
+            token_ceiling=int(raw["token_ceiling"])
+            if "token_ceiling" in raw
+            else base.token_ceiling,
+            loadout_size=str(raw["loadout_size"]) if "loadout_size" in raw else base.loadout_size,
+        )
+    return base
 
 
 def is_actionable_stderr(stderr: str, written_files: tuple[str, ...] | list[str]) -> bool:

--- a/agent_fleet/config.py
+++ b/agent_fleet/config.py
@@ -75,6 +75,11 @@ class FleetConfig:
     max_redispatches: int = 1
     enforce_token_ceiling: bool = False
     persona_routing: PersonaRoutingConfig | None = None
+    # Per-tier runtime overrides: merged over the Python _RUNTIME_MAP defaults.
+    # Keys are "LOW"/"MED"/"HIGH"; values are partial RuntimeConfig field dicts.
+    complexity_tiers: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Skill-set overrides: keys "minimal_core" (list[str]) and "pr_loop" (list[str]).
+    skill_overrides: dict[str, list[str]] = field(default_factory=dict)
 
 
 def _expand_path(value: str) -> Path:
@@ -141,6 +146,41 @@ def _parse_persona_specs(
     return specs
 
 
+_VALID_TIER_KEYS = frozenset({"LOW", "MED", "HIGH"})
+_VALID_TIER_FIELDS = frozenset({"pipeline", "retries", "token_ceiling", "loadout_size"})
+
+
+def _parse_complexity_tiers(raw: Any) -> dict[str, dict[str, Any]]:  # noqa: ANN401
+    """Parse ``complexity_tiers`` YAML block into per-tier override dicts.
+
+    Only known tier names (LOW/MED/HIGH) and known fields are kept; unknown
+    keys are silently dropped to avoid hard failures on forward-compat config.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for tier, fields in raw.items():
+        key = str(tier).strip().upper()
+        if key not in _VALID_TIER_KEYS or not isinstance(fields, dict):
+            continue
+        result[key] = {k: v for k, v in fields.items() if k in _VALID_TIER_FIELDS}
+    return result
+
+
+def _parse_skill_overrides(raw: Any) -> dict[str, list[str]]:  # noqa: ANN401
+    """Parse ``skills`` YAML block into a dict with optional ``minimal_core``
+    and ``pr_loop`` lists.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, list[str]] = {}
+    for key in ("minimal_core", "pr_loop"):
+        value = raw.get(key)
+        if isinstance(value, list):
+            result[key] = [str(s) for s in value]
+    return result
+
+
 def load_fleet_config(
     path: Path | str | None = None,
     *,
@@ -202,4 +242,6 @@ def load_fleet_config(
         max_redispatches=int(data.get("max_redispatches") or 1),
         enforce_token_ceiling=bool(data.get("enforce_token_ceiling", False)),
         persona_routing=parse_persona_routing(data.get("persona_routing")),
+        complexity_tiers=_parse_complexity_tiers(data.get("complexity_tiers")),
+        skill_overrides=_parse_skill_overrides(data.get("skills")),
     )

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -671,7 +671,10 @@ class FleetDispatcher:
 
                 # Derive runtime parameters from complexity.  If the task also
                 # carries an explicit pipeline override, warn and discard it.
-                runtime = derive_runtime(task.complexity)
+                runtime = derive_runtime(
+                    task.complexity,
+                    tier_overrides=self.config.complexity_tiers or None,
+                )
                 if task.complexity is not None and task.pipeline is not None:
                     logger.warning(
                         "Task has both complexity=%r and pipeline=%r; "

--- a/agent_fleet/orchestration/equip.py
+++ b/agent_fleet/orchestration/equip.py
@@ -17,11 +17,11 @@ from agent_fleet.level_up.models import DispatchEquip
 from agent_fleet.level_up.overlay import compose_overlay_text, load_overlay
 from agent_fleet.level_up.paths import FLEET_TIER, repo_key
 from agent_fleet.skills_lib import (
-    MINIMAL_EXECUTE_SKILL_CORE,
-    PR_LOOP_EXECUTE_SKILLS,
     SYSTEMATIC_DEBUGGING_SKILL,
     base_kit_skill_dirs,
     compose_persona_body,
+    effective_minimal_core,
+    effective_pr_loop_skills,
     load_loadout,
     loadout_execute_skill_ids,
     loadout_review_skill_ids,
@@ -100,7 +100,7 @@ def resolve_dispatch_equip(
         extra_execute.append(SYSTEMATIC_DEBUGGING_SKILL)
 
     if repo is not None and repo.pr_loop is not None and repo.pr_loop.enabled:
-        for skill_id in PR_LOOP_EXECUTE_SKILLS:
+        for skill_id in effective_pr_loop_skills(fleet_config):
             if (
                 skill_exists_in_base_kit(skill_id)
                 and skill_id not in loadout_execute
@@ -118,8 +118,9 @@ def resolve_dispatch_equip(
 
     # Mirror compose_persona_body's minimal filter so the journaled equip matches
     # the skills actually composed into the body (filter the loadout, keep extras).
+    _minimal_core = effective_minimal_core(fleet_config)
     filtered_execute = (
-        [s for s in loadout_execute if s in MINIMAL_EXECUTE_SKILL_CORE]
+        [s for s in loadout_execute if s in _minimal_core]
         if loadout_size == "minimal"
         else loadout_execute
     )
@@ -135,6 +136,7 @@ def resolve_dispatch_equip(
         level_up_generation=generation,
         skill_dirs=skill_dirs,
         loadout_size=loadout_size,
+        minimal_core=_minimal_core,
     )
 
     equip = DispatchEquip(

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -952,7 +952,12 @@ class LocalFleetRunner:
         )
         # Derive runtime parameters from complexity.  Falls back to the
         # FleetRunConfig value when no complexity is declared.
-        _runtime = derive_runtime(task_complexity)
+        _runtime = derive_runtime(
+            task_complexity,
+            tier_overrides=(self._fleet_config.complexity_tiers or None)
+            if self._fleet_config is not None
+            else None,
+        )
         effective_max_retries = (
             _runtime.retries if task_complexity is not None else self._config.max_verify_retries
         )

--- a/agent_fleet/skills_lib.py
+++ b/agent_fleet/skills_lib.py
@@ -33,6 +33,34 @@ PR_LOOP_EXECUTE_SKILLS: tuple[str, ...] = (
 )
 
 
+def effective_minimal_core(fleet_config: object | None = None) -> frozenset[str]:
+    """Return the effective minimal-execute skill core set.
+
+    When *fleet_config* supplies a ``skills.minimal_core`` list it overrides
+    the Python constant; otherwise ``MINIMAL_EXECUTE_SKILL_CORE`` is returned.
+    """
+    if fleet_config is not None:
+        overrides: dict[str, list[str]] = getattr(fleet_config, "skill_overrides", {}) or {}
+        raw = overrides.get("minimal_core")
+        if raw is not None:
+            return frozenset(raw)
+    return MINIMAL_EXECUTE_SKILL_CORE
+
+
+def effective_pr_loop_skills(fleet_config: object | None = None) -> tuple[str, ...]:
+    """Return the effective PR-loop execute skills.
+
+    When *fleet_config* supplies a ``skills.pr_loop`` list it overrides the
+    Python constant; otherwise ``PR_LOOP_EXECUTE_SKILLS`` is returned.
+    """
+    if fleet_config is not None:
+        overrides: dict[str, list[str]] = getattr(fleet_config, "skill_overrides", {}) or {}
+        raw = overrides.get("pr_loop")
+        if raw is not None:
+            return tuple(raw)
+    return PR_LOOP_EXECUTE_SKILLS
+
+
 def base_kit_dir() -> Path:
     return _BASE_KIT_DIR
 
@@ -151,12 +179,14 @@ def compose_persona_body(
     skill_dirs: list[Path] | None = None,
     level_up_generation: int = 0,
     loadout_size: str | None = None,
+    minimal_core: frozenset[str] | None = None,
 ) -> str:
     """Layer base-kit skills, persona stub, fleet/repo overlays into one prompt body."""
     dirs = skill_dirs or base_kit_skill_dirs()
     skill_ids = _loadout_execute_skill_ids(loadout)
     if loadout_size == "minimal":
-        skill_ids = [s for s in skill_ids if s in MINIMAL_EXECUTE_SKILL_CORE]
+        _core = minimal_core if minimal_core is not None else MINIMAL_EXECUTE_SKILL_CORE
+        skill_ids = [s for s in skill_ids if s in _core]
     if extra_skills:
         skill_ids.extend(extra_skills)
 

--- a/tests/test_configurable_tiers_skills.py
+++ b/tests/test_configurable_tiers_skills.py
@@ -1,0 +1,253 @@
+"""Regression tests: configurable complexity tiers and skill sets via fleet.yaml.
+
+These tests verify that:
+- YAML complexity_tiers overrides change the effective RuntimeConfig.
+- YAML skills overrides change the effective minimal_core and pr_loop skill sets.
+- Absent config yields the current Python defaults unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_fleet.complexity import _RUNTIME_MAP, RuntimeConfig, derive_runtime
+from agent_fleet.config import load_fleet_config
+from agent_fleet.skills_lib import (
+    MINIMAL_EXECUTE_SKILL_CORE,
+    PR_LOOP_EXECUTE_SKILLS,
+    effective_minimal_core,
+    effective_pr_loop_skills,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# derive_runtime: tier_overrides param
+# ---------------------------------------------------------------------------
+
+
+def test_derive_runtime_no_overrides_uses_defaults() -> None:
+    """tier_overrides=None preserves the Python constant defaults."""
+    for level in ("LOW", "MED", "HIGH"):
+        assert derive_runtime(level) == _RUNTIME_MAP[level]
+        assert derive_runtime(level, tier_overrides=None) == _RUNTIME_MAP[level]
+
+
+def test_derive_runtime_partial_override_low_token_ceiling() -> None:
+    """A single field override merges over the default; other fields unchanged."""
+    overrides = {"LOW": {"token_ceiling": 2_000_000}}
+    rt = derive_runtime("LOW", tier_overrides=overrides)
+    default = _RUNTIME_MAP["LOW"]
+    assert rt.token_ceiling == 2_000_000
+    assert rt.pipeline == default.pipeline
+    assert rt.retries == default.retries
+    assert rt.loadout_size == default.loadout_size
+
+
+def test_derive_runtime_override_different_tier_unchanged() -> None:
+    """Override for MED does not affect LOW or HIGH."""
+    overrides = {"MED": {"retries": 3}}
+    assert derive_runtime("LOW", tier_overrides=overrides) == _RUNTIME_MAP["LOW"]
+    assert derive_runtime("HIGH", tier_overrides=overrides) == _RUNTIME_MAP["HIGH"]
+    rt_med = derive_runtime("MED", tier_overrides=overrides)
+    assert rt_med.retries == 3
+
+
+def test_derive_runtime_all_fields_override() -> None:
+    """All RuntimeConfig fields can be overridden for a single tier."""
+    overrides = {
+        "HIGH": {
+            "pipeline": "simple",
+            "retries": 5,
+            "token_ceiling": 99_000_000,
+            "loadout_size": "minimal",
+        }
+    }
+    rt = derive_runtime("HIGH", tier_overrides=overrides)
+    assert rt == RuntimeConfig(
+        pipeline="simple",
+        retries=5,
+        token_ceiling=99_000_000,
+        loadout_size="minimal",
+    )
+
+
+def test_derive_runtime_empty_overrides_dict() -> None:
+    """Empty overrides dict is equivalent to None — uses Python defaults."""
+    assert derive_runtime("MED", tier_overrides={}) == _RUNTIME_MAP["MED"]
+
+
+# ---------------------------------------------------------------------------
+# load_fleet_config: complexity_tiers and skills parsed from YAML
+# ---------------------------------------------------------------------------
+
+
+def test_load_fleet_config_no_tiers_empty_by_default(tmp_path: Path) -> None:
+    """A config with no complexity_tiers block yields empty complexity_tiers."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text("default_model: composer-2.5\n", encoding="utf-8")
+    fc = load_fleet_config(cfg_file)
+    assert fc.complexity_tiers == {}
+
+
+def test_load_fleet_config_no_skills_empty_by_default(tmp_path: Path) -> None:
+    """A config with no skills block yields empty skill_overrides."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text("default_model: composer-2.5\n", encoding="utf-8")
+    fc = load_fleet_config(cfg_file)
+    assert fc.skill_overrides == {}
+
+
+def test_load_fleet_config_complexity_tiers_parsed(tmp_path: Path) -> None:
+    """complexity_tiers block is parsed and stored on FleetConfig."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "complexity_tiers:\n"
+        "  LOW:\n"
+        "    token_ceiling: 2000000\n"
+        "    retries: 2\n"
+        "  MED:\n"
+        "    pipeline: simple\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    assert fc.complexity_tiers["LOW"]["token_ceiling"] == 2_000_000
+    assert fc.complexity_tiers["LOW"]["retries"] == 2
+    assert fc.complexity_tiers["MED"]["pipeline"] == "simple"
+    assert "HIGH" not in fc.complexity_tiers
+
+
+def test_load_fleet_config_skills_parsed(tmp_path: Path) -> None:
+    """skills block minimal_core and pr_loop are parsed."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "skills:\n"
+        "  minimal_core:\n"
+        "    - pstack/tdd\n"
+        "    - custom/skill\n"
+        "  pr_loop:\n"
+        "    - cursor-team-kit/fix-ci\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    assert fc.skill_overrides["minimal_core"] == ["pstack/tdd", "custom/skill"]
+    assert fc.skill_overrides["pr_loop"] == ["cursor-team-kit/fix-ci"]
+
+
+def test_load_fleet_config_example_yaml_no_tiers() -> None:
+    """fleet.example.yaml has no complexity_tiers/skills — existing defaults unchanged."""
+    fc = load_fleet_config(ROOT / "fleet.example.yaml")
+    assert fc.complexity_tiers == {}
+    assert fc.skill_overrides == {}
+    # Existing behavior: derive_runtime still returns Python defaults.
+    assert derive_runtime("LOW", tier_overrides=fc.complexity_tiers or None) == _RUNTIME_MAP["LOW"]
+
+
+# ---------------------------------------------------------------------------
+# effective_minimal_core / effective_pr_loop_skills
+# ---------------------------------------------------------------------------
+
+
+def test_effective_minimal_core_no_config_returns_default() -> None:
+    """Without a config, the Python constant is returned."""
+    assert effective_minimal_core(None) is MINIMAL_EXECUTE_SKILL_CORE
+    assert effective_minimal_core() is MINIMAL_EXECUTE_SKILL_CORE
+
+
+def test_effective_minimal_core_empty_overrides_returns_default() -> None:
+    """Config with no skills block returns the constant."""
+    fc = load_fleet_config(ROOT / "fleet.example.yaml")
+    assert effective_minimal_core(fc) is MINIMAL_EXECUTE_SKILL_CORE
+
+
+def test_effective_minimal_core_config_override(tmp_path: Path) -> None:
+    """Config minimal_core list replaces the constant."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "skills:\n  minimal_core:\n    - pstack/tdd\n    - custom/extra\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    core = effective_minimal_core(fc)
+    assert core == frozenset({"pstack/tdd", "custom/extra"})
+    assert core is not MINIMAL_EXECUTE_SKILL_CORE
+
+
+def test_effective_pr_loop_skills_no_config_returns_default() -> None:
+    """Without a config, the Python constant is returned."""
+    assert effective_pr_loop_skills(None) is PR_LOOP_EXECUTE_SKILLS
+    assert effective_pr_loop_skills() is PR_LOOP_EXECUTE_SKILLS
+
+
+def test_effective_pr_loop_skills_config_override(tmp_path: Path) -> None:
+    """Config pr_loop list replaces the constant."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "skills:\n  pr_loop:\n    - cursor-team-kit/fix-ci\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    skills = effective_pr_loop_skills(fc)
+    assert skills == ("cursor-team-kit/fix-ci",)
+    assert skills is not PR_LOOP_EXECUTE_SKILLS
+
+
+# ---------------------------------------------------------------------------
+# Integration: YAML-driven tier override flows end-to-end through derive_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_tier_override_changes_effective_runtime(tmp_path: Path) -> None:
+    """A complexity_tiers override in fleet.yaml changes what derive_runtime returns."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "complexity_tiers:\n  LOW:\n    token_ceiling: 500000\n    retries: 3\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    rt = derive_runtime("LOW", tier_overrides=fc.complexity_tiers or None)
+    assert rt.token_ceiling == 500_000
+    assert rt.retries == 3
+    # Fields not in override stay at Python defaults.
+    assert rt.pipeline == _RUNTIME_MAP["LOW"].pipeline
+    assert rt.loadout_size == _RUNTIME_MAP["LOW"].loadout_size
+
+
+def test_absent_yaml_tier_override_preserves_defaults(tmp_path: Path) -> None:
+    """When complexity_tiers is absent, all tiers stay at Python defaults."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text("", encoding="utf-8")
+    fc = load_fleet_config(cfg_file)
+    for level in ("LOW", "MED", "HIGH"):
+        rt = derive_runtime(level, tier_overrides=fc.complexity_tiers or None)
+        assert rt == _RUNTIME_MAP[level]
+
+
+# ---------------------------------------------------------------------------
+# Parse helpers: invalid/unknown keys silently dropped
+# ---------------------------------------------------------------------------
+
+
+def test_parse_complexity_tiers_unknown_tier_ignored(tmp_path: Path) -> None:
+    """Unknown tier names are silently dropped."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "complexity_tiers:\n  EXTREME:\n    retries: 10\n  LOW:\n    retries: 2\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    assert "EXTREME" not in fc.complexity_tiers
+    assert fc.complexity_tiers["LOW"]["retries"] == 2
+
+
+def test_parse_complexity_tiers_unknown_field_ignored(tmp_path: Path) -> None:
+    """Unknown field names within a tier are silently dropped."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "complexity_tiers:\n  MED:\n    token_ceiling: 3000000\n    unknown_field: oops\n",
+        encoding="utf-8",
+    )
+    fc = load_fleet_config(cfg_file)
+    assert "unknown_field" not in fc.complexity_tiers.get("MED", {})
+    assert fc.complexity_tiers["MED"]["token_ceiling"] == 3_000_000


### PR DESCRIPTION
## Summary

- Adds a `complexity_tiers` block to fleet.yaml / .agent-fleet.yaml that overrides per-tier runtime parameters (`pipeline`, `retries`, `token_ceiling`, `loadout_size`) by merging over the Python `_RUNTIME_MAP` defaults — the same pattern `pipelines` uses over `_DEFAULT_PIPELINES`.
- Adds a `skills` block that overrides `minimal_core` and `pr_loop` skill lists, surfaced through new `effective_minimal_core(fleet_config)` and `effective_pr_loop_skills(fleet_config)` helpers in `skills_lib.py`.
- All callsites (`dispatcher.py`, `runner.py`, `orchestration/equip.py`) now pass config-driven overrides; absent config leaves every current behavior unchanged.

## Data shape

```yaml
complexity_tiers:
  LOW:
    token_ceiling: 2_000_000
    retries: 2
  MED:
    pipeline: simple

skills:
  minimal_core:
    - pstack/tdd
    - custom/extra-skill
  pr_loop:
    - cursor-team-kit/fix-ci
```

Only the fields present in the override are changed; Python defaults fill the rest. Unknown tier names and unknown field names are silently dropped.

## Tests

19 focused regression tests in `tests/test_configurable_tiers_skills.py`:
- YAML tier override changes the effective `RuntimeConfig` (partial and full override cases).
- Override for one tier does not affect others.
- Empty/absent config yields Python defaults unchanged.
- `effective_minimal_core` and `effective_pr_loop_skills` return constants when no config is supplied and config-derived sets when overrides are present.
- Parse helpers drop unknown tier names and unknown field names silently.

Generated with Claude Code (https://claude.com/claude-code)