### PR TITLE
feat(scripts): outcome scorecard over run logs

### DIFF
--- a/scripts/outcome_scorecard.py
+++ b/scripts/outcome_scorecard.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Aggregate task outcomes over agent-fleet run logs (JSONL).
+
+Usage:
+    python scripts/outcome_scorecard.py [--runs-dir DIR] [--json] [--include-synthetic] [--top N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+_ORCHESTRATION_PHASES = {
+    "RESEARCH", "PLAN", "IMPLEMENT", "VERIFY", "SYNTHESIZE",
+    "TECH_LEAD", "OPEN_PR",
+}
+
+
+def _default_runs_dir() -> Path:
+    env = os.environ.get("AGENT_FLEET_RUNS_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".agent-fleet" / "fleet" / "runs"
+
+
+def _is_real(events: list[dict]) -> bool:
+    """A file is real if any llm.usage model != 'm', max tokens > 10000, or run.start present."""
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+        if e.get("event") == "run.start":
+            return True
+        data = e.get("data")
+        if not isinstance(data, dict):
+            continue
+        model = data.get("model")
+        if isinstance(model, str) and model and model != "m":
+            return True
+        total_tok = data.get("total_tokens")
+        if isinstance(total_tok, (int, float)) and total_tok > 10000:
+            return True
+    return False
+
+
+def _infer_pipeline(phases: set[str]) -> str:
+    lc = {p.lower() for p in phases}
+    if "analyze" in lc:
+        return "pr_review"
+    orch = _ORCHESTRATION_PHASES & phases
+    if orch - {"REVIEW"}:
+        return "full"
+    if "review" in lc and "execute" in lc:
+        return "code_review"
+    if "execute" in lc:
+        return "simple"
+    return "unknown"
+
+
+def _most_common_model(events: list[dict]) -> str | None:
+    counts: Counter[str] = Counter()
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+        data = e.get("data")
+        if not isinstance(data, dict):
+            continue
+        if e.get("event") == "llm.usage":
+            model = data.get("model")
+            if isinstance(model, str) and model:
+                counts[model] += 1
+    return counts.most_common(1)[0][0] if counts else None
+
+
+def _parse_file(path: Path) -> dict | None:
+    events: list[dict] = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                events.append(obj)
+    except OSError:
+        return None
+
+    run_id: str | None = None
+    goal: str | None = None
+    persona: str | None = None
+    last_complete: dict | None = None
+    run_end: dict | None = None
+    has_error = False
+    tokens_total = 0
+    fix_phase_tokens = 0
+    phases: set[str] = set()
+    rollup_tokens: int | None = None
+    issue_top: int | None = None
+    pr_number: int | None = None
+
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+
+        ev = e.get("event")
+        if not isinstance(ev, str):
+            continue
+
+        if run_id is None:
+            cand = e.get("run_id")
+            if isinstance(cand, str) and cand:
+                run_id = cand
+
+        if issue_top is None:
+            it = e.get("issue_number")
+            if isinstance(it, int):
+                issue_top = it
+
+        phase = e.get("phase")
+        if isinstance(phase, str) and phase:
+            phases.add(phase)
+
+        if ev == "fleet.task.start":
+            if goal is None:
+                data = e.get("data")
+                if isinstance(data, dict):
+                    g = data.get("goal")
+                    if isinstance(g, str):
+                        goal = g
+                    p = data.get("persona")
+                    if isinstance(p, str) and persona is None:
+                        persona = p
+
+        elif ev == "fleet.task.complete":
+            last_complete = e
+
+        elif ev == "fleet.task.error":
+            has_error = True
+
+        elif ev == "llm.usage":
+            data = e.get("data")
+            if isinstance(data, dict):
+                tok = data.get("total_tokens")
+                if isinstance(tok, (int, float)):
+                    tokens_total += int(tok)
+                    ph = e.get("phase")
+                    if isinstance(ph, str) and ph.lower() == "fix":
+                        fix_phase_tokens += int(tok)
+
+        elif ev == "llm.usage.task_rollup":
+            data = e.get("data")
+            if isinstance(data, dict):
+                totals = data.get("totals", {})
+                if isinstance(totals, dict):
+                    t = totals.get("total_tokens")
+                    if isinstance(t, (int, float)):
+                        rollup_tokens = int(t)
+
+        elif ev == "run.start":
+            data = e.get("data")
+            if isinstance(data, dict) and persona is None:
+                p = e.get("persona") or data.get("persona")
+                if isinstance(p, str):
+                    persona = p
+
+        elif ev == "run.end":
+            run_end = e
+            data = e.get("data")
+            if isinstance(data, dict):
+                prn = data.get("pr_number")
+                if isinstance(prn, int):
+                    pr_number = prn
+
+    if persona is None:
+        for e in events:
+            if not isinstance(e, dict):
+                continue
+            p = e.get("persona")
+            if isinstance(p, str) and p:
+                persona = p
+                break
+
+    status: str
+    fix_attempts = 0
+    verify_attempts = 0
+    verify_failure: bool | None = None
+    changed_files_count: int | None = None
+    issue_number: int | None = None
+    repo_key: str | None = None
+    duration_seconds: float | None = None
+
+    # Prefer the orchestration/issue-loop verdict (run.end.outcome), then the dispatch
+    # verdict (fleet.task.complete.status), then a bare error, then incomplete.
+    resolved: str | None = None
+    source_data: dict = {}
+    if run_end is not None:
+        d = run_end.get("data")
+        if isinstance(d, dict):
+            oc = d.get("outcome")
+            if isinstance(oc, (str, int, float)) and str(oc):
+                resolved = str(oc)
+                source_data = d
+    if resolved is None and last_complete is not None:
+        d = last_complete.get("data")
+        if isinstance(d, dict):
+            source_data = d
+            raw_status = d.get("status")
+            if isinstance(raw_status, (str, int, float)):
+                resolved = str(raw_status)
+            dur = d.get("duration_seconds")
+            if isinstance(dur, (int, float)):
+                duration_seconds = float(dur)
+    status = resolved if resolved is not None else ("error" if has_error else "incomplete")
+
+    om = source_data.get("outcome_metrics")
+    if isinstance(om, dict):
+        fa = om.get("fix_attempts")
+        if isinstance(fa, int):
+            fix_attempts = fa
+        va = om.get("verify_attempts")
+        if isinstance(va, int):
+            verify_attempts = va
+        vf = om.get("verify_failure")
+        if vf is not None:
+            verify_failure = bool(vf)
+        cfc = om.get("changed_files_count")
+        if isinstance(cfc, int):
+            changed_files_count = cfc
+        iss = om.get("issue_number")
+        if isinstance(iss, int):
+            issue_number = iss
+        rk = om.get("repo_key")
+        if isinstance(rk, str) and rk:
+            repo_key = rk
+    if issue_number is None:
+        issue_number = issue_top
+
+    if tokens_total == 0 and rollup_tokens is not None:
+        tokens_total = rollup_tokens
+
+    return {
+        "run_id": run_id if run_id is not None else path.stem,
+        "file": path.name,
+        "kind": "real" if _is_real(events) else "synthetic",
+        "goal": goal,
+        "persona": persona,
+        "model": _most_common_model(events),
+        "pipeline": _infer_pipeline(phases),
+        "status": status,
+        "success": status == "completed",
+        "fix_attempts": fix_attempts,
+        "verify_attempts": verify_attempts,
+        "verify_failure": verify_failure,
+        "changed_files_count": changed_files_count,
+        "issue_number": issue_number,
+        "pr_number": pr_number,
+        "repo_key": repo_key,
+        "tokens_total": tokens_total,
+        "fix_phase_tokens": fix_phase_tokens,
+        "duration_seconds": duration_seconds,
+    }
+
+
+def _load_all(runs_dir: Path) -> list[dict]:
+    rows = []
+    for jsonl in sorted(runs_dir.glob("*.jsonl")):
+        row = _parse_file(jsonl)
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
+def _build_summary(rows: list[dict]) -> dict:
+    if not rows:
+        return {
+            "total": 0,
+            "success_rate": None,
+            "status_histogram": {},
+            "tokens_by_status": {},
+            "spiral": {},
+            "by_persona": {},
+            "by_pipeline": {},
+            "by_repo_key": {},
+            "by_model": {},
+        }
+
+    total = len(rows)
+    success_count = sum(1 for r in rows if r["success"])
+    success_rate = round(success_count / total, 4) if total else None
+
+    status_counts: Counter[str] = Counter(r["status"] for r in rows)
+    status_histogram = {
+        s: {"count": c, "pct": round(c / total, 4)}
+        for s, c in status_counts.most_common()
+    }
+
+    tokens_by_status: dict[str, int] = {}
+    for r in rows:
+        st = r["status"]
+        tokens_by_status[st] = tokens_by_status.get(st, 0) + r["tokens_total"]
+
+    total_tok = sum(r["tokens_total"] for r in rows) or 1
+    fix_tok = sum(r["fix_phase_tokens"] for r in rows)
+    spiral_runs = [r for r in rows if r["fix_attempts"] > 0 or r["verify_attempts"] > 1]
+
+    spiral = {
+        "count": len(spiral_runs),
+        "fix_phase_token_share": round(fix_tok / total_tok, 4),
+        "total_fix_phase_tokens": fix_tok,
+        "top_by_fix_phase_tokens": sorted(
+            [
+                {
+                    "run_id": r["run_id"],
+                    "fix_phase_tokens": r["fix_phase_tokens"],
+                    "status": r["status"],
+                    "repo_key": r["repo_key"],
+                }
+                for r in rows
+            ],
+            key=lambda x: x["fix_phase_tokens"],
+            reverse=True,
+        )[:5],
+    }
+
+    def _breakdown(key: str) -> dict:
+        groups: dict[str, list[dict]] = {}
+        for r in rows:
+            k = str(r.get(key) or "unknown")
+            groups.setdefault(k, []).append(r)
+        out = {}
+        for k, group in sorted(groups.items()):
+            sc = sum(1 for g in group if g["success"])
+            out[k] = {
+                "count": len(group),
+                "success_count": sc,
+                "success_rate": round(sc / len(group), 4),
+            }
+        return out
+
+    return {
+        "total": total,
+        "success_count": success_count,
+        "success_rate": success_rate,
+        "status_histogram": status_histogram,
+        "tokens_by_status": tokens_by_status,
+        "spiral": spiral,
+        "by_persona": _breakdown("persona"),
+        "by_pipeline": _breakdown("pipeline"),
+        "by_repo_key": _breakdown("repo_key"),
+        "by_model": _breakdown("model"),
+    }
+
+
+def _print_human(rows: list[dict], top_n: int, runs_dir: Path) -> None:
+    real = [r for r in rows if r["kind"] == "real"]
+    synth = [r for r in rows if r["kind"] == "synthetic"]
+    total_scanned = len(rows)
+
+    print(
+        f"Scanned {total_scanned} files: {len(real)} real, {len(synth)} synthetic "
+        f"(excluded). Real = model != 'm' OR max_tokens > 10000 OR run.start present."
+    )
+
+    if not real:
+        print("No real runs found.")
+        return
+
+    s = _build_summary(real)
+    total = s["total"]
+    sc = s.get("success_count", 0)
+
+    print(f"\nSuccess rate: {sc}/{total} ({100 * (s['success_rate'] or 0):.1f}%)\n")
+
+    print("Status histogram:")
+    for status, info in s["status_histogram"].items():
+        bar = "#" * int(info["pct"] * 40)
+        print(f"  {status:<30}  {info['count']:>5}  {100*info['pct']:>5.1f}%  {bar}")
+
+    print("\nTokens by status:")
+    for st, tok in sorted(s["tokens_by_status"].items(), key=lambda x: -x[1]):
+        print(f"  {st:<30}  {tok:>12,}")
+
+    sp = s["spiral"]
+    fix_share_pct = 100 * sp["fix_phase_token_share"]
+    print(
+        f"\nSpiral signal: {sp['count']} runs with fix_attempts>0 or verify_attempts>1, "
+        f"fix-phase token share {fix_share_pct:.1f}%"
+    )
+    if sp["top_by_fix_phase_tokens"]:
+        print("  Top runs by fix_phase_tokens:")
+        for r in sp["top_by_fix_phase_tokens"]:
+            print(
+                f"    {r['run_id']:<36}  fix_tok={r['fix_phase_tokens']:>8,}"
+                f"  status={r['status']}  repo={r['repo_key']}"
+            )
+
+    for label, key in [
+        ("By persona", "by_persona"),
+        ("By pipeline", "by_pipeline"),
+        ("By repo_key", "by_repo_key"),
+        ("By model", "by_model"),
+    ]:
+        breakdown = s[key]
+        print(f"\n{label}:")
+        for k, info in breakdown.items():
+            print(
+                f"  {k:<30}  count={info['count']:>5}  "
+                f"success={info['success_count']:>5}  "
+                f"rate={100*info['success_rate']:>5.1f}%"
+            )
+
+    failures = sorted(
+        [r for r in real if not r["success"]],
+        key=lambda r: r["tokens_total"],
+        reverse=True,
+    )[:top_n]
+    print(f"\nTop {top_n} highest-token non-completed runs (capability killers):")
+    hdr = f"  {'run_id':<36}  {'status':<25}  {'tokens':>10}  {'repo':<18}  goal"
+    print(hdr)
+    print("  " + "-" * (len(hdr) - 2))
+    for r in failures:
+        goal_trunc = (r["goal"] or "")[:50]
+        print(
+            f"  {r['run_id']:<36}  {r['status']:<25}  {r['tokens_total']:>10,}"
+            f"  {r['repo_key'] or ''!s:<18}  {goal_trunc}"
+        )
+
+    print(
+        "\nNote: no version is stamped in the logs; monthly buckets below use file mtime"
+        " as a proxy, not a per-version measurement."
+    )
+    buckets: dict[str, list[bool]] = {}
+    for r in real:
+        p = runs_dir / r["file"]
+        try:
+            mtime = p.stat().st_mtime
+            month = datetime.datetime.fromtimestamp(mtime).strftime("%Y-%m")
+        except OSError:
+            month = "unknown"
+        buckets.setdefault(month, []).append(r["success"])
+
+    print("\nMonthly success-rate proxy (file mtime):")
+    for month in sorted(buckets):
+        hits = buckets[month]
+        rate = sum(hits) / len(hits)
+        print(
+            f"  {month}  count={len(hits):>4}  "
+            f"success={sum(hits):>4}  rate={100*rate:>5.1f}%"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate task outcomes from agent-fleet run logs."
+    )
+    parser.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory containing *.jsonl run logs"
+            " (default: AGENT_FLEET_RUNS_DIR or ~/.agent-fleet/fleet/runs)"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Emit a JSON object with 'runs' and 'summary' keys.",
+    )
+    parser.add_argument(
+        "--include-synthetic",
+        action="store_true",
+        help="Include synthetic fixtures in the summary (default: real only).",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Number of top failures to show (default: 10).",
+    )
+    args = parser.parse_args(argv)
+
+    runs_dir: Path = args.runs_dir or _default_runs_dir()
+    if not runs_dir.is_dir():
+        print(f"runs-dir not found: {runs_dir}", file=sys.stderr)
+        return 1
+
+    all_rows = _load_all(runs_dir)
+
+    summary_rows = (
+        all_rows if args.include_synthetic else [r for r in all_rows if r["kind"] == "real"]
+    )
+
+    if args.output_json:
+        print(
+            json.dumps(
+                {"runs": all_rows, "summary": _build_summary(summary_rows)},
+                indent=2,
+            )
+        )
+    else:
+        _print_human(all_rows, top_n=args.top, runs_dir=runs_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_outcome_scorecard.py
+++ b/tests/test_outcome_scorecard.py
@@ -1,0 +1,707 @@
+"""Tests for scripts/outcome_scorecard.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(tmp_path: Path, extra_args: list[str] | None = None) -> dict:
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "scripts/outcome_scorecard.py",
+        "--runs-dir",
+        str(tmp_path),
+        "--json",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _write(path: Path, events: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_real_completed(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "real-completed.jsonl",
+        [
+            {
+                "ts": "2026-05-29T00:00:00+00:00",
+                "run_id": "real-completed",
+                "event": "fleet.task.start",
+                "level": "info",
+                "persona": "lakestore",
+                "data": {
+                    "task_index": 0,
+                    "persona": "lakestore",
+                    "goal": "fix snapshot bootstrap bug",
+                    "has_handoff": False,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:01:00+00:00",
+                "run_id": "real-completed",
+                "event": "llm.usage",
+                "level": "info",
+                "phase": "execute",
+                "data": {
+                    "model": "composer-2.5",
+                    "agent_id": "agent-abc",
+                    "duration_s": 60.0,
+                    "input_tokens": 50000,
+                    "output_tokens": 5000,
+                    "cache_read_tokens": 40000,
+                    "cache_write_tokens": 0,
+                    "total_tokens": 95000,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:02:00+00:00",
+                "run_id": "real-completed",
+                "event": "fleet.task.complete",
+                "level": "info",
+                "persona": "lakestore",
+                "data": {
+                    "task_index": 0,
+                    "persona": "lakestore",
+                    "status": "completed",
+                    "duration_seconds": 120.0,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "verify_attempts": 1,
+                        "fix_attempts": 0,
+                        "repo_key": "silphcoanalytics",
+                        "issue_number": 42,
+                        "duration_seconds": 120.0,
+                        "changed_files_count": 3,
+                        "verify_failure": None,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+    r = runs_by_id["real-completed"]
+
+    assert r["kind"] == "real"
+    assert r["success"] is True
+    assert r["status"] == "completed"
+    assert r["model"] == "composer-2.5"
+    assert r["persona"] == "lakestore"
+    assert r["goal"] == "fix snapshot bootstrap bug"
+    assert r["tokens_total"] == 95000
+    assert r["fix_attempts"] == 0
+    assert r["verify_attempts"] == 1
+    assert r["repo_key"] == "silphcoanalytics"
+    assert r["issue_number"] == 42
+    assert r["changed_files_count"] == 3
+    assert r["pipeline"] == "simple"
+
+
+def test_real_verify_failed(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "real-verify-failed.jsonl",
+        [
+            {
+                "ts": "2026-05-29T00:00:00+00:00",
+                "run_id": "real-verify-failed",
+                "event": "fleet.task.start",
+                "level": "info",
+                "persona": "coder",
+                "data": {
+                    "task_index": 0,
+                    "persona": "coder",
+                    "goal": "refactor dispatch loop",
+                    "has_handoff": False,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:01:00+00:00",
+                "run_id": "real-verify-failed",
+                "event": "llm.usage",
+                "level": "info",
+                "phase": "execute",
+                "data": {
+                    "model": "composer-2.5",
+                    "agent_id": "agent-xyz",
+                    "duration_s": 80.0,
+                    "input_tokens": 100000,
+                    "output_tokens": 8000,
+                    "cache_read_tokens": 90000,
+                    "cache_write_tokens": 0,
+                    "total_tokens": 198000,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:02:00+00:00",
+                "run_id": "real-verify-failed",
+                "event": "llm.usage",
+                "level": "info",
+                "phase": "fix",
+                "data": {
+                    "model": "composer-2.5",
+                    "agent_id": "agent-xyz",
+                    "duration_s": 30.0,
+                    "input_tokens": 40000,
+                    "output_tokens": 3000,
+                    "cache_read_tokens": 35000,
+                    "cache_write_tokens": 0,
+                    "total_tokens": 78000,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:03:00+00:00",
+                "run_id": "real-verify-failed",
+                "event": "fleet.task.complete",
+                "level": "info",
+                "persona": "coder",
+                "data": {
+                    "task_index": 0,
+                    "persona": "coder",
+                    "status": "verify_failed",
+                    "duration_seconds": 200.0,
+                    "outcome_metrics": {
+                        "status": "verify_failed",
+                        "verify_attempts": 2,
+                        "fix_attempts": 1,
+                        "repo_key": "agent-fleet",
+                        "issue_number": 0,
+                        "duration_seconds": 200.0,
+                        "changed_files_count": 0,
+                        "verify_failure": True,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+    r = runs_by_id["real-verify-failed"]
+
+    assert r["kind"] == "real"
+    assert r["success"] is False
+    assert r["status"] == "verify_failed"
+    assert r["fix_attempts"] == 1
+    assert r["verify_attempts"] == 2
+    assert r["verify_failure"] is True
+    assert r["tokens_total"] == 276000
+    assert r["fix_phase_tokens"] == 78000
+
+
+def test_synthetic_excluded_from_summary(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "synth-dispatch.jsonl",
+        [
+            {
+                "ts": "2026-05-29T00:00:00+00:00",
+                "run_id": "synth-dispatch",
+                "event": "fleet.task.start",
+                "level": "info",
+                "persona": "coder",
+                "data": {
+                    "task_index": 0,
+                    "persona": "coder",
+                    "goal": "legacy",
+                    "has_handoff": False,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:00:01+00:00",
+                "run_id": "synth-dispatch",
+                "event": "llm.usage",
+                "level": "info",
+                "phase": "execute",
+                "data": {
+                    "model": "m",
+                    "agent_id": None,
+                    "duration_s": 0.1,
+                    "input_tokens": 0,
+                    "output_tokens": 7,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "total_tokens": 7,
+                },
+            },
+            {
+                "ts": "2026-05-29T00:00:02+00:00",
+                "run_id": "synth-dispatch",
+                "event": "fleet.task.complete",
+                "level": "info",
+                "persona": "coder",
+                "data": {
+                    "task_index": 0,
+                    "persona": "coder",
+                    "status": "completed",
+                    "duration_seconds": 0.09,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "verify_attempts": 0,
+                        "fix_attempts": 0,
+                        "repo_key": "test_dispatch_x",
+                        "issue_number": 0,
+                        "duration_seconds": 0.09,
+                        "changed_files_count": 0,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+    r = runs_by_id["synth-dispatch"]
+
+    assert r["kind"] == "synthetic"
+    # Synthetic excluded from default summary
+    assert out["summary"]["total"] == 0
+
+
+def test_real_and_synthetic_summary_separation(tmp_path: Path) -> None:
+    # Real completed run
+    _write(
+        tmp_path / "r1.jsonl",
+        [
+            {
+                "run_id": "r1",
+                "event": "fleet.task.start",
+                "data": {"persona": "backend", "goal": "g1", "has_handoff": False, "task_index": 0},
+            },
+            {
+                "run_id": "r1",
+                "event": "llm.usage",
+                "phase": "execute",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 50000,
+                    "input_tokens": 30000,
+                    "output_tokens": 5000,
+                    "cache_read_tokens": 15000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 30.0,
+                    "agent_id": "a1",
+                },
+            },
+            {
+                "run_id": "r1",
+                "event": "fleet.task.complete",
+                "data": {
+                    "status": "completed",
+                    "task_index": 0,
+                    "persona": "backend",
+                    "duration_seconds": 60.0,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "fix_attempts": 0,
+                        "verify_attempts": 0,
+                        "repo_key": "silphcoanalytics",
+                        "issue_number": 0,
+                        "duration_seconds": 60.0,
+                        "changed_files_count": 2,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+    # Synthetic run
+    _write(
+        tmp_path / "s1.jsonl",
+        [
+            {
+                "run_id": "s1",
+                "event": "fleet.task.start",
+                "data": {
+                    "persona": "coder",
+                    "goal": "synth",
+                    "has_handoff": False,
+                    "task_index": 0,
+                },
+            },
+            {
+                "run_id": "s1",
+                "event": "llm.usage",
+                "phase": "execute",
+                "data": {
+                    "model": "m",
+                    "total_tokens": 5,
+                    "input_tokens": 0,
+                    "output_tokens": 5,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "duration_s": 0.01,
+                    "agent_id": None,
+                },
+            },
+            {
+                "run_id": "s1",
+                "event": "fleet.task.complete",
+                "data": {
+                    "status": "completed",
+                    "task_index": 0,
+                    "persona": "coder",
+                    "duration_seconds": 0.1,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "fix_attempts": 0,
+                        "verify_attempts": 0,
+                        "repo_key": "test_abc",
+                        "issue_number": 0,
+                        "duration_seconds": 0.1,
+                        "changed_files_count": 0,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+
+    assert runs_by_id["r1"]["kind"] == "real"
+    assert runs_by_id["s1"]["kind"] == "synthetic"
+
+    # Default summary covers real only
+    assert out["summary"]["total"] == 1
+    assert out["summary"]["success_count"] == 1
+    assert out["summary"]["success_rate"] == 1.0
+    assert out["summary"]["status_histogram"]["completed"]["count"] == 1
+
+
+def test_pipeline_inference(tmp_path: Path) -> None:
+    # File with 'analyze' phase -> pr_review
+    _write(
+        tmp_path / "pr-review-run.jsonl",
+        [
+            {
+                "run_id": "pr-review-run",
+                "event": "llm.usage",
+                "phase": "analyze",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 20000,
+                    "input_tokens": 15000,
+                    "output_tokens": 2000,
+                    "cache_read_tokens": 3000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 20.0,
+                    "agent_id": "a1",
+                },
+            },
+        ],
+    )
+    # File with uppercase orchestration phases -> full
+    _write(
+        tmp_path / "full-pipeline-run.jsonl",
+        [
+            {
+                "run_id": "full-pipeline-run",
+                "event": "run.start",
+                "data": {"title": "test run", "visual_audit": False, "phase_order": []},
+                "persona": "backend",
+                "issue_number": 99,
+                "level": "info",
+                "ts": "2026-05-29T00:00:00+00:00",
+            },
+            {
+                "run_id": "full-pipeline-run",
+                "event": "llm.usage",
+                "phase": "PLAN",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 30000,
+                    "input_tokens": 20000,
+                    "output_tokens": 5000,
+                    "cache_read_tokens": 5000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 40.0,
+                    "agent_id": "a2",
+                },
+            },
+            {
+                "run_id": "full-pipeline-run",
+                "event": "llm.usage",
+                "phase": "IMPLEMENT",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 40000,
+                    "input_tokens": 25000,
+                    "output_tokens": 6000,
+                    "cache_read_tokens": 9000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 50.0,
+                    "agent_id": "a2",
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+
+    assert runs_by_id["pr-review-run"]["pipeline"] == "pr_review"
+    assert runs_by_id["full-pipeline-run"]["pipeline"] == "full"
+
+
+def test_include_synthetic_flag(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "synth2.jsonl",
+        [
+            {
+                "run_id": "synth2",
+                "event": "fleet.task.start",
+                "data": {"persona": "coder", "goal": "g", "has_handoff": False, "task_index": 0},
+            },
+            {
+                "run_id": "synth2",
+                "event": "fleet.task.complete",
+                "data": {
+                    "status": "completed",
+                    "task_index": 0,
+                    "persona": "coder",
+                    "duration_seconds": 0.1,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "fix_attempts": 0,
+                        "verify_attempts": 0,
+                        "repo_key": "test_xyz",
+                        "issue_number": 0,
+                        "duration_seconds": 0.1,
+                        "changed_files_count": 0,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out_default = _run(tmp_path)
+    out_with_synth = _run(tmp_path, extra_args=["--include-synthetic"])
+
+    # Default: synthetic excluded from summary
+    assert out_default["summary"]["total"] == 0
+    # With flag: synthetic included
+    assert out_with_synth["summary"]["total"] == 1
+
+
+def test_no_task_events_status_incomplete(tmp_path: Path) -> None:
+    # A run.start file with no fleet.task events -> incomplete
+    _write(
+        tmp_path / "run-start-only.jsonl",
+        [
+            {
+                "ts": "2026-05-29T00:00:00+00:00",
+                "run_id": "run-start-only",
+                "event": "run.start",
+                "level": "info",
+                "issue_number": 100,
+                "persona": "frontend",
+                "data": {"title": "some issue", "visual_audit": False},
+            },
+            {
+                "ts": "2026-05-29T00:01:00+00:00",
+                "run_id": "run-start-only",
+                "event": "llm.usage",
+                "level": "info",
+                "phase": "PLAN",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 50000,
+                    "input_tokens": 30000,
+                    "output_tokens": 5000,
+                    "cache_read_tokens": 15000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 40.0,
+                    "agent_id": "a3",
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+    r = runs_by_id["run-start-only"]
+
+    assert r["kind"] == "real"
+    assert r["status"] == "incomplete"
+    assert r["success"] is False
+    assert r["tokens_total"] == 50000
+
+
+def test_fix_phase_tokens_tracked(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "fix-tokens-run.jsonl",
+        [
+            {
+                "run_id": "fix-tokens-run",
+                "event": "llm.usage",
+                "phase": "execute",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 80000,
+                    "input_tokens": 60000,
+                    "output_tokens": 8000,
+                    "cache_read_tokens": 12000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 60.0,
+                    "agent_id": "a4",
+                },
+            },
+            {
+                "run_id": "fix-tokens-run",
+                "event": "llm.usage",
+                "phase": "fix",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 25000,
+                    "input_tokens": 20000,
+                    "output_tokens": 2000,
+                    "cache_read_tokens": 3000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 20.0,
+                    "agent_id": "a4",
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    runs_by_id = {r["run_id"]: r for r in out["runs"]}
+    r = runs_by_id["fix-tokens-run"]
+
+    assert r["tokens_total"] == 105000
+    assert r["fix_phase_tokens"] == 25000
+    assert r["pipeline"] == "simple"
+
+
+def test_run_end_outcome_is_terminal_status(tmp_path: Path) -> None:
+    """Orchestration/issue-loop runs end via run.end.outcome, not fleet.task.complete."""
+    _write(
+        tmp_path / "issue-loop-run.jsonl",
+        [
+            {
+                "ts": "2026-05-24T20:24:16+00:00",
+                "run_id": "issue-loop-run",
+                "event": "run.start",
+                "level": "info",
+                "issue_number": 1860,
+                "persona": "frontend",
+                "data": {"title": "fix loading states", "visual_audit": True},
+            },
+            {
+                "run_id": "issue-loop-run",
+                "event": "llm.usage",
+                "phase": "IMPLEMENT",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 300000,
+                    "input_tokens": 200000,
+                    "output_tokens": 30000,
+                    "cache_read_tokens": 70000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 100.0,
+                    "agent_id": "a5",
+                },
+            },
+            {
+                "ts": "2026-05-24T20:57:22+00:00",
+                "run_id": "issue-loop-run",
+                "event": "run.end",
+                "level": "info",
+                "issue_number": 1860,
+                "persona": "frontend",
+                "data": {
+                    "outcome": "review_changes_requested",
+                    "pr_number": 1883,
+                    "jsonl": "/home/evan/.hermes/fleet/runs/issue-loop-run.jsonl",
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    r = {x["run_id"]: x for x in out["runs"]}["issue-loop-run"]
+
+    assert r["kind"] == "real"
+    assert r["status"] == "review_changes_requested"
+    assert r["success"] is False
+    assert r["pr_number"] == 1883
+    assert r["issue_number"] == 1860
+    assert r["pipeline"] == "full"
+    assert r["tokens_total"] == 300000
+
+
+def test_run_end_completed_counts_as_success(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "orch-completed.jsonl",
+        [
+            {
+                "run_id": "orch-completed",
+                "event": "run.start",
+                "issue_number": 200,
+                "persona": "backend",
+                "data": {"title": "add endpoint", "visual_audit": False},
+            },
+            {
+                "run_id": "orch-completed",
+                "event": "llm.usage",
+                "phase": "IMPLEMENT",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 120000,
+                    "input_tokens": 90000,
+                    "output_tokens": 10000,
+                    "cache_read_tokens": 20000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 70.0,
+                    "agent_id": "a6",
+                },
+            },
+            {
+                "run_id": "orch-completed",
+                "event": "run.end",
+                "issue_number": 200,
+                "persona": "backend",
+                "data": {"outcome": "completed", "pr_number": 201},
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    summary = out["summary"]
+    r = {x["run_id"]: x for x in out["runs"]}["orch-completed"]
+
+    assert r["status"] == "completed"
+    assert r["success"] is True
+    assert r["pr_number"] == 201
+    assert summary["success_count"] == 1
+    assert summary["status_histogram"]["completed"]["count"] == 1


### PR DESCRIPTION
## What

Adds `scripts/outcome_scorecard.py` (+ test). It aggregates task **outcomes** across the `~/.agent-fleet/fleet/runs/*.jsonl` logs, where `efficiency_report.py` only aggregated tokens. Same one-row-per-file grain, so the two compose.

No log schema change. Every field it reads was already emitted; it was just never aggregated.

## Why

We need to measure whether the fleet can handle difficult tasks, not just how many tokens it spends. This is the instrument: success rate, terminal-status histogram, token-weighted outcomes, the fix/retry spiral signal, and breakdowns by persona / pipeline / repo / model.

## How the verdict is resolved

Two run shapes exist in the logs. The resolver reads, in order:
1. `run.end.data.outcome` (orchestration and issue-loop runs).
2. `fleet.task.complete.data.status` (dispatch runs).
3. `error` if a `fleet.task.error` was seen, else `incomplete`.

Resolving `run.end.outcome` is load-bearing: 220 of the real runs complete via `run.end` and emit no `fleet.task.complete`. Reading only the dispatch event mislabels them all as `incomplete` and drags the headline success rate from 24% down to a false 7%.

## What it found on the current 1,813 logs

- The corpus is ~96% leaked test-suite fixtures (model `m`, `repo_key=test_*`). The scorecard classifies and **excludes** them by default; `--include-synthetic` opts back in. Real runs: **300**.
- Real success rate: **73/300 (24.3%)**. Status histogram is now legible (completed 73, error 67, incomplete 46, review_changes_requested 41, verify_failed 21, plus the orchestration-specific outcomes).
- By repo: `silphcoanalytics` additive tasks succeed (12/19, 63%); `agent-fleet` and `lake-of-rage` hard refactors are 0/9. By pipeline: `simple` 54%, `full` orchestration 20%.
- Capability killers surface at the top: the `pokemontcg_pipe cleanups` runs and several `pr-loop` runs burn 5M–11M tokens to `verify_failed` / `incomplete`.

## Caveats stated in the output

- **No version is stamped in any log.** The "success over time" view uses file mtime as a proxy and says so. A real per-version axis needs a version stamp added to the run logs (follow-up).
- Spiral is reported two ways: per-run `fix_attempts` / `verify_attempts` (the primary retry-depth signal) and aggregate fix-phase token share. The big verify_failed runs spiral via whole-pipeline retries, not a discrete FIX phase, so retry-depth is the truer signal.

## Verification

`uv run pytest -q` 1012 passed, 4 skipped. `uv run ruff check` and `uv run ty check agent_fleet tests integrations` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)