### PR TITLE
fix(dispatcher): retry hard failures on the batch path, matching single-task

### DIFF
--- a/agent_fleet/dispatcher.py
+++ b/agent_fleet/dispatcher.py
@@ -966,17 +966,32 @@ class FleetDispatcher:
                 )
             ]
 
+        def _run_task_with_retry(idx: int, task: FleetTask) -> FleetTaskResult:
+            def _dispatch(
+                t: FleetTask,
+                *,
+                handoff: HandoffNote | None = None,
+            ) -> FleetTaskResult:
+                return self._execute_task(
+                    idx,
+                    t,
+                    batch_size=batch_size,
+                    same_workspace_tasks=workspace_counts[self._workspace_key(t)],
+                    base_branch=base_branches[idx] if idx < len(base_branches) else None,
+                    handoff=handoff,
+                )
+
+            return dispatch_with_retry(
+                task,
+                dispatch=_dispatch,
+                policy=RetryPolicy.from_max_redispatches(self.config.max_redispatches),
+                on_event=self._emit_progress,
+            )
+
         results: list[FleetTaskResult | None] = [None] * batch_size
         with ThreadPoolExecutor(max_workers=batch_size) as pool:
             futures = {
-                pool.submit(
-                    self._execute_task,
-                    idx,
-                    task,
-                    batch_size=batch_size,
-                    same_workspace_tasks=workspace_counts[self._workspace_key(task)],
-                    base_branch=base_branches[idx] if idx < len(base_branches) else None,
-                ): idx
+                pool.submit(_run_task_with_retry, idx, task): idx
                 for idx, task in enumerate(normalized)
             }
             for future in as_completed(futures):

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -171,3 +171,49 @@ def test_fleet_dispatcher_does_not_retry_scope_violation(
     assert len(results) == 1
     assert results[0].status == "scope_violation"
     assert call_count == 1  # terminal: no retry despite budget=3
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-level: batch (parallel) tasks retry hard failures like single tasks
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_dispatcher_batch_retries_hard_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A batch (>1 task) must retry a hard transient failure, same as a single task.
+
+    Before the fix, the batch path submitted ``_execute_task`` raw to the thread
+    pool with no ``dispatch_with_retry`` wrapper, so a transient failure in a
+    parallel run was returned permanently while the identical task run alone
+    would have retried.
+    """
+    from agent_fleet.config import load_fleet_config
+    from agent_fleet.dispatcher import FleetDispatcher
+
+    call_counts: dict[int, int] = {}
+
+    def fake_execute_task(self, task_index, task, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001
+        attempt = call_counts.get(task_index, 0) + 1
+        call_counts[task_index] = attempt
+        if attempt == 1:
+            return FakeResult(status="error", exit_code=1)
+        return FakeResult(status="completed")
+
+    monkeypatch.setattr(FleetDispatcher, "_execute_task", fake_execute_task)
+
+    fc = load_fleet_config(ROOT / "fleet.example.yaml")
+    fc.max_redispatches = 2
+    dispatcher = FleetDispatcher(config=fc)
+
+    results = dispatcher.dispatch(
+        tasks=[
+            {"goal": "batch task a", "persona": "coder", "workspace": str(ROOT)},
+            {"goal": "batch task b", "persona": "coder", "workspace": str(ROOT)},
+        ],
+    )
+
+    assert len(results) == 2
+    assert {r.status for r in results} == {"completed"}
+    # Each task: first attempt failed (error), redispatch succeeded → 2 calls each.
+    assert call_counts == {0: 2, 1: 2}


### PR DESCRIPTION
## The divergence

`FleetDispatcher.dispatch` branches at `dispatcher.py:950`:

| Path | Retry behavior |
|---|---|
| `batch_size == 1` (single task) | Wraps `_run_one` in `dispatch_with_retry(policy=RetryPolicy.from_max_redispatches(max_redispatches))` |
| `batch_size > 1` (parallel batch) | Submitted `_execute_task` **raw** to the `ThreadPoolExecutor` — no retry wrapper |

Because the batch path never called `dispatch_with_retry`, every hard transient failure (`error`, `cancelled`, `expired`, `timeout`) in a batch task was returned immediately, ignoring `max_redispatches`. The identical task run alone would have retried. Splitting one task into many to parallelize silently degraded reliability.

## The fix

Wrap each batch task's `_execute_task` in the same `dispatch_with_retry` the single-task path already uses, governed by the same canonical source `FleetConfig.max_redispatches`. The per-task kwargs (`batch_size`, `same_workspace_tasks`, `base_branch`) are preserved exactly. `_execute_task` already accepts `handoff`, so no signature change was needed.

The single-task branch is left untouched — its `base_branch`/`same_workspace_tasks` semantics differ slightly and rewiring it would be scope creep with no behavior gain.

## Test

`test_fleet_dispatcher_batch_retries_hard_failure`: a 2-task batch where each task hard-fails on attempt 1 then succeeds. With the fix, both recover (`completed`, 2 calls each). I verified it **fails** against the un-fixed raw-submit path (returns `error`, 1 call), so it is a real regression guard.

Full suite: 1000 passed, 4 skipped. `ruff` clean. `ty check` clean.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)