### PR TITLE
feat: stamp fleet version into run logs and surface it in the scorecard

### DIFF
--- a/agent_fleet/observability/log.py
+++ b/agent_fleet/observability/log.py
@@ -6,8 +6,15 @@ from __future__ import annotations
 
 import contextlib
 import time
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+try:
+    _FLEET_VERSION = _pkg_version("agent-fleet")
+except PackageNotFoundError:
+    _FLEET_VERSION = "unknown"
 
 from agent_fleet.config import default_runs_dir
 from agent_fleet.observability.context import bind_phase, get_run_context
@@ -56,6 +63,7 @@ class RunLog:
         self._usage_by_phase: dict[str, dict[str, int]] = {}
         self._usage_rollup_emitted: bool = False
         self._last_usage_rollup: dict[str, Any] | None = None
+        self._version_stamped: bool = False
 
     @classmethod
     def create(
@@ -99,6 +107,10 @@ class RunLog:
         phase: str | None = None,
         data: dict[str, Any] | None = None,
     ) -> FleetEvent:
+        # Stamp fleet_version on the first event so the scorecard can attribute every run.
+        if not self._version_stamped:
+            data = {**(data or {}), "fleet_version": _FLEET_VERSION}
+            self._version_stamped = True
         ctx = get_run_context() or self.context
         fleet_event = FleetEvent.now(
             run_id=self.run_id,

--- a/scripts/outcome_scorecard.py
+++ b/scripts/outcome_scorecard.py
@@ -104,6 +104,7 @@ def _parse_file(path: Path) -> dict | None:
     rollup_tokens: int | None = None
     issue_top: int | None = None
     pr_number: int | None = None
+    fleet_version: str | None = None
 
     for e in events:
         if not isinstance(e, dict):
@@ -122,6 +123,13 @@ def _parse_file(path: Path) -> dict | None:
             it = e.get("issue_number")
             if isinstance(it, int):
                 issue_top = it
+
+        if fleet_version is None:
+            d = e.get("data")
+            if isinstance(d, dict):
+                fv = d.get("fleet_version")
+                if isinstance(fv, str) and fv:
+                    fleet_version = fv
 
         phase = e.get("phase")
         if isinstance(phase, str) and phase:
@@ -255,6 +263,7 @@ def _parse_file(path: Path) -> dict | None:
         "pipeline": _infer_pipeline(phases),
         "status": status,
         "success": status == "completed",
+        "version": fleet_version,
         "fix_attempts": fix_attempts,
         "verify_attempts": verify_attempts,
         "verify_failure": verify_failure,
@@ -289,6 +298,7 @@ def _build_summary(rows: list[dict]) -> dict:
             "by_pipeline": {},
             "by_repo_key": {},
             "by_model": {},
+            "by_version": {},
         }
 
     total = len(rows)
@@ -344,6 +354,19 @@ def _build_summary(rows: list[dict]) -> dict:
             }
         return out
 
+    version_groups: dict[str, list[dict]] = {}
+    for r in rows:
+        k = r.get("version") or "unstamped"
+        version_groups.setdefault(k, []).append(r)
+    by_version: dict[str, dict] = {}
+    for k, group in sorted(version_groups.items(), key=lambda x: (x[0] == "unstamped", x[0])):
+        sc = sum(1 for g in group if g["success"])
+        by_version[k] = {
+            "count": len(group),
+            "success_count": sc,
+            "success_rate": round(sc / len(group), 4),
+        }
+
     return {
         "total": total,
         "success_count": success_count,
@@ -355,6 +378,7 @@ def _build_summary(rows: list[dict]) -> dict:
         "by_pipeline": _breakdown("pipeline"),
         "by_repo_key": _breakdown("repo_key"),
         "by_model": _breakdown("model"),
+        "by_version": by_version,
     }
 
 
@@ -416,6 +440,14 @@ def _print_human(rows: list[dict], top_n: int, runs_dir: Path) -> None:
                 f"rate={100*info['success_rate']:>5.1f}%"
             )
 
+    print("\nBy fleet version:")
+    for k, info in s["by_version"].items():
+        print(
+            f"  {k:<30}  count={info['count']:>5}  "
+            f"success={info['success_count']:>5}  "
+            f"rate={100*info['success_rate']:>5.1f}%"
+        )
+
     failures = sorted(
         [r for r in real if not r["success"]],
         key=lambda r: r["tokens_total"],
@@ -433,8 +465,8 @@ def _print_human(rows: list[dict], top_n: int, runs_dir: Path) -> None:
         )
 
     print(
-        "\nNote: no version is stamped in the logs; monthly buckets below use file mtime"
-        " as a proxy, not a per-version measurement."
+        "\nNote: the version axis is available for runs stamped at or after this change;"
+        " unstamped runs fall back to mtime months below."
     )
     buckets: dict[str, list[bool]] = {}
     for r in real:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -296,6 +296,29 @@ def test_changed_lines_non_git_dir(tmp_path: Path) -> None:
     assert changed_lines(tmp_path) == 0
 
 
