### PR TITLE
test(backends): guard doctor parity with the backend registry

### DIFF
--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -67,3 +67,24 @@ def test_unknown_backend_raises_helpful_error(monkeypatch: pytest.MonkeyPatch) -
     # Error message must list known backends so the user knows what to use.
     assert "cursor" in str(exc_info.value)
     assert "kimi" in str(exc_info.value)
+
+
+def test_doctor_covers_every_registered_backend() -> None:
+    """A registered backend must have a real key check, not a fallback warn.
+
+    make_backend resolves any registered backend from one file, but the backend's
+    env-var contract is duplicated as a closed {cursor, kimi} set in doctor,
+    cli_env, and pr_review.github_action. A third backend instantiates yet
+    silently degrades there (doctor warns "unknown backend", the preflights skip
+    its key check). This pins the doctor copy to the registry so that drift fails
+    loudly instead of shipping a half-wired backend.
+    """
+    from agent_fleet import backends
+    from agent_fleet.doctor import _BACKEND_ENV
+
+    missing = set(backends._REGISTRY) - set(_BACKEND_ENV)
+    assert not missing, (
+        f"backends registered but absent from doctor._BACKEND_ENV: {sorted(missing)}. "
+        "Add the env var there (and in cli_env and pr_review.github_action), or wire the "
+        "env contract into the registry so all three derive from one source."
+    )


### PR DESCRIPTION
## What

Adds one standing regression test, `test_doctor_covers_every_registered_backend`, that pins `doctor._BACKEND_ENV` to the backend registry.

## Why

A backend instantiates from a single `register()` call in `backends.py`, and `make_backend` resolves it across all 14 call sites with no other edits. But the backend's env-var contract is re-encoded as a closed `{cursor, kimi}` set in three sibling files the registry does not feed:

- `doctor.py:21` `_BACKEND_ENV` — a third backend degrades to a generic "unknown backend, cannot verify a key" warn instead of a real key check.
- `cli_env.py:16,19` — the preflight silently skips an unregistered name's key check.
- `pr_review/github_action.py:39` — same silent skip in the CI-action path.

The failure mode is silent degradation, which is worse than a crash. This guard turns the drift loud. It passes today (`{cursor, kimi} == {cursor, kimi}`) and fails the instant the registry grows without the metadata following, with a message naming the three files to wire.

A follow-up PR will collapse the four-file closed set into registry-carried env metadata and upgrade this guard to assert the single-source invariant directly.

## Test

`uv run pytest -q tests/test_backend_registry.py` → 5 passed. `ty` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)