### PR TITLE
fix(redispatch): make token-ceiling breach terminal, not retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ MCP + persistent sessions: [docs/SESSIONS.md](docs/SESSIONS.md) · [docs/MCP.md]
 | `pr_review` | analyze | PR diff only (no implement) |
 | `full` | PLAN → … → REVIEW → TECH_LEAD? | Large features, branch + PR |
 
-Outcomes: `completed`, `scope_violation`, `verify_failed`, `review_changes_requested`, `review_blocked`, `error`, `decompose_partial`, `decompose_failed`, `dag_partial`, `dag_failed`.
+Outcomes: `completed`, `scope_violation`, `token_ceiling_exceeded`, `verify_failed`, `review_changes_requested`, `review_blocked`, `error`, `decompose_partial`, `decompose_failed`, `dag_partial`, `dag_failed`.
 
 **Orchestration (v0.6.4+):** When the planner returns `decompose`, the fleet automatically fans out `child_issues_proposed` as parallel scoped tasks (default pipeline: `code_review`). Enable via `.agent-fleet.yaml`:
 

--- a/agent_fleet/orchestration/convergence.py
+++ b/agent_fleet/orchestration/convergence.py
@@ -9,7 +9,14 @@ from agent_fleet.hooks import FleetTaskResult
 SUCCESS_STATUSES = frozenset({"completed", "merged"})
 PARTIAL_OK = frozenset({"review_changes_requested"})
 FAILURE_STATUSES = frozenset(
-    {"error", "verify_failed", "scope_violation", "review_blocked", "rejected"}
+    {
+        "error",
+        "verify_failed",
+        "scope_violation",
+        "review_blocked",
+        "rejected",
+        "token_ceiling_exceeded",
+    }
 )
 
 _TERMINAL = SUCCESS_STATUSES | PARTIAL_OK | {"skipped"}

