### PR TITLE
refactor(phases): subtract PHASE_REGISTRY dict to _KNOWN_PHASES frozenset

### DIFF
--- a/agent_fleet/phases.py
+++ b/agent_fleet/phases.py
@@ -36,20 +36,19 @@ if TYPE_CHECKING:
     from agent_fleet.level_up.models import DispatchEquip
     from agent_fleet.repo import RepoConfig
 
-# Registry of phase names handled by run_pipeline.  Presence in the dict is
-# the source of truth; the value is unused (None) and exists only to give a
-# dict[str, None] type that callers can introspect.
-PHASE_REGISTRY: dict[str, None] = {"execute": None, "analyze": None, "review": None}
+# The phase names run_pipeline knows how to dispatch.  validate_phases rejects
+# anything outside this set before any agent runs.
+_KNOWN_PHASES: frozenset[str] = frozenset({"execute", "analyze", "review"})
 
 
 def validate_phases(phases: list[str]) -> None:
-    """Raise ValueError if any phase name is not in PHASE_REGISTRY.
+    """Raise ValueError if any phase name is not a known phase.
 
     Call at pipeline-resolve time so unknown names fail before any agent runs.
     """
-    unknown = [p for p in phases if p not in PHASE_REGISTRY]
+    unknown = [p for p in phases if p not in _KNOWN_PHASES]
     if unknown:
-        known = sorted(PHASE_REGISTRY)
+        known = sorted(_KNOWN_PHASES)
         raise ValueError(f"Unknown phase(s) {unknown!r}; known phases are {known}")
 
 

--- a/tests/test_phase_registry.py
+++ b/tests/test_phase_registry.py
@@ -9,7 +9,7 @@ import pytest
 from agent_fleet.config import load_fleet_config
 from agent_fleet.hooks import FleetTask
 from agent_fleet.personas import YamlPersonaResolver
-from agent_fleet.phases import PHASE_REGISTRY, run_pipeline, validate_phases
+from agent_fleet.phases import run_pipeline, validate_phases
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -51,14 +51,14 @@ def test_validate_phases_empty_list_ok() -> None:
 
 
 # ---------------------------------------------------------------------------
-# PHASE_REGISTRY shape
+# Each known phase is accepted by validate_phases
 # ---------------------------------------------------------------------------
 
 
-def test_phase_registry_contains_expected_keys() -> None:
-    assert "execute" in PHASE_REGISTRY
-    assert "analyze" in PHASE_REGISTRY
-    assert "review" in PHASE_REGISTRY
+def test_validate_phases_accepts_each_known_phase() -> None:
+    # Every phase run_pipeline can dispatch must pass validation.
+    for phase in ("execute", "analyze", "review"):
+        validate_phases([phase])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Subtracts `PHASE_REGISTRY: dict[str, None]` to `_KNOWN_PHASES: frozenset[str]` in `agent_fleet/phases.py`. Zero behavior change. Closes #73 (F4).

## Why

`PHASE_REGISTRY` was a `dict[str, None]` whose values were always `None` and never read. It served only as a membership set for `validate_phases`. The dict shape implied a name-to-handler registry that does not exist. `run_pipeline` dispatches phases through a hardcoded `if/elif` chain that never consults the dict, so the `dict[str, None]` type advertised a pluggability the code never delivered.

`frozenset[str]` is the honest shape. It is an immutable set of known phase names with no dead value slot. The "registry maps names to handlers" reading becomes unrepresentable. It is an implementation detail of `validate_phases`, so it is now private (`_KNOWN_PHASES`).

## Changes

- `agent_fleet/phases.py`: replace the constant and its 3-line explanatory comment with the one-line `frozenset`. Point `validate_phases` and its docstring at `_KNOWN_PHASES`. Logic and error message unchanged.
- `tests/test_phase_registry.py`: drop the now-private constant from the import. Replace the `in PHASE_REGISTRY` shape assertion with a `validate_phases`-behavior test over each known phase. The existing `validate_phases` accept/reject tests are unchanged and still pass.

## Verification

Local on this branch: `uv run ruff check` clean, `uv run ty check agent_fleet tests integrations` clean, `uv run pytest -q` 1002 passed and 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)