### PR TITLE
fix(config): raise on unknown complexity_tier field keys

### DIFF
--- a/agent_fleet/config.py
+++ b/agent_fleet/config.py
@@ -153,8 +153,9 @@ _VALID_TIER_FIELDS = frozenset({"pipeline", "retries", "token_ceiling", "loadout
 def _parse_complexity_tiers(raw: Any) -> dict[str, dict[str, Any]]:  # noqa: ANN401
     """Parse ``complexity_tiers`` YAML block into per-tier override dicts.
 
-    Only known tier names (LOW/MED/HIGH) and known fields are kept; unknown
-    keys are silently dropped to avoid hard failures on forward-compat config.
+    Unknown tier names (not LOW/MED/HIGH) are silently ignored for forward
+    compatibility.  Unknown field keys within a known tier raise ``ValueError``
+    so typos are surfaced immediately rather than silently dropped.
     """
     if not isinstance(raw, dict):
         return {}
@@ -163,7 +164,13 @@ def _parse_complexity_tiers(raw: Any) -> dict[str, dict[str, Any]]:  # noqa: ANN
         key = str(tier).strip().upper()
         if key not in _VALID_TIER_KEYS or not isinstance(fields, dict):
             continue
-        result[key] = {k: v for k, v in fields.items() if k in _VALID_TIER_FIELDS}
+        unknown = set(fields) - _VALID_TIER_FIELDS
+        if unknown:
+            raise ValueError(
+                f"complexity_tiers[{key!r}] contains unknown field(s) {sorted(unknown)}; "
+                f"valid fields: {sorted(_VALID_TIER_FIELDS)}"
+            )
+        result[key] = dict(fields)
     return result
 
 

--- a/tests/test_configurable_tiers_skills.py
+++ b/tests/test_configurable_tiers_skills.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from agent_fleet.complexity import _RUNTIME_MAP, RuntimeConfig, derive_runtime
 from agent_fleet.config import load_fleet_config
 from agent_fleet.skills_lib import (
@@ -225,7 +227,7 @@ def test_absent_yaml_tier_override_preserves_defaults(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Parse helpers: invalid/unknown keys silently dropped
+# Parse helpers: unknown tier names dropped, unknown fields raise
 # ---------------------------------------------------------------------------
 
 
@@ -241,13 +243,26 @@ def test_parse_complexity_tiers_unknown_tier_ignored(tmp_path: Path) -> None:
     assert fc.complexity_tiers["LOW"]["retries"] == 2
 
 
-def test_parse_complexity_tiers_unknown_field_ignored(tmp_path: Path) -> None:
-    """Unknown field names within a tier are silently dropped."""
+def test_parse_complexity_tiers_unknown_field_raises(tmp_path: Path) -> None:
+    """Unknown field names within a tier raise ValueError (typo surfaced at load time)."""
     cfg_file = tmp_path / "fleet.yaml"
     cfg_file.write_text(
         "complexity_tiers:\n  MED:\n    token_ceiling: 3000000\n    unknown_field: oops\n",
         encoding="utf-8",
     )
-    fc = load_fleet_config(cfg_file)
-    assert "unknown_field" not in fc.complexity_tiers.get("MED", {})
-    assert fc.complexity_tiers["MED"]["token_ceiling"] == 3_000_000
+    with pytest.raises(ValueError, match="unknown_field"):
+        load_fleet_config(cfg_file)
+
+
+def test_parse_complexity_tiers_unknown_field_message_names_valid_fields(
+    tmp_path: Path,
+) -> None:
+    """ValueError message lists the valid fields so the user knows how to fix it."""
+    cfg_file = tmp_path / "fleet.yaml"
+    cfg_file.write_text(
+        "complexity_tiers:\n  LOW:\n    retriees: 2\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="retriees") as exc_info:
+        load_fleet_config(cfg_file)
+    assert "pipeline" in str(exc_info.value)


### PR DESCRIPTION
## What

`_parse_complexity_tiers` silently dropped unknown field keys within a known tier. A typo such as `retriees: 2` under `LOW:` vanished with no signal, and the tier silently kept its Python default — the user thinks they configured a retry count, but nothing changed.

This makes the parser raise `ValueError` at config-load time when a known tier (`LOW`/`MED`/`HIGH`) contains an unknown field. The message names the offending key(s) and lists the valid fields (`pipeline`, `retries`, `token_ceiling`, `loadout_size`).

Unknown tier **names** still pass through silently for forward-compat. That asymmetry is intentional: a new tier name is a plausible future addition; a misspelled field within a known tier is always a mistake.

## Why this is safe

No shipped YAML (`fleet.example.yaml`) contains a `complexity_tiers` block, so raising on a typo cannot break any real config in the repo. The change only fires on malformed input that was previously being silently discarded.

## Tests

- `test_parse_complexity_tiers_unknown_field_raises` — unknown field raises.
- `test_parse_complexity_tiers_unknown_field_message_names_valid_fields` — message lists valid fields.
- `test_parse_complexity_tiers_unknown_tier_ignored` — unknown tier names still pass through.

Full suite: 1000 passed, 4 skipped. `ruff` clean. `ty check` clean.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)