### PR TITLE
feat: break the verify-fix spiral on a reproduced failure

### DIFF
--- a/agent_fleet/fix_attempt.py
+++ b/agent_fleet/fix_attempt.py
@@ -18,6 +18,7 @@ from agent_fleet.implementer import implement
 from agent_fleet.synthesizer import synthesize
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from agent_fleet.contracts.implementation_brief import ImplementationBrief
@@ -37,6 +38,16 @@ def _truncate(message: str, *, max_lines: int = 50) -> str:
         return message
     omitted = len(lines) - max_lines
     return "\n".join(lines[:max_lines]) + f"\n... [{omitted} more lines truncated]"
+
+
+def is_repeated_verify_failure(message: str, accumulated: Sequence[str]) -> bool:
+    """True when *message* repeats the most recent accumulated verify failure.
+
+    A FIX phase runs between two verify attempts. An identical failure message
+    on the next attempt means that FIX changed nothing that affects the verdict,
+    so further fixes are doomed and the loop should stop.
+    """
+    return bool(message) and bool(accumulated) and message == accumulated[-1]
 
 
 @dataclass(frozen=True)

--- a/agent_fleet/runner.py
+++ b/agent_fleet/runner.py
@@ -24,7 +24,13 @@ from agent_fleet.disposition import (
     RunFacts,
     decide_disposition,
 )
-from agent_fleet.fix_attempt import FixMemory, _FixDeps, make_fix_strategy
+from agent_fleet.fix_attempt import (
+    FixMemory,
+    _FixDeps,
+    _truncate,
+    is_repeated_verify_failure,
+    make_fix_strategy,
+)
 from agent_fleet.fleet_session import create_fleet_session
 from agent_fleet.hooks import ExperienceRecorder, FleetTask, LevelUpRecorder, ResumableGitOps
 from agent_fleet.implementer import implement
@@ -563,6 +569,15 @@ class LocalFleetRunner:
                     if verify_result.severity == VerifySeverity.OK:
                         break
                     if verify_result.severity == VerifySeverity.FATAL:
+                        break
+                    if is_repeated_verify_failure(verify_result.message, _accumulated_failures):
+                        run_log.emit(
+                            "verify.repeated_failure",
+                            data={
+                                "verify_attempts": verify_attempts + 1,
+                                "failure_signature": _truncate(verify_result.message),
+                            },
+                        )
                         break
                     if verify_result.message:
                         _accumulated_failures.append(verify_result.message)

--- a/tests/test_runner_fix_loop.py
+++ b/tests/test_runner_fix_loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from agent_fleet.fix_attempt import _truncate as _truncate_verify_message
+from agent_fleet.fix_attempt import is_repeated_verify_failure
 from agent_fleet.runner import FleetRunConfig
 
 
@@ -29,3 +30,23 @@ def test_truncate_verify_message_clips_long_output() -> None:
     assert lines[0] == "line 0"
     assert lines[49] == "line 49"
     assert lines[-1] == "... [150 more lines truncated]"
+
+
+def test_is_repeated_verify_failure_empty_accumulated_is_false() -> None:
+    assert is_repeated_verify_failure("boom", ()) is False
+
+
+def test_is_repeated_verify_failure_empty_message_is_false() -> None:
+    assert is_repeated_verify_failure("", ("boom",)) is False
+
+
+def test_is_repeated_verify_failure_matches_last_entry() -> None:
+    assert is_repeated_verify_failure("boom", ("boom",)) is True
+
+
+def test_is_repeated_verify_failure_differs_from_last_entry() -> None:
+    assert is_repeated_verify_failure("different", ("boom",)) is False
+
+
+def test_is_repeated_verify_failure_earlier_nonlast_entry_is_false() -> None:
+    assert is_repeated_verify_failure("A", ("A", "B")) is False


### PR DESCRIPTION
## What

Adds a circuit breaker to the VERIFY/FIX retry loop in `LocalFleetRunner`. When a verify attempt returns the exact failure message the previous attempt did, the loop stops instead of replaying another SYNTHESIZE+IMPLEMENT.

## Why

A FIX phase runs between two verify attempts. An identical failure message on the next attempt means that FIX changed nothing the verdict depends on, so every further retry is a full, expensive replay against the same dead end. Real runs (pokemontcg_pipe cleanups, agent-fleet "version" tasks, pr-loop runs) burned 5M-11M tokens spiraling to `verify_failed` / `incomplete` this way. The controller's `halt_after_attempts` does not help here because it equals the loop bound.

## How

- `fix_attempt.py` gains a pure predicate `is_repeated_verify_failure(message, accumulated)` — true when `message` is non-empty and equals the last accumulated failure. It lives next to `_truncate` and `FixMemory`, matching the module's "pure decision, IO in runner" idiom.
- `runner.py` calls it in the verify loop between the FATAL break and the failure-accumulation append. On a match it emits `verify.repeated_failure` (carrying the attempt count and a truncated signature) and breaks.

The break deliberately leaves `_halted_by_controller` untouched. That routes the run through the existing, already-tested `verify_failed` / `verify_failed_salvaged` disposition — the same terminal state the loop reaches today on retry-exhaustion, just sooner and far cheaper. No new terminal status, no disposition change.

## Verification

- `uv run pytest -q` — 1020 passed, 4 skipped (5 new predicate tests)
- `uv run ruff check` — clean
- `uv run ty check agent_fleet tests integrations` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)