### PR TITLE
fix(dispatcher,complexity): thread and brand loadout_size (#71, #75)

### DIFF
--- a/agent_fleet/complexity.py
+++ b/agent_fleet/complexity.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 Complexity = Literal["LOW", "MED", "HIGH"]
 _VALID: frozenset[str] = frozenset({"LOW", "MED", "HIGH"})
 
+LoadoutSize = Literal["minimal", "standard", "full"]
+_VALID_LOADOUT_SIZES: frozenset[str] = frozenset({"minimal", "standard", "full"})
+
 
 @dataclass(frozen=True)
 class TokenCeilingBreach:
@@ -85,7 +88,7 @@ class RuntimeConfig:
     pipeline: str
     retries: int
     token_ceiling: int
-    loadout_size: str
+    loadout_size: LoadoutSize
 
 
 _RUNTIME_MAP: dict[str, RuntimeConfig] = {
@@ -219,13 +222,23 @@ def derive_runtime(
     base = _RUNTIME_MAP[level]
     if tier_overrides and level in tier_overrides:
         raw = tier_overrides[level]
+        if "loadout_size" in raw:
+            raw_ls = str(raw["loadout_size"])
+            if raw_ls not in _VALID_LOADOUT_SIZES:
+                raise ValueError(
+                    f"Invalid loadout_size {raw_ls!r} in tier override for {level!r}. "
+                    f"Must be one of {sorted(_VALID_LOADOUT_SIZES)}."
+                )
+            loadout_size: LoadoutSize = cast("LoadoutSize", raw_ls)
+        else:
+            loadout_size = base.loadout_size
         base = RuntimeConfig(
             pipeline=str(raw["pipeline"]) if "pipeline" in raw else base.pipeline,
             retries=int(raw["retries"]) if "retries" in raw else base.retries,
             token_ceiling=int(raw["token_ceiling"])
             if "token_ceiling" in raw
             else base.token_ceiling,
-            loadout_size=str(raw["loadout_size"]) if "loadout_size" in raw else base.loadout_size,
+            loadout_size=loadout_size,
         )
     return base
 

--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -750,6 +750,7 @@ class FleetDispatcher:
                     task_config,
                     repo_config or git_repo,
                     run_id=fleet_log.run_id,
+                    loadout_size=runtime.loadout_size,
                 )
                 task = replace(task, equip=equip)
 

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -85,6 +85,19 @@ def test_fleet_task_complexity_defaults_none() -> None:
     assert task.complexity is None
 
 
+def test_derive_runtime_invalid_loadout_size_raises() -> None:
+    """A misspelled loadout_size in a tier override is rejected, not silently coerced."""
+    with pytest.raises(ValueError, match="Invalid loadout_size"):
+        derive_runtime("LOW", tier_overrides={"LOW": {"loadout_size": "ful"}})
+
+
+def test_derive_runtime_valid_loadout_sizes_accepted() -> None:
+    """All three valid loadout_size values are accepted without error."""
+    for size in ("minimal", "standard", "full"):
+        rt = derive_runtime("MED", tier_overrides={"MED": {"loadout_size": size}})
+        assert rt.loadout_size == size
+
+
 # ---------------------------------------------------------------------------
 # Token ceiling metric (no mid-run abort)
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatcher_loadout_size.py
+++ b/tests/test_dispatcher_loadout_size.py
@@ -1,0 +1,79 @@
+"""Regression: dispatcher must forward loadout_size from runtime to resolve_dispatch_equip.
+
+Before the fix, the call omitted loadout_size, silently passing None (full loadout)
+even when the complexity tier derived a smaller size.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from agent_fleet.config import load_fleet_config
+from agent_fleet.dispatcher import FleetDispatcher
+from agent_fleet.level_up.models import DispatchEquip
+
+if TYPE_CHECKING:
+    import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_STUB_EQUIP = DispatchEquip(
+    skill_slots_execute=(),
+    skill_slots_review=(),
+    level_up_generation=0,
+    compose_body="",
+)
+
+
+def _dispatcher(tmp_path: Path) -> FleetDispatcher:
+    fc = load_fleet_config(ROOT / "fleet.example.yaml")
+    fc.default_workspace = str(tmp_path)
+    return FleetDispatcher(config=fc)
+
+
+def test_dispatcher_forwards_tier_loadout_size_to_resolve_dispatch_equip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatcher path must pass loadout_size from the derived runtime, not None."""
+    captured: list[str | None] = []
+
+    def _fake_resolve_dispatch_equip(
+        task,  # noqa: ANN001, ARG001
+        fleet_config,  # noqa: ANN001, ARG001
+        repo,  # noqa: ANN001, ARG001
+        run_id=None,  # noqa: ANN001, ARG001
+        loadout_size=None,  # noqa: ANN001
+    ) -> DispatchEquip:
+        captured.append(loadout_size)
+        return _STUB_EQUIP
+
+    backend = MagicMock()
+    backend.run.return_value = MagicMock(
+        stdout="done", stderr="", exit_code=0, duration_s=0.1, agent_id=None
+    )
+
+    dispatcher = _dispatcher(tmp_path)
+    dispatcher.backend = backend  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        "agent_fleet.dispatcher_task.should_isolate_worktree", lambda *_a, **_k: False
+    )
+
+    with patch(
+        "agent_fleet.orchestration.equip.resolve_dispatch_equip",
+        side_effect=_fake_resolve_dispatch_equip,
+    ):
+        dispatcher.dispatch(
+            goal="test task",
+            persona="coder",
+            workspace=str(tmp_path),
+            complexity="LOW",
+        )
+
+    assert len(captured) == 1, f"resolve_dispatch_equip should be called once, got {len(captured)}"
+    assert captured[0] == "minimal", (
+        f"LOW complexity tier should forward loadout_size='minimal', got {captured[0]!r}"
+    )


### PR DESCRIPTION
Lands two verified loadout_size fixes from the architecture review of PRs #59-66. Each was implemented in an isolated worktree, adversarially verified, and re-run against the full suite locally (1002 passed, 4 skipped).

## F2 — dispatcher dropped the tier loadout_size (#71)
`FleetDispatcher._execute_task` called `resolve_dispatch_equip(...)` without `loadout_size`. The default is `None` (full loadout), so the size derived from `task.complexity` was silently inert on the dispatcher path while `runner.py:1061` forwarded it correctly. Fix: pass `loadout_size=runtime.loadout_size`.

## F6 — invalid loadout_size coerced instead of rejected (#75)
`RuntimeConfig.loadout_size` was typed `str`, so a misspelled tier override (`"ful"`) fell through to full loadout. Branded as `Literal["minimal","standard","full"]` and validated in `derive_runtime`, which now raises `ValueError` on an unknown size. Uses `cast` to match the file's `coerce_complexity` convention.

## Tests
- `test_dispatcher_forwards_tier_loadout_size_to_resolve_dispatch_equip`: LOW tier forwards `loadout_size="minimal"`, not `None`.
- `test_derive_runtime_invalid_loadout_size_raises` / `_valid_loadout_sizes_accepted`.

Closes #71
Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)