+def test_fleet_version_stamped_on_first_event_only(tmp_path: Path) -> None:
+    import importlib.metadata
+
+    expected_version = importlib.metadata.version("agent-fleet")
+    ring = MemoryRingSink(max_events=10)
+    run_log = RunLog.create(
+        run_id="version-stamp-test",
+        runs_dir=tmp_path,
+        include_memory_ring=False,
+    )
+    run_log._sinks = [ring]
+
+    run_log.emit("run.start", data={"title": "test"})
+    run_log.emit("run.end", data={"outcome": "completed"})
+
+    events = list(ring.events)
+    assert len(events) == 2
+    assert events[0].data is not None
+    assert events[0].data.get("fleet_version") == expected_version
+    assert events[1].data is not None
+    assert "fleet_version" not in events[1].data
+
+
 def test_changed_lines_none() -> None:
     assert changed_lines(None) == 0
 

--- a/tests/test_outcome_scorecard.py
+++ b/tests/test_outcome_scorecard.py
@@ -705,3 +705,122 @@ def test_run_end_completed_counts_as_success(tmp_path: Path) -> None:
     assert r["pr_number"] == 201
     assert summary["success_count"] == 1
     assert summary["status_histogram"]["completed"]["count"] == 1
+
+
+def test_version_stamped_run_in_by_version(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "stamped-run.jsonl",
+        [
+            {
+                "run_id": "stamped-run",
+                "event": "run.start",
+                "data": {"title": "stamped test", "fleet_version": "0.12.0"},
+            },
+            {
+                "run_id": "stamped-run",
+                "event": "llm.usage",
+                "phase": "execute",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 50000,
+                    "input_tokens": 30000,
+                    "output_tokens": 5000,
+                    "cache_read_tokens": 15000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 30.0,
+                    "agent_id": "a1",
+                },
+            },
+            {
+                "run_id": "stamped-run",
+                "event": "fleet.task.complete",
+                "data": {
+                    "status": "completed",
+                    "task_index": 0,
+                    "persona": "backend",
+                    "duration_seconds": 60.0,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "fix_attempts": 0,
+                        "verify_attempts": 0,
+                        "repo_key": "agent-fleet",
+                        "issue_number": 0,
+                        "duration_seconds": 60.0,
+                        "changed_files_count": 2,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    r = {x["run_id"]: x for x in out["runs"]}["stamped-run"]
+    assert r["version"] == "0.12.0"
+
+    by_version = out["summary"]["by_version"]
+    assert "0.12.0" in by_version
+    bucket = by_version["0.12.0"]
+    assert bucket["count"] == 1
+    assert bucket["success_count"] == 1
+    assert bucket["success_rate"] == 1.0
+
+
+def test_unstamped_run_in_by_version(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "unstamped-run.jsonl",
+        [
+            {
+                "run_id": "unstamped-run",
+                "event": "run.start",
+                "data": {"title": "no version"},
+            },
+            {
+                "run_id": "unstamped-run",
+                "event": "llm.usage",
+                "phase": "execute",
+                "data": {
+                    "model": "composer-2.5",
+                    "total_tokens": 50000,
+                    "input_tokens": 30000,
+                    "output_tokens": 5000,
+                    "cache_read_tokens": 15000,
+                    "cache_write_tokens": 0,
+                    "duration_s": 30.0,
+                    "agent_id": "a2",
+                },
+            },
+            {
+                "run_id": "unstamped-run",
+                "event": "fleet.task.complete",
+                "data": {
+                    "status": "completed",
+                    "task_index": 0,
+                    "persona": "backend",
+                    "duration_seconds": 60.0,
+                    "outcome_metrics": {
+                        "status": "completed",
+                        "fix_attempts": 0,
+                        "verify_attempts": 0,
+                        "repo_key": "agent-fleet",
+                        "issue_number": 0,
+                        "duration_seconds": 60.0,
+                        "changed_files_count": 2,
+                    },
+                    "error": None,
+                    "stderr_snippet": None,
+                },
+            },
+        ],
+    )
+
+    out = _run(tmp_path)
+    r = {x["run_id"]: x for x in out["runs"]}["unstamped-run"]
+    assert r["version"] is None
+
+    by_version = out["summary"]["by_version"]
+    assert "unstamped" in by_version
+    bucket = by_version["unstamped"]
+    assert bucket["count"] == 1
+    assert bucket["success_count"] == 1


### PR DESCRIPTION
Stamps the agent-fleet package version onto every run log and gives the outcome scorecard a real by-version success-rate axis, replacing the file-mtime proxy.

**Producer.** `RunLog.emit` injects `data.fleet_version` onto the first event each run emits. Both run shapes (dispatch `fleet.task.start`, orchestration `run.start`) funnel through this one choke point, so every run file carries its producing version without the stamp being duplicated across call sites. The version comes from `importlib.metadata.version("agent-fleet")` rather than `agent_fleet.__version__`, because `log.py` is imported transitively by the package `__init__` and the direct import would cycle.

**Consumer.** `outcome_scorecard.py` reads `fleet_version` off the first event that carries it and adds a `by_version` breakdown (count, successes, rate). Runs logged before this change have no version and bucket under `unstamped`, so all 300 current real runs land there until new runs accrue.

**Why.** The scorecard's over-time view used file mtime as a stand-in for "which version produced this outcome". That proxy can't attribute a regression or improvement to a release. This makes the axis a real measurement.

Tests cover first-event-only stamping (producer) and both the stamped and unstamped scorecard buckets (consumer). `uv run pytest -q` (1015 passed), `ruff check`, and `ty check agent_fleet tests integrations` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)