--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -629,6 +629,12 @@ def resolve_pipeline_outcome(
         violating = scope.get("violating_files") or []
         return "scope_violation", f"Files outside persona scope: {violating}"
 
+    ceiling = by_phase.get("ceiling_abort")
+    if ceiling and ceiling.get("enforced"):
+        observed = ceiling.get("observed_total_tokens")
+        limit = ceiling.get("ceiling")
+        return "token_ceiling_exceeded", f"Token ceiling exceeded: {observed} > {limit}"
+
     for verify in [item for item in phase_results if item.get("phase") == "verify"]:
         if not verify.get("passed", True):
             command = verify.get("command", "verify")

--- a/agent_fleet/redispatch.py
+++ b/agent_fleet/redispatch.py
@@ -11,12 +11,21 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _HARD_STATUSES = frozenset(
-    {"error", "cancelled", "expired", "timeout", "scope_violation", "pipeline_nonzero"}
+    {
+        "error",
+        "cancelled",
+        "expired",
+        "timeout",
+        "scope_violation",
+        "pipeline_nonzero",
+        "token_ceiling_exceeded",
+    }
 )
 
-# scope_violation is a deterministic outcome: retrying the same task into the same
-# scope constraint will produce the same result. Never retry these.
-_TERMINAL_STATUSES = frozenset({"scope_violation"})
+# scope_violation and token_ceiling_exceeded are deterministic outcomes: retrying the
+# same task into the same scope constraint or token ceiling produces the same result.
+# Never retry these.
+_TERMINAL_STATUSES = frozenset({"scope_violation", "token_ceiling_exceeded"})
 
 
 @dataclass

--- a/docs/REDISPATCH.md
+++ b/docs/REDISPATCH.md
@@ -16,11 +16,17 @@ plus any non-zero `exit_code`:
 | `status = "expired"` | Cursor agent session expired before completing |
 | `status = "timeout"` | Fleet-level timeout (`timeout_seconds`) exceeded |
 | `status = "scope_violation"` | Implementer modified files outside the persona allowlist |
+| `status = "token_ceiling_exceeded"` | Observed token usage exceeded the declared-complexity ceiling (enforcement on) |
 | `status = "pipeline_nonzero"` | A phase's underlying command returned non-zero |
 | `exit_code != 0` | Any result where `exit_code` is non-zero |
 
-These all have one thing in common: the failure is **environmental or infrastructural**, not
+Most of these share one thing: the failure is **environmental or infrastructural**, not
 a judgment call. Retrying with fresh context is likely to help.
+
+Two are different. `scope_violation` and `token_ceiling_exceeded` are **deterministic**: the
+persona allowlist and the token ceiling do not change between attempts, so a retry breaches
+the same constraint and burns budget for nothing. They are members of `_TERMINAL_STATUSES`,
+and `RetryPolicy.should_retry()` never retries them despite their hard-failure status.
 
 ## What does NOT trigger redispatch
 

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -115,6 +115,24 @@ def test_resolve_pipeline_outcome_scope_violation() -> None:
     assert "infra/x.yaml" in (error or "")
 
 
+def test_resolve_pipeline_outcome_token_ceiling_exceeded() -> None:
+    status, error = resolve_pipeline_outcome(
+        [
+            {"phase": "execute", "exit_code": 0},
+            {"phase": "scope", "passed": True},
+            {
+                "phase": "ceiling_abort",
+                "enforced": True,
+                "observed_total_tokens": 904185,
+                "ceiling": 750000,
+            },
+        ],
+        1,
+    )
+    assert status == "token_ceiling_exceeded"
+    assert "904185" in (error or "")
+
+
 def test_resolve_pipeline_outcome_review_blocked() -> None:
     status, _ = resolve_pipeline_outcome(
         [

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -83,6 +83,7 @@ def _emit_captured(result: object, fmt: str = "json") -> tuple[int, str]:
         ("error", 1),
         ("rejected", 1),
         ("scope_violation", 1),
+        ("token_ceiling_exceeded", 1),
         ("decompose_failed", 1),
         ("complexity_underestimated", 1),
     ],

--- a/tests/test_redispatch.py
+++ b/tests/test_redispatch.py
@@ -30,6 +30,7 @@ class FakeResult:
         ("expired", 1, True),
         ("timeout", 1, True),
         ("scope_violation", 1, True),
+        ("token_ceiling_exceeded", 1, True),
         ("pipeline_nonzero", 2, True),
         ("verify_failed", 0, False),
         ("review_rejected", 0, False),

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -38,6 +38,13 @@ def test_scope_violation_is_never_retried() -> None:
     assert policy.should_retry(result, attempt=0) is False
 
 
+def test_token_ceiling_exceeded_is_never_retried() -> None:
+    policy = RetryPolicy(max_attempts=5)
+    result = FakeResult(status="token_ceiling_exceeded", exit_code=1)
+    # a token-ceiling breach is deterministic, so a retry hits the same ceiling
+    assert policy.should_retry(result, attempt=0) is False
+
+
 def test_transient_failure_retries_within_budget() -> None:
     policy = RetryPolicy(max_attempts=3)
     result = FakeResult(status="expired", exit_code=1)
@@ -113,6 +120,20 @@ def test_dispatch_with_retry_does_not_retry_scope_violation() -> None:
 
     result = dispatch_with_retry({"id": 1}, dispatch=fake_dispatch, max_redispatches=5)
     assert result.status == "scope_violation"
+    assert calls == 1  # no retry for terminal status
+
+
+def test_dispatch_with_retry_does_not_retry_token_ceiling_exceeded() -> None:
+    """token_ceiling_exceeded must stop after one attempt, even with budget remaining."""
+    calls = 0
+
+    def fake_dispatch(task, *, handoff=None):  # noqa: ANN001, ANN202, ARG001
+        nonlocal calls
+        calls += 1
+        return FakeResult(status="token_ceiling_exceeded", exit_code=1)
+
+    result = dispatch_with_retry({"id": 1}, dispatch=fake_dispatch, max_redispatches=5)
+    assert result.status == "token_ceiling_exceeded"
     assert calls == 1  # no retry for terminal status
 
 


### PR DESCRIPTION
## Problem

When `enforce_token_ceiling` is on and `observe_token_ceiling` detects a breach, `dispatcher_task.py` appends a `ceiling_abort` phase and returns `exit_code=1`. But `resolve_pipeline_outcome` (phases.py) had no branch for that phase, so the outcome fell through to `status="error"`.

`"error"` is in `_HARD_STATUSES` but not `_TERMINAL_STATUSES`, so `dispatch_with_retry` retried the task up to `max_redispatches`. A token-ceiling breach is **deterministic**: every retry breaches the same ceiling and the whole redispatch budget is burned for nothing. At `max_redispatches=5` that is 6 wasted attempts.

## Fix

Map the `ceiling_abort` phase to a dedicated terminal status `token_ceiling_exceeded`, mirroring exactly how `scope_violation` is already handled:

- `phases.py` — `resolve_pipeline_outcome` returns `token_ceiling_exceeded` for an enforced `ceiling_abort` phase.
- `redispatch.py` — add `token_ceiling_exceeded` to `_TERMINAL_STATUSES` (never retried) and `_HARD_STATUSES`.
- `convergence.py` — add to `FAILURE_STATUSES` so roll-ups surface it as a failure.
- `docs/REDISPATCH.md`, `README.md` — document the new status. The doc note also corrects a latent ambiguity: `scope_violation` was listed under "triggers redispatch" but has always been terminal.

`enforce_token_ceiling` stays opt-in (default `False`). This only changes what happens once a breach has already aborted a run.

## Verification

TDD evidence. Against unfixed source the three new regression gates fail; the retry test reports `assert 6 == 1` (the bug). With the fix:

- `test_resolve_pipeline_outcome_token_ceiling_exceeded`
- `test_token_ceiling_exceeded_is_never_retried`
- `test_dispatch_with_retry_does_not_retry_token_ceiling_exceeded` (exactly 1 attempt at `max_redispatches=5`)
- status-table rows in `test_redispatch.py` and `test_emit.py`

Full suite: **999 passed, 4 skipped**. `ruff format --check` and `ruff check` clean on all changed files.

## Provenance

This bug was surfaced by an adversarial design review of PRs #59-#66, then drafted by the agent-fleet `coder` persona in a dogfood `fleet run`. That run auto-routed simple→code_review, wrote this exact fix, and passed the full suite in its worktree, but the scope guardrail correctly blocked the commit because `phases.py` is a `critical_path_prefix` outside the `coder` allowlist. This PR re-lands that verified fix from the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)